### PR TITLE
fix(ci): triage monitoring report failures

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -31,9 +31,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Build project
-        run: pnpm run build
-
       - name: Check bundle size
         uses: preactjs/compressed-size-action@v3
         with:
@@ -41,7 +38,7 @@ jobs:
           pattern: './build/**/*.{js,css}'
           exclude: '**/*.map,**/*.svg,**/*.png,**/*.jpg'
           minimum-change-threshold: '1KB'
-          build-script: 'build'
+          build-script: 'pnpm run build'
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7
@@ -66,11 +63,11 @@ jobs:
 
             function calculateSize(dir) {
               const files = fs.readdirSync(dir);
-              
+
               for (const file of files) {
                 const filePath = path.join(dir, file);
                 const stat = fs.statSync(filePath);
-                
+
                 if (stat.isDirectory()) {
                   calculateSize(filePath);
                 } else if (file.endsWith('.js')) {
@@ -109,11 +106,11 @@ jobs:
 
             if (github.event_name === 'pull_request') {
               comment += '### Changes\n\n';
-              
+
               if (totalSize > 500 * 1024) {
                 comment += '⚠️ **Warning:** Bundle size is over 500KB\n\n';
               }
-              
+
               if (totalSize > 1024 * 1024) {
                 comment += '🚨 **Critical:** Bundle size is over 1MB\n\n';
               }
@@ -134,7 +131,7 @@ jobs:
               issue_number: context.issue.number,
             });
 
-            const existingComment = comments.find(c => 
+            const existingComment = comments.find(c =>
               c.body.includes('Bundle Size Report')
             );
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -29,6 +29,8 @@ jobs:
 
   coverage-check:
     runs-on: ubuntu-latest
+    env:
+      NODE_OPTIONS: --max-old-space-size=8192
     steps:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
@@ -36,7 +38,8 @@ jobs:
           node-version: '22'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run test:coverage
+      - run: node scripts/ensure-coverage-dirs.mjs
+      - run: pnpm exec vitest run --coverage --exclude=src/App.test.tsx --exclude=src/App.integration.test.tsx --exclude=src/hooks/useMeetings.test.tsx --maxWorkers=2
       - uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -52,12 +55,12 @@ jobs:
           node-version: '22'
       - run: corepack enable
       - run: pnpm install --frozen-lockfile
-      - run: pnpm run build
       - uses: preactjs/compressed-size-action@v3
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: './build/**/*.{js,css}'
           exclude: '**/*.map'
+          build-script: 'pnpm run build'
 
   security-scan:
     runs-on: ubuntu-latest

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -30,7 +30,7 @@ jobs:
         run: pnpm install --no-frozen-lockfile
 
       - name: Install Vercel CLI
-        run: pnpm install -g vercel@latest
+        run: npm install -g vercel@latest
 
       - name: Validate Vercel secrets
         shell: bash

--- a/scripts/fetch-github-errors.js
+++ b/scripts/fetch-github-errors.js
@@ -13,6 +13,10 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import dotenv from 'dotenv';
 
+import { parseErrors, partitionWorkflowFailures } from './github-error-reporting.mjs';
+
+export { parseErrors, partitionWorkflowFailures };
+
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // Load environment variables from .env.local FIRST (takes precedence)
@@ -31,7 +35,11 @@ const config = {
 };
 
 // Ensure output directory exists
-if (!fs.existsSync(config.outputDir)) {
+if (
+  process.argv[1] &&
+  path.resolve(process.argv[1]) === fileURLToPath(import.meta.url) &&
+  !fs.existsSync(config.outputDir)
+) {
   fs.mkdirSync(config.outputDir, { recursive: true });
   console.log(`📁 Created output directory: ${config.outputDir}`);
 }
@@ -98,48 +106,6 @@ async function fetchWorkflowRuns() {
   return response.data.workflow_runs;
 }
 
-function getWorkflowKey(run) {
-  return run.name || String(run.workflow_id || run.id || 'unknown-workflow');
-}
-
-export function partitionWorkflowFailures(runs) {
-  const latestByWorkflow = new Map();
-
-  for (const run of runs) {
-    const key = getWorkflowKey(run);
-    const currentLatest = latestByWorkflow.get(key);
-
-    if (
-      !currentLatest ||
-      new Date(run.created_at).getTime() > new Date(currentLatest.created_at).getTime()
-    ) {
-      latestByWorkflow.set(key, run);
-    }
-  }
-
-  const activeFailures = [];
-  const resolvedFailures = [];
-
-  for (const run of runs) {
-    if (run.conclusion !== 'failure') {
-      continue;
-    }
-
-    const latestRun = latestByWorkflow.get(getWorkflowKey(run));
-    if (latestRun && latestRun.id === run.id) {
-      activeFailures.push(run);
-    } else {
-      resolvedFailures.push(run);
-    }
-  }
-
-  return {
-    activeFailures,
-    resolvedFailures,
-    latestByWorkflow: Array.from(latestByWorkflow.values()),
-  };
-}
-
 // Fetch job logs
 async function fetchJobLogs(jobId, jobName) {
   console.log(`  📄 Fetching logs for job: ${jobName}`);
@@ -203,37 +169,6 @@ async function fetchJobLogs(jobId, jobName) {
 
     req.end();
   });
-}
-
-// Parse error from logs
-function parseErrors(logs) {
-  const errors = [];
-  const lines = logs.split('\n');
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-
-    // Look for error patterns
-    if (
-      line.includes('Error:') ||
-      line.includes('ERROR') ||
-      line.includes('❌') ||
-      line.includes('FAILED')
-    ) {
-      // Get context (5 lines before and after)
-      const start = Math.max(0, i - 5);
-      const end = Math.min(lines.length, i + 5);
-      const context = lines.slice(start, end).join('\n');
-
-      errors.push({
-        line: line.trim(),
-        context: context,
-        lineNumber: i + 1,
-      });
-    }
-  }
-
-  return errors;
 }
 
 // Generate error report

--- a/scripts/fetch-github-errors.test.ts
+++ b/scripts/fetch-github-errors.test.ts
@@ -1,4 +1,4 @@
-import { partitionWorkflowFailures } from './fetch-github-errors.js';
+import { parseErrors, partitionWorkflowFailures } from './github-error-reporting.mjs';
 
 function makeRun(overrides: Record<string, unknown>) {
   return {
@@ -98,5 +98,42 @@ describe('partitionWorkflowFailures', () => {
     expect(result.activeFailures.map((run) => run.id)).toEqual([3]);
     expect(result.resolvedFailures.map((run) => run.id)).toEqual([1]);
     expect(result.latestByWorkflow).toHaveLength(2);
+  });
+});
+
+describe('parseErrors', () => {
+  it('keeps terminal Vitest worker failures instead of recorder stderr from tests', () => {
+    const errors = parseErrors(`
+stderr | src/hooks/useAudioHardware.test.ts > useAudioHardware > cleanupRecorder is invoked when recorder setup fails
+Recording start failed. Error: MediaRecorder init failed
+[2985:0xaaf5000] allocation failure
+FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
+Unhandled Errors
+Error: [vitest-pool]: Worker forks emitted error.
+Caused by: Error: Worker exited unexpectedly
+ELIFECYCLE Command failed with exit code 1.
+`);
+
+    expect(errors.map((error) => error.line)).toContain(
+      'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory'
+    );
+    expect(errors.map((error) => error.line)).toContain(
+      'Error: [vitest-pool]: Worker forks emitted error.'
+    );
+    expect(errors.map((error) => error.line)).not.toContain(
+      'Recording start failed. Error: MediaRecorder init failed'
+    );
+  });
+
+  it('keeps compressed-size action setup failures as actionable GitHub errors', () => {
+    const errors = parseErrors(`
+Run preactjs/compressed-size-action@v3
+Error: Unable to locate executable file: build. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable.
+Process completed with exit code 1.
+`);
+
+    expect(errors.map((error) => error.line)).toContain(
+      'Error: Unable to locate executable file: build. Please verify either the file path exists or the file can be found within a directory specified by the PATH environment variable.'
+    );
   });
 });

--- a/scripts/github-error-reporting.mjs
+++ b/scripts/github-error-reporting.mjs
@@ -1,0 +1,126 @@
+function getWorkflowKey(run) {
+  return run.name || String(run.workflow_id || run.id || 'unknown-workflow');
+}
+
+export function partitionWorkflowFailures(runs) {
+  const latestByWorkflow = new Map();
+
+  for (const run of runs) {
+    const key = getWorkflowKey(run);
+    const currentLatest = latestByWorkflow.get(key);
+
+    if (
+      !currentLatest ||
+      new Date(run.created_at).getTime() > new Date(currentLatest.created_at).getTime()
+    ) {
+      latestByWorkflow.set(key, run);
+    }
+  }
+
+  const activeFailures = [];
+  const resolvedFailures = [];
+
+  for (const run of runs) {
+    if (run.conclusion !== 'failure') {
+      continue;
+    }
+
+    const latestRun = latestByWorkflow.get(getWorkflowKey(run));
+    if (latestRun && latestRun.id === run.id) {
+      activeFailures.push(run);
+    } else {
+      resolvedFailures.push(run);
+    }
+  }
+
+  return {
+    activeFailures,
+    resolvedFailures,
+    latestByWorkflow: Array.from(latestByWorkflow.values()),
+  };
+}
+
+function stripLogFormatting(line) {
+  return String(line || '')
+    .replace(/\u001b\[[0-9;]*m/g, '')
+    .replace(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s+/, '')
+    .trim();
+}
+
+function isVitestStreamMarker(line) {
+  return /^(stderr|stdout)\s+\|/i.test(stripLogFormatting(line));
+}
+
+function isKnownTestStderrNoise(line, previousLines) {
+  const text = stripLogFormatting(line);
+  const recentContext = previousLines.slice(-3).map(stripLogFormatting).join('\n');
+
+  if (isVitestStreamMarker(text)) {
+    return true;
+  }
+
+  if (!/^(stderr|stdout)\s+\|/im.test(recentContext)) {
+    return false;
+  }
+
+  return (
+    /^Recording start failed\./i.test(text) ||
+    /^Immediate workspace sync after delete failed:/i.test(text) ||
+    /^Audio hydration failed\b/i.test(text) ||
+    /^\[httpClient\]\s+/i.test(text) ||
+    /^Failed to fetch$/i.test(text) ||
+    /^Permission denied$/i.test(text)
+  );
+}
+
+function isActionableGithubLogLine(line, previousLines) {
+  const text = stripLogFormatting(line);
+
+  if (!text || isKnownTestStderrNoise(text, previousLines)) {
+    return false;
+  }
+
+  if (
+    /FATAL ERROR:/i.test(text) ||
+    /\[vitest-pool\]/i.test(text) ||
+    /Worker exited unexpectedly/i.test(text) ||
+    /ELIFECYCLE.*exit code/i.test(text) ||
+    /Process completed with exit code/i.test(text) ||
+    /Unable to locate executable file:/i.test(text) ||
+    /Code style issues found/i.test(text)
+  ) {
+    return true;
+  }
+
+  return (
+    text.includes('Error:') ||
+    text.includes('ERROR') ||
+    text.includes('FAILED') ||
+    text.includes('failed')
+  );
+}
+
+// Parse actionable error lines from GitHub job logs. Test stderr often contains
+// expected simulated failures, so prefer terminal CI failure lines.
+export function parseErrors(logs) {
+  const errors = [];
+  const lines = logs.split('\n');
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+
+    if (isActionableGithubLogLine(line, lines.slice(0, i))) {
+      const start = Math.max(0, i - 5);
+      const end = Math.min(lines.length, i + 5);
+      const context = lines.slice(start, end).join('\n');
+
+      errors.push({
+        line: stripLogFormatting(line),
+        context,
+        lineNumber: i + 1,
+      });
+    }
+  }
+
+  return errors;
+}

--- a/scripts/monitoring-error-groups.mjs
+++ b/scripts/monitoring-error-groups.mjs
@@ -104,6 +104,70 @@ function firstParsedError(jobFailure) {
   return null;
 }
 
+function parsedErrorText(parsedError) {
+  return toText(parsedError?.line || parsedError?.message || parsedError?.context, '');
+}
+
+function githubParsedErrorScore(parsedError) {
+  const text = parsedErrorText(parsedError).toLowerCase();
+
+  if (!text) {
+    return 0;
+  }
+
+  if (
+    text.includes('fatal error:') ||
+    text.includes('[vitest-pool]') ||
+    text.includes('worker exited unexpectedly') ||
+    text.includes('unable to locate executable file:') ||
+    text.includes('code style issues found') ||
+    text.includes('process completed with exit code') ||
+    /elifecycle.*exit code/.test(text)
+  ) {
+    return 100;
+  }
+
+  if (/^(stderr|stdout)\s+\|/i.test(text)) {
+    return 0;
+  }
+
+  if (
+    text.includes('recording start failed') ||
+    text.includes('immediate workspace sync after delete failed') ||
+    text.includes('audio hydration failed') ||
+    text.includes('[httpclient] retry')
+  ) {
+    return 10;
+  }
+
+  if (/\b(error|failed|failure|unhandled|exception)\b/i.test(text)) {
+    return 50;
+  }
+
+  return 1;
+}
+
+function primaryParsedError(jobFailure) {
+  const errors = Array.isArray(jobFailure?.errors) ? jobFailure.errors : [];
+
+  if (errors.length === 0) {
+    return null;
+  }
+
+  return [...errors].sort((left, right) => {
+    const scoreDelta = githubParsedErrorScore(right) - githubParsedErrorScore(left);
+
+    if (scoreDelta !== 0) {
+      return scoreDelta;
+    }
+
+    return (
+      Number(left?.lineNumber ?? Number.MAX_SAFE_INTEGER) -
+      Number(right?.lineNumber ?? Number.MAX_SAFE_INTEGER)
+    );
+  })[0];
+}
+
 export function extractGithubFailureGroups(report) {
   const groups = new Map();
   const failures = Array.isArray(report?.failures) ? report.failures : [];
@@ -134,7 +198,7 @@ export function extractGithubFailureGroups(report) {
     }
 
     for (const jobFailure of jobFailures) {
-      const parsedError = firstParsedError(jobFailure);
+      const parsedError = primaryParsedError(jobFailure) || firstParsedError(jobFailure);
       const area = [
         failure?.runName || 'workflow',
         jobFailure?.jobName || 'job',

--- a/scripts/monitoring-error-groups.test.ts
+++ b/scripts/monitoring-error-groups.test.ts
@@ -95,6 +95,45 @@ describe('monitoring error groups', () => {
     expect(groups[0].source).toBe('github-actions');
   });
 
+  it('selects the terminal GitHub CI failure over Vitest stderr noise', () => {
+    const groups = extractGithubFailureGroups({
+      failures: [
+        {
+          runId: 3001,
+          runName: 'Code Review',
+          branch: 'dependabot/npm_and_yarn/development-dependencies-70c9663c6e',
+          commit: 'fe8a218',
+          htmlUrl: 'https://example.test/runs/3001',
+          errors: [
+            {
+              jobName: 'coverage-check',
+              stepName: 'Run pnpm run test:coverage',
+              errors: [
+                {
+                  lineNumber: 40,
+                  line: 'Recording start failed. Error: MediaRecorder init failed',
+                },
+                {
+                  lineNumber: 150,
+                  line: 'FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory',
+                },
+                {
+                  lineNumber: 190,
+                  line: 'Error: [vitest-pool]: Worker forks emitted error.',
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].message).toContain('fatal error: reached heap limit');
+    expect(groups[0].originalMessage).not.toContain('Recording start failed');
+    expect(groups[0].occurrences[0].lineNumber).toBe(150);
+  });
+
   it('creates a GitHub group even when job logs were not parsed', () => {
     const groups = extractGithubFailureGroups({
       failures: [

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -100,6 +100,78 @@ describe('GitHub workflows validation', () => {
     }
   });
 
+  it('runs compressed-size-action with the package-manager build command', () => {
+    const workflowNames = ['bundle-size.yml', 'code-review.yml'];
+
+    for (const workflowName of workflowNames) {
+      const workflowPath = path.join(workflowDir, workflowName);
+      const parsed = parse(readFileSync(workflowPath, 'utf8')) as {
+        jobs?: Record<
+          string,
+          {
+            steps?: Array<{
+              run?: string;
+              uses?: string;
+              with?: Record<string, unknown>;
+            }>;
+          }
+        >;
+      } | null;
+
+      for (const [jobName, job] of Object.entries(parsed?.jobs ?? {})) {
+        const steps = job.steps ?? [];
+        const compressedSizeStep = steps.find((step) =>
+          step.uses?.startsWith('preactjs/compressed-size-action@')
+        );
+
+        if (!compressedSizeStep) {
+          continue;
+        }
+
+        expect(
+          compressedSizeStep.with?.['build-script'],
+          `${workflowName} ${jobName} build-script`
+        ).toBe('pnpm run build');
+        expect(
+          steps.some((step) => step.run === 'pnpm run build'),
+          `${workflowName} ${jobName} duplicate standalone build`
+        ).toBe(false);
+      }
+    }
+  });
+
+  it('gives code review coverage check extra heap for the large coverage suite', () => {
+    const workflowPath = path.join(workflowDir, 'code-review.yml');
+    const parsed = parse(readFileSync(workflowPath, 'utf8')) as {
+      jobs?: {
+        'coverage-check'?: {
+          env?: Record<string, string>;
+          steps?: Array<{
+            run?: string;
+          }>;
+        };
+      };
+    } | null;
+
+    expect(parsed?.jobs?.['coverage-check']?.env?.NODE_OPTIONS).toBe('--max-old-space-size=8192');
+
+    const coverageRun = parsed?.jobs?.['coverage-check']?.steps?.find((step) =>
+      step.run?.includes('vitest run --coverage')
+    )?.run;
+    expect(coverageRun).toContain('--exclude=src/App.test.tsx');
+    expect(coverageRun).toContain('--exclude=src/App.integration.test.tsx');
+    expect(coverageRun).toContain('--exclude=src/hooks/useMeetings.test.tsx');
+    expect(coverageRun).toContain('--maxWorkers=2');
+  });
+
+  it('installs Vercel preview CLI without requiring a pnpm global bin dir', () => {
+    const workflowPath = path.join(workflowDir, 'preview.yml');
+    const content = readFileSync(workflowPath, 'utf8');
+
+    expect(content).toContain('npm install -g vercel@latest');
+    expect(content).not.toContain('pnpm install -g vercel@latest');
+  });
+
   it('gives optimized ci test job extra heap for the large Vitest suite', () => {
     const workflowPath = path.join(workflowDir, 'ci-optimized.yml');
     const parsed = parse(readFileSync(workflowPath, 'utf8')) as {


### PR DESCRIPTION
## Issue

Closes #1320 after CI evidence passes and the Regression Gate is reviewed. Related failing dependency PR: #1304.

## Changes

- Fix bundle-size workflows so `preactjs/compressed-size-action` runs `pnpm run build` instead of trying to execute `build`.
- Stabilize Code Review `coverage-check` with the same heavy-test exclusions used by frontend CI, a bounded worker count, and explicit coverage directory setup.
- Fix preview workflow Vercel CLI install so it does not depend on pnpm global-bin configuration.
- Extract pure GitHub error reporting helpers and filter expected Vitest/test stderr noise out of monitoring reports.
- Prefer terminal CI failure lines when grouping GitHub monitoring errors.
- Add regression coverage for noisy CI logs, bundle-size workflow config, coverage-check config, preview CLI install, and CI grouping.

## Tests run

- `node_modules\\.bin\\vitest.cmd run -c vitest.scripts.config.ts scripts/monitoring-error-groups.test.ts scripts/fetch-github-errors.test.ts scripts/validate-github-workflows.test.ts --coverage.enabled=false` — passed, 36 tests.
- `corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/monitoring-error-groups.test.ts scripts/validate-github-workflows.test.ts --coverage.enabled=false` — passed, 28 tests before the preview/coverage-check assertion update.
- `node scripts\\validate-github-workflows.mjs` — passed.
- `node scripts\\validate-vercel-workflows.mjs` — passed.
- `corepack pnpm exec prettier --check .github/workflows/bundle-size.yml .github/workflows/code-review.yml .github/workflows/preview.yml scripts/fetch-github-errors.js scripts/fetch-github-errors.test.ts scripts/github-error-reporting.mjs scripts/monitoring-error-groups.mjs scripts/monitoring-error-groups.test.ts scripts/validate-github-workflows.test.ts` — passed.
- Pre-push release guard — passed after final push: `test:server:retry` 90 passed / 2 skipped files, 1284 passed / 82 skipped tests; extra targeted Vitest 3 files / 81 tests passed; `audit:build-warnings` passed.

## CI evidence

Fresh PR run on commit `3d8f0ca`:

- Passed: Backend Vitest, Frontend Vitest, Quality Gates, Build, Security Audit, Remote API E2E, Docker image, E2E Playwright, Deploy Preview, Vercel, Visual Baselines, Code Review `coverage-check`, Code Review `bundle-size`, Code Review `eslint-review`, Code Review `security-scan`, and branch `Bundle Size Monitor`.
- Known residual: one `pull_request_target` Bundle Size Monitor check still uses the workflow from current `main` (`0315d0f...`), so it fails with the old `build-script: build` until this workflow fix is merged into `main`. The failure log confirms `Running build script: build` and `Unable to locate executable file: build`.

## Known risks

- Full `corepack pnpm run format:check` still fails on 14 pre-existing `src/` and `server/` files outside this branch. Changed files pass targeted Prettier check.
- PR #1304 still needs its own rerun/rebase; this PR fixes the monitoring/workflow causes, not Dependabot's formatting drift directly.
- The residual red `pull_request_target` Bundle Size check is expected for this PR because `pull_request_target` reads workflow config from `main`; it should go away for future PRs after this merge.

## Follow-up tasks

- Rerun PR #1304 checks after this merges or rebase Dependabot so the updated workflow config is used.
- If #1304 still fails `format:check`, handle those 7 files in the Dependabot branch or a dedicated follow-up PR.