### PR TITLE
[#1263] Configure Codex production-readiness queue automation

### DIFF
--- a/.github/codex/prompts/execute-next-production-issue.md
+++ b/.github/codex/prompts/execute-next-production-issue.md
@@ -1,0 +1,142 @@
+# Execute next production-readiness issue
+
+You are Codex working in repository `maniczko/audioRecorder`.
+
+## Goal
+
+Implement the next production-readiness GitHub issue in strict queue order.
+
+## Queue source
+
+Use GitHub issue `#1263` as the source of truth.
+
+## Selection rules
+
+1. Find the first unchecked issue in `#1263`.
+2. Only consider issues that are open.
+3. Skip an issue if it has `codex:blocked`.
+4. Stop without coding when any open production-readiness issue has `codex:in-progress` or `codex:pr-open`, unless that issue is the one you were explicitly assigned.
+5. Prefer priority order already encoded in `#1263`: P0, then P1, then P2, then P3.
+6. Do not start an issue if it depends on another open issue.
+
+## Status rules
+
+Before coding:
+
+1. Comment on the selected issue:
+   `Codex started work on this issue.`
+2. Remove `codex:ready` when present.
+3. Add `codex:in-progress` when available.
+4. Create a dedicated branch:
+   `production-readiness/<issue-number>-<short-slug>`.
+   If repository policy allows `codex/*`, use `codex/<issue-number>-<short-slug>`.
+
+When implementation succeeds:
+
+1. Open a PR titled:
+   `[#<issue-number>] <issue title>`
+2. Include `Closes #<issue-number>` in the PR body.
+3. Include:
+   - Summary
+   - Changed files
+   - Tests run
+   - Risks
+   - Rollback notes
+4. Remove `codex:in-progress` when present.
+5. Add `codex:pr-open` when available.
+6. Comment on the issue with the PR link and test results.
+
+When blocked:
+
+1. Stop.
+2. Remove `codex:in-progress` when present.
+3. Add `codex:blocked` when available.
+4. Comment with:
+   - blocker
+   - attempted approach
+   - decision needed
+   - next recommended action
+
+## Hard rules
+
+- Work on exactly one issue.
+- Do not implement more than one issue.
+- Do not merge PRs.
+- Do not skip tests unless impossible; if impossible, explain why.
+- Do not change unrelated files.
+- Do not silently change production behavior outside issue scope.
+- Do not remove privacy, security, auth, workspace, or audit checks to make tests pass.
+- Do not print secrets, tokens, service-role keys, database passwords, raw transcripts, or audio content.
+
+## Verification
+
+Run the smallest relevant verification set.
+
+For backend changes:
+
+```bash
+pnpm run typecheck:server
+pnpm run test:server:retry
+```
+
+For frontend changes:
+
+```bash
+pnpm run typecheck
+pnpm run lint:all
+```
+
+For workflow/config/agent changes:
+
+```bash
+pnpm run test:workflows
+pnpm run audit:mojibake
+```
+
+For cross-cutting production changes:
+
+```bash
+pnpm run typecheck:all
+pnpm run lint:all
+pnpm run test:server:retry
+```
+
+For recorder/queue changes, run at minimum:
+
+```bash
+pnpm exec vitest run src/hooks/useAudioHardware.test.ts src/hooks/useRecorder.test.tsx src/lib/recordingQueue.test.ts src/store/recorderStore.test.ts src/store/recorderQueueProcessor.test.ts --coverage.enabled=false
+```
+
+## PR body template
+
+```markdown
+Closes #<issue-number>
+
+## Summary
+- 
+
+## Changed files
+- 
+
+## Tests run
+- [ ] `pnpm run typecheck:server`
+- [ ] `pnpm run test:server:retry`
+- [ ] other: 
+
+## Risks
+- 
+
+## Rollback notes
+- 
+```
+
+## Final response
+
+Report:
+
+- selected issue number
+- branch name
+- PR link
+- tests run
+- known risks
+- whether the issue was completed or blocked

--- a/.github/workflows/codex-production-readiness-queue.yml
+++ b/.github/workflows/codex-production-readiness-queue.yml
@@ -1,0 +1,341 @@
+name: Codex Production Readiness Queue
+
+on:
+  workflow_dispatch:
+    inputs:
+      mode:
+        description: 'Operation to run'
+        required: true
+        default: 'dispatch-next'
+        type: choice
+        options:
+          - bootstrap-labels
+          - dispatch-next
+          - status
+      dry_run:
+        description: 'Do not mutate issues; print intended actions only'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review, closed]
+
+concurrency:
+  group: codex-production-readiness-queue
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  queue:
+    name: Sync and dispatch production-readiness queue
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      GH_TOKEN: ${{ github.token }}
+      REPO: ${{ github.repository }}
+      INDEX_ISSUE: '1263'
+      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      MODE: ${{ github.event.inputs.mode || 'sync-pr' }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Ensure labels exist
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          create_label() {
+            local name="$1"
+            local color="$2"
+            local desc="$3"
+            if [ "$DRY_RUN" = "true" ]; then
+              echo "[dry-run] ensure label: $name"
+              return 0
+            fi
+            gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" --force >/dev/null
+          }
+
+          create_label "production-readiness" "0052CC" "Production readiness audit backlog"
+          create_label "priority:P0" "B60205" "Production blocker"
+          create_label "priority:P1" "D93F0B" "MVP hardening"
+          create_label "priority:P2" "FBCA04" "Production stabilization"
+          create_label "priority:P3" "C5DEF5" "Enterprise readiness"
+          create_label "codex:ready" "0E8A16" "Ready for Codex execution"
+          create_label "codex:in-progress" "FBCA04" "Codex is currently working"
+          create_label "codex:pr-open" "1D76DB" "Codex opened a PR"
+          create_label "codex:blocked" "D93F0B" "Codex is blocked"
+          create_label "codex:review" "5319E7" "Needs human review"
+          create_label "codex:done" "6F42C1" "Completed by merged PR"
+
+      - name: Run queue operation
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          log() {
+            echo "[codex-queue] $*"
+          }
+
+          issue_body() {
+            gh issue view "$1" --repo "$REPO" --json body --jq '.body // ""'
+          }
+
+          issue_state() {
+            gh issue view "$1" --repo "$REPO" --json state --jq '.state'
+          }
+
+          issue_labels() {
+            gh issue view "$1" --repo "$REPO" --json labels --jq '.labels[].name' || true
+          }
+
+          issue_in_index() {
+            local issue="$1"
+            issue_body "$INDEX_ISSUE" | grep -Eq "#${issue}([^0-9]|$)"
+          }
+
+          add_label() {
+            local issue="$1"
+            local label="$2"
+            if [ "$DRY_RUN" = "true" ]; then
+              log "[dry-run] add label '$label' to #$issue"
+              return 0
+            fi
+            gh issue edit "$issue" --repo "$REPO" --add-label "$label" >/dev/null
+          }
+
+          remove_label() {
+            local issue="$1"
+            local label="$2"
+            if [ "$DRY_RUN" = "true" ]; then
+              log "[dry-run] remove label '$label' from #$issue"
+              return 0
+            fi
+            gh issue edit "$issue" --repo "$REPO" --remove-label "$label" >/dev/null 2>&1 || true
+          }
+
+          comment_issue() {
+            local issue="$1"
+            local body="$2"
+            if [ "$DRY_RUN" = "true" ]; then
+              log "[dry-run] comment on #$issue:"
+              echo "$body"
+              return 0
+            fi
+            gh issue comment "$issue" --repo "$REPO" --body "$body" >/dev/null
+          }
+
+          priority_from_title() {
+            local issue="$1"
+            local title
+            title=$(gh issue view "$issue" --repo "$REPO" --json title --jq '.title')
+            if [[ "$title" == *"[P0]"* ]]; then echo "priority:P0"; return; fi
+            if [[ "$title" == *"[P1]"* ]]; then echo "priority:P1"; return; fi
+            if [[ "$title" == *"[P2]"* ]]; then echo "priority:P2"; return; fi
+            if [[ "$title" == *"[P3]"* ]]; then echo "priority:P3"; return; fi
+            echo ""
+          }
+
+          bootstrap_labels() {
+            local numbers
+            numbers=$(issue_body "$INDEX_ISSUE" | grep -Eo '#[0-9]+' | tr -d '#' | sort -n | uniq)
+            for issue in $numbers; do
+              if [ "$issue" = "$INDEX_ISSUE" ]; then
+                add_label "$issue" "production-readiness"
+                continue
+              fi
+              local state prio
+              state=$(issue_state "$issue")
+              add_label "$issue" "production-readiness"
+              prio=$(priority_from_title "$issue")
+              if [ -n "$prio" ]; then add_label "$issue" "$prio"; fi
+              if [ "$state" = "OPEN" ]; then
+                labels=$(issue_labels "$issue")
+                if ! echo "$labels" | grep -qx "codex:done" && ! echo "$labels" | grep -qx "codex:blocked" && ! echo "$labels" | grep -qx "codex:pr-open" && ! echo "$labels" | grep -qx "codex:in-progress"; then
+                  add_label "$issue" "codex:ready"
+                fi
+              fi
+            done
+          }
+
+          has_active_work() {
+            local in_progress pr_open
+            in_progress=$(gh issue list --repo "$REPO" --state open --label "production-readiness" --label "codex:in-progress" --json number --jq 'length')
+            pr_open=$(gh issue list --repo "$REPO" --state open --label "production-readiness" --label "codex:pr-open" --json number --jq 'length')
+            if [ "$in_progress" != "0" ] || [ "$pr_open" != "0" ]; then
+              log "Active queue work exists: codex:in-progress=$in_progress codex:pr-open=$pr_open"
+              return 0
+            fi
+            return 1
+          }
+
+          next_issue_from_index() {
+            local body lines issue state labels
+            body=$(issue_body "$INDEX_ISSUE")
+            lines=$(printf '%s\n' "$body" | grep -E '^- \[ \] #[0-9]+' || true)
+            while IFS= read -r line; do
+              [ -n "$line" ] || continue
+              issue=$(echo "$line" | grep -Eo '#[0-9]+' | head -1 | tr -d '#')
+              [ -n "$issue" ] || continue
+              state=$(issue_state "$issue")
+              [ "$state" = "OPEN" ] || continue
+              labels=$(issue_labels "$issue")
+              if echo "$labels" | grep -qx "codex:blocked"; then
+                log "Skipping blocked issue #$issue"
+                continue
+              fi
+              echo "$issue"
+              return 0
+            done <<< "$lines"
+            return 1
+          }
+
+          check_index_item() {
+            local issue="$1"
+            local body tmp
+            body=$(issue_body "$INDEX_ISSUE")
+            tmp=$(mktemp)
+            python3 - "$issue" > "$tmp" <<'PY'
+          import re
+          import sys
+          issue = sys.argv[1]
+          body = sys.stdin.read()
+          pattern = re.compile(rf'(^- \[ \] #{re.escape(issue)}(\b|\D))', re.M)
+          body = pattern.sub(lambda m: m.group(0).replace('- [ ]', '- [x]', 1), body, count=1)
+          print(body, end='')
+          PY
+            if [ "$DRY_RUN" = "true" ]; then
+              log "[dry-run] would check #$issue in #$INDEX_ISSUE"
+              rm -f "$tmp"
+              return 0
+            fi
+            gh issue edit "$INDEX_ISSUE" --repo "$REPO" --body-file "$tmp" >/dev/null
+            rm -f "$tmp"
+          }
+
+          linked_issue_from_pr_body() {
+            local body="$1"
+            printf '%s\n' "$body" | grep -Eio '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | head -1 | grep -Eo '[0-9]+' || true
+          }
+
+          sync_pr_open() {
+            local issue="$1"
+            local pr_number="$2"
+            [ -n "$issue" ] || return 0
+            issue_in_index "$issue" || { log "PR links #$issue, but it is not in #$INDEX_ISSUE. Skipping."; return 0; }
+            add_label "$issue" "production-readiness"
+            add_label "$issue" "codex:pr-open"
+            remove_label "$issue" "codex:in-progress"
+            remove_label "$issue" "codex:ready"
+            comment_issue "$issue" "PR #${pr_number} is open for this production-readiness task. Queue status moved to \`codex:pr-open\`."
+          }
+
+          sync_pr_merged() {
+            local issue="$1"
+            local pr_number="$2"
+            [ -n "$issue" ] || return 0
+            issue_in_index "$issue" || { log "Merged PR links #$issue, but it is not in #$INDEX_ISSUE. Skipping."; return 0; }
+            add_label "$issue" "production-readiness"
+            add_label "$issue" "codex:done"
+            remove_label "$issue" "codex:pr-open"
+            remove_label "$issue" "codex:in-progress"
+            remove_label "$issue" "codex:ready"
+            remove_label "$issue" "codex:blocked"
+            check_index_item "$issue"
+            comment_issue "$issue" "Merged via PR #${pr_number}. Queue status moved to \`codex:done\`, and #${INDEX_ISSUE} was checked off."
+          }
+
+          dispatch_next() {
+            if has_active_work; then
+              log "No dispatch: active work already exists."
+              return 0
+            fi
+
+            local issue title prio prompt
+            if ! issue=$(next_issue_from_index); then
+              log "No open unchecked production-readiness issue found in #$INDEX_ISSUE."
+              return 0
+            fi
+
+            title=$(gh issue view "$issue" --repo "$REPO" --json title --jq '.title')
+            prio=$(priority_from_title "$issue")
+            add_label "$issue" "production-readiness"
+            if [ -n "$prio" ]; then add_label "$issue" "$prio"; fi
+            add_label "$issue" "codex:in-progress"
+            remove_label "$issue" "codex:ready"
+            remove_label "$issue" "codex:blocked"
+
+            prompt=$(cat <<EOF
+@codex Please execute this production-readiness issue exactly as scoped.
+
+Queue source: #${INDEX_ISSUE}
+Selected issue: #${issue}
+
+Rules:
+- Work on exactly this one issue.
+- Do not start any other issue.
+- Create a dedicated branch: \`production-readiness/${issue}-<short-slug>\`.
+- Keep the change limited to this issue body and explicit dependencies.
+- Run the relevant verification from \`.github/codex/prompts/execute-next-production-issue.md\`.
+- Open a PR titled \`[#${issue}] ${title}\`.
+- Include \`Closes #${issue}\` in the PR body.
+- Include summary, changed files, tests run, risks, and rollback notes.
+- Do not merge the PR.
+- If blocked, remove \`codex:in-progress\`, add \`codex:blocked\`, and comment with blocker, attempted approach, decision needed, and next action.
+EOF
+            )
+
+            comment_issue "$issue" "$prompt"
+            log "Dispatched #$issue: $title"
+          }
+
+          if [ "$MODE" = "bootstrap-labels" ]; then
+            bootstrap_labels
+            exit 0
+          fi
+
+          if [ "$MODE" = "status" ]; then
+            log "Open in-progress issues:"
+            gh issue list --repo "$REPO" --state open --label "production-readiness" --label "codex:in-progress" || true
+            log "Open PR-linked issues:"
+            gh issue list --repo "$REPO" --state open --label "production-readiness" --label "codex:pr-open" || true
+            exit 0
+          fi
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            pr_number="${{ github.event.pull_request.number }}"
+            pr_body=$(gh pr view "$pr_number" --repo "$REPO" --json body --jq '.body // ""')
+            issue=$(linked_issue_from_pr_body "$pr_body")
+
+            if [ -z "$issue" ]; then
+              log "No Closes/Fixes/Resolves issue reference found in PR body."
+              exit 0
+            fi
+
+            if [ "${{ github.event.action }}" = "closed" ] && [ "${{ github.event.pull_request.merged }}" = "true" ]; then
+              sync_pr_merged "$issue" "$pr_number"
+              dispatch_next
+              exit 0
+            fi
+
+            if [ "${{ github.event.action }}" != "closed" ]; then
+              sync_pr_open "$issue" "$pr_number"
+              exit 0
+            fi
+          fi
+
+          if [ "$MODE" = "dispatch-next" ]; then
+            dispatch_next
+            exit 0
+          fi
+
+          log "No operation performed for mode=$MODE event=${{ github.event_name }} action=${{ github.event.action || '' }}"

--- a/.github/workflows/codex-production-readiness-queue.yml
+++ b/.github/workflows/codex-production-readiness-queue.yml
@@ -146,21 +146,26 @@ jobs:
           }
 
           bootstrap_labels() {
-            local numbers
+            local numbers labels
             numbers=$(issue_body "$INDEX_ISSUE" | grep -Eo '#[0-9]+' | tr -d '#' | sort -n | uniq)
             for issue in $numbers; do
               if [ "$issue" = "$INDEX_ISSUE" ]; then
                 add_label "$issue" "production-readiness"
                 continue
               fi
+
               local state prio
               state=$(issue_state "$issue")
               add_label "$issue" "production-readiness"
               prio=$(priority_from_title "$issue")
               if [ -n "$prio" ]; then add_label "$issue" "$prio"; fi
+
               if [ "$state" = "OPEN" ]; then
                 labels=$(issue_labels "$issue")
-                if ! echo "$labels" | grep -qx "codex:done" && ! echo "$labels" | grep -qx "codex:blocked" && ! echo "$labels" | grep -qx "codex:pr-open" && ! echo "$labels" | grep -qx "codex:in-progress"; then
+                if ! echo "$labels" | grep -qx "codex:done" && \
+                   ! echo "$labels" | grep -qx "codex:blocked" && \
+                   ! echo "$labels" | grep -qx "codex:pr-open" && \
+                   ! echo "$labels" | grep -qx "codex:in-progress"; then
                   add_label "$issue" "codex:ready"
                 fi
               fi
@@ -201,25 +206,29 @@ jobs:
 
           check_index_item() {
             local issue="$1"
-            local body tmp
-            body=$(issue_body "$INDEX_ISSUE")
+            local body_file tmp
+            body_file=$(mktemp)
             tmp=$(mktemp)
-            python3 - "$issue" > "$tmp" <<'PY'
+            issue_body "$INDEX_ISSUE" > "$body_file"
+            python3 - "$issue" "$body_file" > "$tmp" <<'PY'
+          import pathlib
           import re
           import sys
+
           issue = sys.argv[1]
-          body = sys.stdin.read()
+          body_file = pathlib.Path(sys.argv[2])
+          body = body_file.read_text(encoding='utf-8')
           pattern = re.compile(rf'(^- \[ \] #{re.escape(issue)}(\b|\D))', re.M)
           body = pattern.sub(lambda m: m.group(0).replace('- [ ]', '- [x]', 1), body, count=1)
           print(body, end='')
           PY
             if [ "$DRY_RUN" = "true" ]; then
               log "[dry-run] would check #$issue in #$INDEX_ISSUE"
-              rm -f "$tmp"
+              rm -f "$tmp" "$body_file"
               return 0
             fi
             gh issue edit "$INDEX_ISSUE" --repo "$REPO" --body-file "$tmp" >/dev/null
-            rm -f "$tmp"
+            rm -f "$tmp" "$body_file"
           }
 
           linked_issue_from_pr_body() {
@@ -338,4 +347,4 @@ EOF
             exit 0
           fi
 
-          log "No operation performed for mode=$MODE event=${{ github.event_name }} action=${{ github.event.action || '' }}"
+          log "No operation performed for mode=$MODE event=${{ github.event_name }}"

--- a/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
+++ b/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
@@ -1,0 +1,122 @@
+# Codex Production Readiness Queue
+
+This document defines the queue workflow for the production-readiness backlog created from the production audit.
+
+Source of truth: GitHub issue `#1263`.
+
+Audit prompt source: the production readiness audit prompt requires a detailed repo audit, production scoring, blocker list, and Codex-ready implementation backlog. The resulting issue queue is implemented as GitHub issues `#1225` through `#1263`.
+
+## Goal
+
+Codex should execute one production-readiness issue at a time, in queue order, and leave a reviewable PR for humans and CI before the next issue starts.
+
+## Queue rules
+
+1. `#1263` is the backlog index and queue order.
+2. Work starts from the first unchecked `- [ ] #issue` line in `#1263`.
+3. Do not start a new issue when any open production-readiness issue has:
+   - `codex:in-progress`
+   - `codex:pr-open`
+4. Codex must implement exactly one issue per run.
+5. Codex must not merge PRs.
+6. Human review and CI remain the release gate.
+
+## Labels
+
+The queue workflows use these labels:
+
+- `production-readiness`
+- `priority:P0`
+- `priority:P1`
+- `priority:P2`
+- `priority:P3`
+- `codex:ready`
+- `codex:in-progress`
+- `codex:pr-open`
+- `codex:blocked`
+- `codex:review`
+- `codex:done`
+
+The workflow `.github/workflows/codex-production-readiness-queue.yml` can create these labels when run with `mode=bootstrap-labels`.
+
+## Recommended start sequence
+
+Run the workflow manually first:
+
+1. `Codex Production Readiness Queue` → `workflow_dispatch` → `mode=bootstrap-labels`.
+2. `Codex Production Readiness Queue` → `workflow_dispatch` → `mode=dispatch-next`.
+3. Confirm that the first issue gets a `@codex` dispatch comment and `codex:in-progress`.
+4. Wait for Codex to open a PR.
+5. Review CI and merge manually.
+6. The workflow will mark the linked issue as done and dispatch the next queue item.
+
+## GitHub Codex integration assumption
+
+The dispatch workflow posts a `@codex` comment on the selected issue.
+
+This assumes the repository has a GitHub Codex integration or agent that reacts to `@codex` issue comments. If that integration is not active, run Codex manually using:
+
+```text
+Use .github/codex/prompts/execute-next-production-issue.md and execute the next production-readiness issue from #1263.
+```
+
+## Codex issue execution contract
+
+When Codex starts an issue:
+
+1. Comment that work has started.
+2. Add `codex:in-progress`.
+3. Remove `codex:ready`.
+4. Create a dedicated branch, preferably `production-readiness/<issue-number>-<short-slug>` or `codex/<issue-number>-<short-slug>` when allowed.
+5. Implement only the selected issue.
+6. Run relevant tests.
+7. Open a PR with `Closes #<issue-number>`.
+8. Add summary, tests, risks, and rollback notes to the PR body.
+9. Do not merge.
+
+## PR status sync
+
+When a PR is opened and its body contains `Closes #<issue-number>`, the workflow marks that issue as `codex:pr-open` and removes `codex:in-progress`.
+
+When that PR is merged, the workflow:
+
+1. Adds `codex:done`.
+2. Removes active queue labels.
+3. Checks the issue line in `#1263`.
+4. Dispatches the next unchecked issue.
+
+## Blocked work
+
+If Codex cannot complete an issue:
+
+1. Remove `codex:in-progress`.
+2. Add `codex:blocked`.
+3. Comment with:
+   - blocker
+   - attempted approach
+   - decision needed
+   - next recommended action
+
+The queue runner skips blocked issues until a human removes `codex:blocked` and adds `codex:ready` again.
+
+## Safety rules
+
+- Never auto-merge P0/P1 PRs.
+- Never run two production-readiness issues in parallel.
+- Never remove privacy, security, or auth checks to make tests pass.
+- Never print secrets in issue comments, PR bodies, logs, screenshots, or artifacts.
+- Prefer small PRs over broad refactors.
+- Migration, storage, privacy, and job-queue changes require explicit rollback notes.
+
+## Minimal production gate before starting P1
+
+P1 should not begin until these P0 issues are merged or explicitly deferred with a dated exception:
+
+- `#1225`
+- `#1226`
+- `#1227`
+- `#1228`
+- `#1229`
+- `#1230`
+- `#1231`
+- `#1232`


### PR DESCRIPTION
Related to #1263

## Summary
- Adds a Codex execution prompt for one-issue-at-a-time production-readiness work.
- Adds a GitHub Actions queue workflow that can:
  - create required labels,
  - label backlog issues from #1263,
  - dispatch the next unchecked issue by posting an `@codex` instruction comment,
  - sync issue status when a linked PR opens or merges,
  - check completed issues in #1263 after merge.
- Adds documentation for how to run and operate the production-readiness queue.

## Changed files
- `.github/codex/prompts/execute-next-production-issue.md`
- `.github/workflows/codex-production-readiness-queue.yml`
- `docs/CODEX_PRODUCTION_READINESS_QUEUE.md`

## How to activate after merge
1. Run workflow `Codex Production Readiness Queue` with `mode=bootstrap-labels`.
2. Run workflow `Codex Production Readiness Queue` with `mode=dispatch-next`.
3. Confirm #1225 receives the `@codex` dispatch comment and label `codex:in-progress`.
4. Review Codex PR manually before merge.

## Assumptions
- The repo has a GitHub Codex integration that reacts to `@codex` issue comments.
- If not, use `.github/codex/prompts/execute-next-production-issue.md` manually in Codex App.

## Tests run
- Not run locally. This change only adds docs/workflow configuration through GitHub connector.

## Risks
- Workflow behavior should be validated with `dry_run=true` before first real dispatch.
- If the GitHub Codex integration is not enabled, the workflow will still comment and label issues, but Codex will not start automatically.

## Rollback notes
- Revert this PR to remove queue automation.
- Remove queue labels manually if they were already created and are no longer wanted.