### PR TITLE
[#1263] Add clean Codex queue reconciliation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,6 +2,10 @@
 
 <!-- What changed and why? -->
 
+## Linked issue
+
+<!-- For production-readiness PRs, use `Closes #<issue-number>` so the queue workflow can sync status. -->
+
 ## Linear
 
 <!-- Link Linear issues, e.g. VAT-123 -->
@@ -15,6 +19,19 @@
 - [ ] Docs
 - [ ] CI/build
 - [ ] Chore
+- [ ] Production readiness
+
+## Production Readiness Queue Checklist
+
+Required when the PR implements an issue from `#1263`:
+
+- [ ] PR body includes `Closes #<issue-number>`.
+- [ ] Linked issue is listed in `#1263`.
+- [ ] Linked issue has `production-readiness`.
+- [ ] Linked issue has `codex:pr-open` after PR creation.
+- [ ] This PR is not auto-merged by Codex.
+- [ ] The next queue issue is not started until this PR is merged.
+- [ ] Migration, storage, privacy, and job-queue changes include rollback notes.
 
 ## Audio Recorder Checklist
 
@@ -56,6 +73,10 @@
 ## Risk Notes
 
 <!-- Known risks, intentionally deferred work, or rollout notes. -->
+
+## Rollback notes
+
+<!-- Required for production readiness, migrations, storage, privacy, and job queue changes. -->
 
 ## Screenshots / Recordings
 

--- a/.github/workflows/codex-production-readiness-queue-reconcile-smoke.yml
+++ b/.github/workflows/codex-production-readiness-queue-reconcile-smoke.yml
@@ -1,0 +1,33 @@
+name: Codex Queue Reconcile Smoke
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/codex-production-readiness-queue.yml'
+      - 'docs/CODEX_PRODUCTION_READINESS_QUEUE.md'
+      - 'docs/github/CODEX_QUEUE_OPERATIONS.md'
+      - '.github/PULL_REQUEST_TEMPLATE.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate-yaml:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Validate workflow YAML parses
+        run: |
+          ruby -ryaml -e 'ARGV.each { |path| YAML.load_file(path); puts "OK: #{path}" }' \
+            .github/workflows/codex-production-readiness-queue.yml \
+            .github/workflows/codex-production-readiness-queue-reconcile-smoke.yml
+
+      - name: Validate reconcile keywords
+        run: |
+          grep -q 'mode=reconcile' docs/CODEX_PRODUCTION_READINESS_QUEUE.md
+          grep -q 'reconcile_open_prs' .github/workflows/codex-production-readiness-queue.yml
+          grep -q 'codex:checks-failed' .github/workflows/codex-production-readiness-queue.yml
+          grep -q 'Production Readiness Queue Checklist' .github/PULL_REQUEST_TEMPLATE.md

--- a/.github/workflows/codex-production-readiness-queue.yml
+++ b/.github/workflows/codex-production-readiness-queue.yml
@@ -47,8 +47,8 @@ jobs:
       GH_TOKEN: ${{ github.token }}
       REPO: ${{ github.repository }}
       INDEX_ISSUE: '1263'
-      DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-      MODE: ${{ github.event_name == 'schedule' && 'reconcile' || github.event.inputs.mode || 'sync-pr' }}
+      DRY_RUN: "${{ github.event.inputs.dry_run || 'false' }}"
+      MODE: "${{ github.event_name == 'schedule' && 'reconcile' || github.event.inputs.mode || 'sync-pr' }}"
 
     steps:
       - name: Ensure labels exist

--- a/.github/workflows/codex-production-readiness-queue.yml
+++ b/.github/workflows/codex-production-readiness-queue.yml
@@ -10,6 +10,7 @@ on:
         type: choice
         options:
           - bootstrap-labels
+          - reconcile
           - dispatch-next
           - status
       dry_run:
@@ -20,6 +21,8 @@ on:
         options:
           - 'false'
           - 'true'
+  schedule:
+    - cron: '17 * * * *'
   pull_request:
     types: [opened, reopened, synchronize, ready_for_review, closed]
 
@@ -31,6 +34,8 @@ permissions:
   contents: read
   issues: write
   pull-requests: read
+  checks: read
+  actions: read
 
 jobs:
   queue:
@@ -43,12 +48,9 @@ jobs:
       REPO: ${{ github.repository }}
       INDEX_ISSUE: '1263'
       DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-      MODE: ${{ github.event.inputs.mode || 'sync-pr' }}
+      MODE: ${{ github.event_name == 'schedule' && 'reconcile' || github.event.inputs.mode || 'sync-pr' }}
 
     steps:
-      - name: Checkout
-        uses: actions/checkout@v6
-
       - name: Ensure labels exist
         shell: bash
         run: |
@@ -73,6 +75,7 @@ jobs:
           create_label "codex:ready" "0E8A16" "Ready for Codex execution"
           create_label "codex:in-progress" "FBCA04" "Codex is currently working"
           create_label "codex:pr-open" "1D76DB" "Codex opened a PR"
+          create_label "codex:checks-failed" "B60205" "Linked PR has failing or pending checks"
           create_label "codex:blocked" "D93F0B" "Codex is blocked"
           create_label "codex:review" "5319E7" "Needs human review"
           create_label "codex:done" "6F42C1" "Completed by merged PR"
@@ -82,62 +85,40 @@ jobs:
         run: |
           set -euo pipefail
 
-          log() {
-            echo "[codex-queue] $*"
-          }
-
-          issue_body() {
-            gh issue view "$1" --repo "$REPO" --json body --jq '.body // ""'
-          }
-
-          issue_state() {
-            gh issue view "$1" --repo "$REPO" --json state --jq '.state'
-          }
-
-          issue_labels() {
-            gh issue view "$1" --repo "$REPO" --json labels --jq '.labels[].name' || true
-          }
-
-          issue_in_index() {
-            local issue="$1"
-            issue_body "$INDEX_ISSUE" | grep -Eq "#${issue}([^0-9]|$)"
-          }
+          log() { echo "[codex-queue] $*"; }
+          issue_body() { gh issue view "$1" --repo "$REPO" --json body --jq '.body // ""'; }
+          issue_state() { gh issue view "$1" --repo "$REPO" --json state --jq '.state'; }
+          issue_labels() { gh issue view "$1" --repo "$REPO" --json labels --jq '.labels[].name' || true; }
+          issue_in_index() { issue_body "$INDEX_ISSUE" | grep -Eq "#$1([^0-9]|$)"; }
 
           add_label() {
-            local issue="$1"
-            local label="$2"
             if [ "$DRY_RUN" = "true" ]; then
-              log "[dry-run] add label '$label' to #$issue"
+              log "[dry-run] add label '$2' to #$1"
               return 0
             fi
-            gh issue edit "$issue" --repo "$REPO" --add-label "$label" >/dev/null
+            gh issue edit "$1" --repo "$REPO" --add-label "$2" >/dev/null
           }
 
           remove_label() {
-            local issue="$1"
-            local label="$2"
             if [ "$DRY_RUN" = "true" ]; then
-              log "[dry-run] remove label '$label' from #$issue"
+              log "[dry-run] remove label '$2' from #$1"
               return 0
             fi
-            gh issue edit "$issue" --repo "$REPO" --remove-label "$label" >/dev/null 2>&1 || true
+            gh issue edit "$1" --repo "$REPO" --remove-label "$2" >/dev/null 2>&1 || true
           }
 
           comment_issue() {
-            local issue="$1"
-            local body="$2"
             if [ "$DRY_RUN" = "true" ]; then
-              log "[dry-run] comment on #$issue:"
-              echo "$body"
+              log "[dry-run] comment on #$1:"
+              echo "$2"
               return 0
             fi
-            gh issue comment "$issue" --repo "$REPO" --body "$body" >/dev/null
+            gh issue comment "$1" --repo "$REPO" --body "$2" >/dev/null
           }
 
           priority_from_title() {
-            local issue="$1"
             local title
-            title=$(gh issue view "$issue" --repo "$REPO" --json title --jq '.title')
+            title=$(gh issue view "$1" --repo "$REPO" --json title --jq '.title')
             if [[ "$title" == *"[P0]"* ]]; then echo "priority:P0"; return; fi
             if [[ "$title" == *"[P1]"* ]]; then echo "priority:P1"; return; fi
             if [[ "$title" == *"[P2]"* ]]; then echo "priority:P2"; return; fi
@@ -145,21 +126,22 @@ jobs:
             echo ""
           }
 
+          linked_issue_from_pr_body() {
+            printf '%s\n' "$1" | grep -Eio '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | head -1 | grep -Eo '[0-9]+' || true
+          }
+
           bootstrap_labels() {
-            local numbers labels
+            local numbers issue state labels prio
             numbers=$(issue_body "$INDEX_ISSUE" | grep -Eo '#[0-9]+' | tr -d '#' | sort -n | uniq)
             for issue in $numbers; do
               if [ "$issue" = "$INDEX_ISSUE" ]; then
                 add_label "$issue" "production-readiness"
                 continue
               fi
-
-              local state prio
               state=$(issue_state "$issue")
               add_label "$issue" "production-readiness"
               prio=$(priority_from_title "$issue")
               if [ -n "$prio" ]; then add_label "$issue" "$prio"; fi
-
               if [ "$state" = "OPEN" ]; then
                 labels=$(issue_labels "$issue")
                 if ! echo "$labels" | grep -qx "codex:done" && \
@@ -205,8 +187,7 @@ jobs:
           }
 
           check_index_item() {
-            local issue="$1"
-            local body_file tmp
+            local issue="$1" body_file tmp
             body_file=$(mktemp)
             tmp=$(mktemp)
             issue_body "$INDEX_ISSUE" > "$body_file"
@@ -214,10 +195,8 @@ jobs:
           import pathlib
           import re
           import sys
-
           issue = sys.argv[1]
-          body_file = pathlib.Path(sys.argv[2])
-          body = body_file.read_text(encoding='utf-8')
+          body = pathlib.Path(sys.argv[2]).read_text(encoding='utf-8')
           pattern = re.compile(rf'(^- \[ \] #{re.escape(issue)}(\b|\D))', re.M)
           body = pattern.sub(lambda m: m.group(0).replace('- [ ]', '- [x]', 1), body, count=1)
           print(body, end='')
@@ -231,31 +210,55 @@ jobs:
             rm -f "$tmp" "$body_file"
           }
 
-          linked_issue_from_pr_body() {
-            local body="$1"
-            printf '%s\n' "$body" | grep -Eio '(close[sd]?|fix(e[sd])?|resolve[sd]?) #[0-9]+' | head -1 | grep -Eo '[0-9]+' || true
+          sync_pr_checks() {
+            local issue="$1" pr_number="$2" failing_checks
+            failing_checks=$(gh pr view "$pr_number" --repo "$REPO" --json statusCheckRollup --jq '
+              [
+                .statusCheckRollup[]?
+                | select(
+                    (.status != "COMPLETED") or
+                    ((.conclusion // "") != "SUCCESS" and (.conclusion // "") != "NEUTRAL" and (.conclusion // "") != "SKIPPED")
+                  )
+              ] | length
+            ' 2>/dev/null || echo "0")
+            if [ "$failing_checks" != "0" ]; then
+              add_label "$issue" "codex:checks-failed"
+              add_label "$pr_number" "codex:checks-failed"
+              log "PR #$pr_number linked to #$issue has failing or pending checks: $failing_checks"
+            else
+              remove_label "$issue" "codex:checks-failed"
+              remove_label "$pr_number" "codex:checks-failed"
+              log "PR #$pr_number linked to #$issue has no failing or pending checks."
+            fi
           }
 
           sync_pr_open() {
-            local issue="$1"
-            local pr_number="$2"
+            local issue="$1" pr_number="$2" labels already_pr_open
             [ -n "$issue" ] || return 0
             issue_in_index "$issue" || { log "PR links #$issue, but it is not in #$INDEX_ISSUE. Skipping."; return 0; }
+            labels=$(issue_labels "$issue")
+            already_pr_open=false
+            if echo "$labels" | grep -qx "codex:pr-open"; then already_pr_open=true; fi
             add_label "$issue" "production-readiness"
             add_label "$issue" "codex:pr-open"
+            add_label "$issue" "codex:review"
             remove_label "$issue" "codex:in-progress"
             remove_label "$issue" "codex:ready"
-            comment_issue "$issue" "PR #${pr_number} is open for this production-readiness task. Queue status moved to \`codex:pr-open\`."
+            remove_label "$issue" "codex:blocked"
+            sync_pr_checks "$issue" "$pr_number"
+            if [ "$already_pr_open" = "false" ]; then
+              comment_issue "$issue" "PR #${pr_number} is open for this production-readiness task. Queue status moved to \`codex:pr-open\`."
+            fi
           }
 
           sync_pr_merged() {
-            local issue="$1"
-            local pr_number="$2"
+            local issue="$1" pr_number="$2"
             [ -n "$issue" ] || return 0
             issue_in_index "$issue" || { log "Merged PR links #$issue, but it is not in #$INDEX_ISSUE. Skipping."; return 0; }
             add_label "$issue" "production-readiness"
             add_label "$issue" "codex:done"
             remove_label "$issue" "codex:pr-open"
+            remove_label "$issue" "codex:checks-failed"
             remove_label "$issue" "codex:in-progress"
             remove_label "$issue" "codex:ready"
             remove_label "$issue" "codex:blocked"
@@ -263,18 +266,31 @@ jobs:
             comment_issue "$issue" "Merged via PR #${pr_number}. Queue status moved to \`codex:done\`, and #${INDEX_ISSUE} was checked off."
           }
 
+          reconcile_open_prs() {
+            local rows row pr_number body issue
+            log "Reconciling open PRs against #$INDEX_ISSUE..."
+            rows=$(gh pr list --repo "$REPO" --state open --limit 100 --json number,body --jq '.[] | @base64')
+            for row in $rows; do
+              body=$(printf '%s' "$row" | base64 -d | jq -r '.body // ""')
+              issue=$(linked_issue_from_pr_body "$body")
+              [ -n "$issue" ] || continue
+              issue_in_index "$issue" || continue
+              pr_number=$(printf '%s' "$row" | base64 -d | jq -r '.number')
+              sync_pr_open "$issue" "$pr_number"
+            done
+          }
+
           dispatch_next() {
+            reconcile_open_prs
             if has_active_work; then
               log "No dispatch: active work already exists."
               return 0
             fi
-
             local issue title prio prompt
             if ! issue=$(next_issue_from_index); then
               log "No open unchecked production-readiness issue found in #$INDEX_ISSUE."
               return 0
             fi
-
             title=$(gh issue view "$issue" --repo "$REPO" --json title --jq '.title')
             prio=$(priority_from_title "$issue")
             add_label "$issue" "production-readiness"
@@ -282,41 +298,39 @@ jobs:
             add_label "$issue" "codex:in-progress"
             remove_label "$issue" "codex:ready"
             remove_label "$issue" "codex:blocked"
-
             prompt=$(cat <<EOF
-          @codex Please execute this production-readiness issue exactly as scoped.
+@codex Please execute this production-readiness issue exactly as scoped.
 
-          Queue source: #${INDEX_ISSUE}
-          Selected issue: #${issue}
+Queue source: #${INDEX_ISSUE}
+Selected issue: #${issue}
 
-          Rules:
-          - Work on exactly this one issue.
-          - Do not start any other issue.
-          - Create a dedicated branch: \`production-readiness/${issue}-<short-slug>\`.
-          - Keep the change limited to this issue body and explicit dependencies.
-          - Run the relevant verification from \`.github/codex/prompts/execute-next-production-issue.md\`.
-          - Open a PR titled \`[#${issue}] ${title}\`.
-          - Include \`Closes #${issue}\` in the PR body.
-          - Include summary, changed files, tests run, risks, and rollback notes.
-          - Do not merge the PR.
-          - If blocked, remove \`codex:in-progress\`, add \`codex:blocked\`, and comment with blocker, attempted approach, decision needed, and next action.
-          EOF
+Rules:
+- Work on exactly this one issue.
+- Do not start any other issue.
+- Create a dedicated branch: \`production-readiness/${issue}-<short-slug>\`.
+- Keep the change limited to this issue body and explicit dependencies.
+- Run the relevant verification from \`.github/codex/prompts/execute-next-production-issue.md\`.
+- Open a PR titled \`[#${issue}] ${title}\`.
+- Include \`Closes #${issue}\` in the PR body.
+- Include summary, changed files, tests run, risks, and rollback notes.
+- Do not merge the PR.
+- If blocked, remove \`codex:in-progress\`, add \`codex:blocked\`, and comment with blocker, attempted approach, decision needed, and next action.
+EOF
             )
-
             comment_issue "$issue" "$prompt"
             log "Dispatched #$issue: $title"
           }
 
-          if [ "$MODE" = "bootstrap-labels" ]; then
-            bootstrap_labels
-            exit 0
-          fi
-
+          if [ "$MODE" = "bootstrap-labels" ]; then bootstrap_labels; exit 0; fi
+          if [ "$MODE" = "reconcile" ]; then reconcile_open_prs; exit 0; fi
           if [ "$MODE" = "status" ]; then
+            reconcile_open_prs
             log "Open in-progress issues:"
             gh issue list --repo "$REPO" --state open --label "production-readiness" --label "codex:in-progress" || true
             log "Open PR-linked issues:"
             gh issue list --repo "$REPO" --state open --label "production-readiness" --label "codex:pr-open" || true
+            log "Open PRs with failing or pending checks:"
+            gh issue list --repo "$REPO" --state open --label "production-readiness" --label "codex:checks-failed" || true
             exit 0
           fi
 
@@ -324,27 +338,14 @@ jobs:
             pr_number="${{ github.event.pull_request.number }}"
             pr_body=$(gh pr view "$pr_number" --repo "$REPO" --json body --jq '.body // ""')
             issue=$(linked_issue_from_pr_body "$pr_body")
-
-            if [ -z "$issue" ]; then
-              log "No Closes/Fixes/Resolves issue reference found in PR body."
-              exit 0
-            fi
-
+            if [ -z "$issue" ]; then log "No Closes/Fixes/Resolves issue reference found in PR body."; exit 0; fi
             if [ "${{ github.event.action }}" = "closed" ] && [ "${{ github.event.pull_request.merged }}" = "true" ]; then
               sync_pr_merged "$issue" "$pr_number"
               dispatch_next
               exit 0
             fi
-
-            if [ "${{ github.event.action }}" != "closed" ]; then
-              sync_pr_open "$issue" "$pr_number"
-              exit 0
-            fi
+            if [ "${{ github.event.action }}" != "closed" ]; then sync_pr_open "$issue" "$pr_number"; exit 0; fi
           fi
 
-          if [ "$MODE" = "dispatch-next" ]; then
-            dispatch_next
-            exit 0
-          fi
-
+          if [ "$MODE" = "dispatch-next" ]; then dispatch_next; exit 0; fi
           log "No operation performed for mode=$MODE event=${{ github.event_name }}"

--- a/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
+++ b/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
@@ -20,6 +20,7 @@ Codex should execute one production-readiness issue at a time, in queue order, a
 4. Codex must implement exactly one issue per run.
 5. Codex must not merge PRs.
 6. Human review and CI remain the release gate.
+7. A linked PR with failing or pending checks must not allow the next queue item to start.
 
 ## Labels
 
@@ -33,22 +34,46 @@ The queue workflows use these labels:
 - `codex:ready`
 - `codex:in-progress`
 - `codex:pr-open`
+- `codex:checks-failed`
 - `codex:blocked`
 - `codex:review`
 - `codex:done`
 
-The workflow `.github/workflows/codex-production-readiness-queue.yml` can create these labels when run with `mode=bootstrap-labels`.
+The workflow `.github/workflows/codex-production-readiness-queue.yml` can create or update these labels when run with `mode=bootstrap-labels`.
 
 ## Recommended start sequence
 
 Run the workflow manually first:
 
-1. `Codex Production Readiness Queue` → `workflow_dispatch` → `mode=bootstrap-labels`.
-2. `Codex Production Readiness Queue` → `workflow_dispatch` → `mode=dispatch-next`.
-3. Confirm that the first issue gets a `@codex` dispatch comment and `codex:in-progress`.
-4. Wait for Codex to open a PR.
-5. Review CI and merge manually.
-6. The workflow will mark the linked issue as done and dispatch the next queue item.
+1. `Codex Production Readiness Queue` -> `workflow_dispatch` -> `mode=bootstrap-labels`.
+2. `Codex Production Readiness Queue` -> `workflow_dispatch` -> `mode=reconcile`.
+3. `Codex Production Readiness Queue` -> `workflow_dispatch` -> `mode=dispatch-next`.
+4. Confirm that the selected issue gets a `@codex` dispatch comment and `codex:in-progress`.
+5. Wait for Codex to open a PR.
+6. Review CI and merge manually.
+7. The workflow will mark the linked issue as done and dispatch the next queue item.
+
+## Reconciliation mode
+
+`mode=reconcile` is the safety net for cases where Codex opens a PR but the issue status does not update through the normal `pull_request` event.
+
+Reconciliation does this:
+
+1. Scans open PRs in the repository.
+2. Reads each PR body.
+3. Finds `Closes #<issue>`, `Fixes #<issue>`, or `Resolves #<issue>`.
+4. Confirms the linked issue exists in `#1263`.
+5. Moves the linked issue to:
+   - `production-readiness`
+   - `codex:pr-open`
+   - `codex:review`
+6. Removes stale queue states from the linked issue:
+   - `codex:in-progress`
+   - `codex:ready`
+   - `codex:blocked`
+7. Checks the PR status checks and adds `codex:checks-failed` when checks are failing or pending.
+
+The workflow also runs reconciliation automatically on an hourly schedule.
 
 ## GitHub Codex integration assumption
 
@@ -76,14 +101,17 @@ When Codex starts an issue:
 
 ## PR status sync
 
-When a PR is opened and its body contains `Closes #<issue-number>`, the workflow marks that issue as `codex:pr-open` and removes `codex:in-progress`.
+When a PR is opened and its body contains `Closes #<issue-number>`, the workflow marks that issue as `codex:pr-open`, adds `codex:review`, and removes `codex:in-progress`.
+
+When that PR has failing or pending checks, the workflow adds `codex:checks-failed` to both the linked issue and the PR.
 
 When that PR is merged, the workflow:
 
 1. Adds `codex:done`.
 2. Removes active queue labels.
-3. Checks the issue line in `#1263`.
-4. Dispatches the next unchecked issue.
+3. Removes `codex:checks-failed`.
+4. Checks the issue line in `#1263`.
+5. Dispatches the next unchecked issue.
 
 ## Blocked work
 
@@ -103,6 +131,7 @@ The queue runner skips blocked issues until a human removes `codex:blocked` and 
 
 - Never auto-merge P0/P1 PRs.
 - Never run two production-readiness issues in parallel.
+- Never dispatch the next issue while any production-readiness PR has `codex:pr-open`.
 - Never remove privacy, security, or auth checks to make tests pass.
 - Never print secrets in issue comments, PR bodies, logs, screenshots, or artifacts.
 - Prefer small PRs over broad refactors.

--- a/docs/github/CODEX_QUEUE_OPERATIONS.md
+++ b/docs/github/CODEX_QUEUE_OPERATIONS.md
@@ -1,0 +1,91 @@
+# Codex Queue Operations
+
+This runbook explains how to operate the production-readiness queue.
+
+## Source of truth
+
+- Backlog index: `#1263`
+- Active task status labels:
+  - `codex:ready`
+  - `codex:in-progress`
+  - `codex:pr-open`
+  - `codex:checks-failed`
+  - `codex:blocked`
+  - `codex:review`
+  - `codex:done`
+
+## Normal flow
+
+1. Run `Codex Production Readiness Queue` with `mode=dispatch-next`.
+2. The workflow reconciles open PRs first.
+3. If no active work exists, it dispatches the first unchecked open issue from `#1263`.
+4. Codex opens a PR with `Closes #<issue-number>`.
+5. The workflow marks the linked issue as `codex:pr-open` and `codex:review`.
+6. Humans review and merge.
+7. The workflow marks the issue as `codex:done`, checks it off in `#1263`, then dispatches the next item.
+
+## Reconcile flow
+
+Run `mode=reconcile` when any of these happen:
+
+- Codex says it opened a PR, but the issue still has `codex:in-progress`.
+- A PR exists with `Closes #<issue>`, but the linked issue is not `codex:pr-open`.
+- A PR has failing checks and should be flagged on the issue.
+- The queue appears stuck.
+
+Reconcile scans open PRs and syncs linked issues based on `Closes/Fixes/Resolves #<issue>` in the PR body.
+
+## Expected active states
+
+### No active work
+
+No open issue should have `codex:in-progress` or `codex:pr-open`.
+
+### Codex is working
+
+Exactly one issue should have:
+
+- `production-readiness`
+- priority label
+- `codex:in-progress`
+
+### PR is open
+
+Exactly one issue should have:
+
+- `production-readiness`
+- priority label
+- `codex:pr-open`
+- `codex:review`
+
+The linked PR should also have `production-readiness`, priority label, `codex:pr-open`, and `codex:review`.
+
+### PR checks are failing or pending
+
+The linked issue and PR should also have:
+
+- `codex:checks-failed`
+
+Do not dispatch the next issue until the PR is merged and the checks/review state is acceptable.
+
+## Manual recovery
+
+If a queue item is incorrectly stuck in `codex:in-progress` but a linked PR exists:
+
+1. Run `mode=reconcile`.
+2. Confirm the issue changes to `codex:pr-open`.
+3. Confirm the PR has `Closes #<issue-number>`.
+4. Continue with review/merge.
+
+If no linked PR exists:
+
+1. Leave the issue as `codex:in-progress` only if Codex is actually working.
+2. Otherwise set `codex:blocked` and comment with the exact failure.
+3. Restart Codex only after removing the stale blocker or clarifying the task.
+
+## Do not
+
+- Do not start the next issue while any issue has `codex:in-progress` or `codex:pr-open`.
+- Do not merge P0/P1 PRs without human review.
+- Do not remove `codex:checks-failed` manually unless the checks were rerun and verified.
+- Do not rely on Codex's text summary alone; verify the GitHub PR exists.


### PR DESCRIPTION
Related to #1263 and #1225.

## Summary
- Adds `mode=reconcile` to the Codex production-readiness queue workflow.
- Adds hourly scheduled reconciliation for open PRs that link issues with `Closes/Fixes/Resolves #<issue>`.
- Syncs linked issues to `codex:pr-open` and `codex:review` when a PR exists.
- Adds `codex:checks-failed` when a linked PR has failing or pending checks.
- Runs reconciliation before dispatching the next queue item.
- Adds a small reconcile smoke workflow, PR template checklist, and queue operations documentation.

## Why
The queue previously depended mainly on immediate `pull_request` events. If Codex opened a PR but the linked issue state did not sync, the queue could remain stuck in `codex:in-progress` or require manual correction. This PR adds a self-healing path.

## Current validation target
- PR #1270 is the active PR for #1225.
- #1225 should stay `codex:pr-open` until #1270 is merged.
- #1226 should not start before #1270 is merged.

## Tests / validation
- Added `Codex Queue Reconcile Smoke` workflow to validate queue workflow YAML and required reconcile markers.
- Not run locally; this is a GitHub workflow/configuration change made through the connector.

## Risks
- Reconcile depends on PR bodies containing `Closes #<issue>` or equivalent.
- `codex:checks-failed` detection depends on GitHub status check rollup shape.
- This does not auto-merge PRs; human review remains required.

## Rollback notes
- Revert this PR to remove reconcile mode and return to manual queue sync.