### PR TITLE
fix(cors): harden production origin handling

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,12 @@
 NODE_ENV=development
 VOICELOG_API_PORT=4000
 VOICELOG_API_HOST=0.0.0.0
+# Local development:
 VOICELOG_ALLOWED_ORIGINS=http://localhost:3000
+# Railway production must use exact deployed frontend origins, for example:
+# VOICELOG_ALLOWED_ORIGINS=https://voicelog-audiorecorder.vercel.app
+# Optional main-branch verification preview:
+# VOICELOG_ALLOWED_ORIGINS=https://voicelog-audiorecorder.vercel.app,https://audiorecorder-git-main-iwoczajka-2703s-projects.vercel.app
 VOICELOG_TRUST_PROXY=false
 # Optional ops token for /metrics and /api/admin/* endpoints
 # VOICELOG_ADMIN_TOKEN=change-this-long-random-token

--- a/docs/PRODUCTION_CORS.md
+++ b/docs/PRODUCTION_CORS.md
@@ -11,11 +11,23 @@ VOICELOG_ALLOW_VERCEL_PREVIEWS=false
 
 ## Current VoiceLog Vercel/Railway setup
 
-If the frontend is served from the Vercel preview deployment used by the main
-branch, Railway must include that exact origin:
+The stable production frontend origin is:
 
 ```bash
-VOICELOG_ALLOWED_ORIGINS=https://audiorecorder-git-main-iwoczajka-2703s-projects.vercel.app
+https://voicelog-audiorecorder.vercel.app
+```
+
+Railway production must include that exact origin:
+
+```bash
+VOICELOG_ALLOWED_ORIGINS=https://voicelog-audiorecorder.vercel.app
+```
+
+If the main-branch Vercel preview is used for production verification, include
+it explicitly in the same comma-separated allowlist:
+
+```bash
+VOICELOG_ALLOWED_ORIGINS=https://voicelog-audiorecorder.vercel.app,https://audiorecorder-git-main-iwoczajka-2703s-projects.vercel.app
 ```
 
 For temporary preview testing across Vercel preview URLs, set:
@@ -35,11 +47,14 @@ preflight requests from Vercel because the API will answer with the local origin
 - A disallowed origin receives the first configured fallback origin, but it does not receive `Access-Control-Allow-Credentials: true`.
 - Vercel preview URLs are blocked in production unless `VOICELOG_ALLOW_VERCEL_PREVIEWS=true`.
 - Wildcard Vercel patterns such as `https://*.vercel.app` are honored only when preview access is explicitly enabled.
+- Startup logs include a sanitized `[Config] CORS` summary with origin count,
+  explicit allowed origins, preview mode and wildcard status. It must not include
+  API keys, service-role keys, tokens or secrets.
 
 ## Verification
 
 ```bash
-pnpm exec vitest run -c server/vitest.config.ts server/tests/app-security.test.ts server/tests/serverUtils.test.ts --coverage.enabled=false
+pnpm exec vitest run -c server/vitest.config.ts server/tests/app-security.test.ts server/tests/serverUtils.test.ts server/tests/config.test.ts --coverage.enabled=false
 ```
 
 Minimum cases covered by production verification:
@@ -48,3 +63,6 @@ Minimum cases covered by production verification:
 - Disallowed origin does not receive credentialed wildcard access.
 - `VOICELOG_ALLOWED_ORIGINS=*` is rejected for production credentials use.
 - Vercel previews are rejected unless `VOICELOG_ALLOW_VERCEL_PREVIEWS=true`.
+- `/health`, `/state/bootstrap`, `/integrations/google/status`, `notFound` and
+  `onError` preserve CORS headers for the production origin.
+- Startup CORS logs are sanitized.

--- a/server/config.ts
+++ b/server/config.ts
@@ -158,6 +158,18 @@ function hasProductionBrowserOrigin(value?: string) {
   );
 }
 
+function logCorsStartupConfig(allowedOrigins: string, allowVercelPreviews: boolean) {
+  const origins = splitAllowedOrigins(allowedOrigins);
+  console.log('[Config] CORS', {
+    nodeEnv: config.NODE_ENV,
+    productionDeployment: isProductionDeployment(),
+    allowedOriginCount: origins.length,
+    allowedOrigins: origins,
+    allowVercelPreviews,
+    hasWildcard: origins.includes('*'),
+  });
+}
+
 function isProductionDeployment() {
   return Boolean(
     config.NODE_ENV === 'production' ||
@@ -172,6 +184,8 @@ export function validateRequiredApiKeys() {
 
   const allowedOrigins = config.VOICELOG_ALLOWED_ORIGINS;
   const allowVercelPreviews = config.VOICELOG_ALLOW_VERCEL_PREVIEWS === true;
+  logCorsStartupConfig(allowedOrigins, allowVercelPreviews);
+
   if (isProductionDeployment()) {
     if (splitAllowedOrigins(allowedOrigins).includes('*')) {
       errors.push(
@@ -186,7 +200,7 @@ export function validateRequiredApiKeys() {
         'Production CORS is configured only for local development origins.\n' +
           '  Browser requests from Vercel will be blocked with Access-Control-Allow-Origin=http://localhost:3000.\n' +
           '  Set VOICELOG_ALLOWED_ORIGINS to the deployed frontend origin, for example:\n' +
-          '  VOICELOG_ALLOWED_ORIGINS=https://audiorecorder-git-main-iwoczajka-2703s-projects.vercel.app\n' +
+          '  VOICELOG_ALLOWED_ORIGINS=https://voicelog-audiorecorder.vercel.app\n' +
           '  Or intentionally allow Vercel previews with VOICELOG_ALLOW_VERCEL_PREVIEWS=true.'
       );
     }

--- a/server/http/app-security.ts
+++ b/server/http/app-security.ts
@@ -12,6 +12,24 @@ function shouldAllowCredentials(requestOrigin: string, responseOrigin: string) {
   return Boolean(requestOrigin && responseOrigin && requestOrigin === responseOrigin);
 }
 
+function buildCredentialHeaders(requestOrigin: string, responseOrigin: string) {
+  return shouldAllowCredentials(requestOrigin, responseOrigin)
+    ? { 'Access-Control-Allow-Credentials': 'true' }
+    : {};
+}
+
+function applyCorsHeadersToContext(c: any, requestOrigin: string, allowedOrigins: string) {
+  const cors = buildCorsHeaders(requestOrigin, allowedOrigins);
+  c.header('Access-Control-Allow-Origin', cors['Access-Control-Allow-Origin']);
+  c.header('Access-Control-Allow-Headers', cors['Access-Control-Allow-Headers']);
+  c.header('Access-Control-Allow-Methods', cors['Access-Control-Allow-Methods']);
+  c.header('Vary', cors['Vary']);
+
+  if (shouldAllowCredentials(requestOrigin, cors['Access-Control-Allow-Origin'])) {
+    c.header('Access-Control-Allow-Credentials', 'true');
+  }
+}
+
 const SERVER_INFRASTRUCTURE_ERROR_PATTERNS = [
   'enotfound',
   'econnrefused',
@@ -52,10 +70,6 @@ export function applyAppCors(app: Hono<any>, _allowedOrigins: string) {
   app.use('*', async (c, next) => {
     const requestOrigin = c.req.header('origin') || '';
     const cors = buildCorsHeaders(requestOrigin, _allowedOrigins);
-    const allowCredentials = shouldAllowCredentials(
-      requestOrigin,
-      cors['Access-Control-Allow-Origin']
-    );
 
     if (c.req.method === 'OPTIONS') {
       return new Response(null, {
@@ -64,7 +78,7 @@ export function applyAppCors(app: Hono<any>, _allowedOrigins: string) {
           'Access-Control-Allow-Origin': cors['Access-Control-Allow-Origin'],
           'Access-Control-Allow-Headers': cors['Access-Control-Allow-Headers'],
           'Access-Control-Allow-Methods': cors['Access-Control-Allow-Methods'],
-          ...(allowCredentials ? { 'Access-Control-Allow-Credentials': 'true' } : {}),
+          ...buildCredentialHeaders(requestOrigin, cors['Access-Control-Allow-Origin']),
           'Access-Control-Max-Age': '86400',
           Vary: cors['Vary'],
         },
@@ -73,13 +87,7 @@ export function applyAppCors(app: Hono<any>, _allowedOrigins: string) {
 
     await next();
 
-    c.header('Access-Control-Allow-Origin', cors['Access-Control-Allow-Origin']);
-    c.header('Access-Control-Allow-Headers', cors['Access-Control-Allow-Headers']);
-    c.header('Access-Control-Allow-Methods', cors['Access-Control-Allow-Methods']);
-    if (allowCredentials) {
-      c.header('Access-Control-Allow-Credentials', 'true');
-    }
-    c.header('Vary', cors['Vary']);
+    applyCorsHeadersToContext(c, requestOrigin, _allowedOrigins);
   });
 }
 
@@ -184,12 +192,7 @@ export function registerNotFoundHandler(app: Hono<any>, allowedOrigins = 'http:/
   app.notFound((c) => {
     const requestOrigin = c.req.header('origin');
     if (requestOrigin) {
-      const cors = buildCorsHeaders(requestOrigin, allowedOrigins);
-      c.header('Access-Control-Allow-Origin', cors['Access-Control-Allow-Origin']);
-      if (shouldAllowCredentials(requestOrigin, cors['Access-Control-Allow-Origin'])) {
-        c.header('Access-Control-Allow-Credentials', 'true');
-      }
-      c.header('Vary', cors['Vary']);
+      applyCorsHeadersToContext(c, requestOrigin, allowedOrigins);
     }
     return c.json({ message: 'Not found.' }, 404);
   });
@@ -204,12 +207,7 @@ export function registerAppErrorHandler(app: Hono<any>, allowedOrigins = 'http:/
     // post-next() header injection, so we set them explicitly here.
     const requestOrigin = c.req.header('origin');
     if (requestOrigin) {
-      const cors = buildCorsHeaders(requestOrigin, allowedOrigins);
-      c.header('Access-Control-Allow-Origin', cors['Access-Control-Allow-Origin']);
-      if (shouldAllowCredentials(requestOrigin, cors['Access-Control-Allow-Origin'])) {
-        c.header('Access-Control-Allow-Credentials', 'true');
-      }
-      c.header('Vary', cors['Vary']);
+      applyCorsHeadersToContext(c, requestOrigin, allowedOrigins);
     }
 
     if (err.name === 'ContextError' || err instanceof z.ZodError || err?.statusCode === 422) {

--- a/server/tests/app-security.test.ts
+++ b/server/tests/app-security.test.ts
@@ -18,6 +18,7 @@ function createServices(allowedOrigins: string) {
 describe('app security CORS contract', () => {
   const originalNodeEnv = process.env.NODE_ENV;
   const originalAllowVercelPreviews = process.env.VOICELOG_ALLOW_VERCEL_PREVIEWS;
+  const productionOrigin = 'https://voicelog-audiorecorder.vercel.app';
 
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
@@ -71,5 +72,82 @@ describe('app security CORS contract', () => {
     expect(res.status).toBe(204);
     expect(res.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example.test');
     expect(res.headers.get('Access-Control-Allow-Credentials')).toBeNull();
+  });
+
+  function expectCredentialedCors(res: Response, origin = productionOrigin) {
+    expect(res.headers.get('Access-Control-Allow-Origin')).toBe(origin);
+    expect(res.headers.get('Access-Control-Allow-Credentials')).toBe('true');
+    expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Authorization');
+    expect(res.headers.get('Access-Control-Allow-Headers')).toContain('Content-Type');
+    expect(res.headers.get('Access-Control-Allow-Headers')).toContain('X-Workspace-Id');
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('GET');
+    expect(res.headers.get('Access-Control-Allow-Methods')).toContain('OPTIONS');
+    expect(res.headers.get('Vary')).toContain('Origin');
+  }
+
+  // ----------------------------------------------------------------
+  // Issue #1305 - Production CORS missing on startup and error paths
+  // Date: 2026-06-30
+  // Bug: production Vercel origins could receive partial or missing CORS
+  //      headers on notFound/onError responses, hiding real 4xx/5xx errors
+  //      behind browser-level CORS failures.
+  // Fix: every success, preflight, auth failure, notFound and onError response
+  //      carries the same explicit CORS contract for allowlisted origins.
+  // ----------------------------------------------------------------
+  describe('Regression: Issue #1305 - production CORS startup paths', () => {
+    function createProductionApp() {
+      process.env.NODE_ENV = 'production';
+      delete process.env.VOICELOG_ALLOW_VERCEL_PREVIEWS;
+      return createApp(
+        createServices(`${productionOrigin},https://audiorecorder-git-main.example.vercel.app`)
+      );
+    }
+
+    it('returns full CORS headers for startup success, preflight, auth failure, notFound and onError paths', async () => {
+      const app = createProductionApp();
+      app.get('/boom', () => {
+        throw new Error('boom');
+      });
+
+      const health = await app.request('/health', {
+        method: 'GET',
+        headers: { Origin: productionOrigin },
+      });
+      expectCredentialedCors(health);
+
+      for (const path of ['/health', '/state/bootstrap', '/integrations/google/status']) {
+        const res = await app.request(path, {
+          method: 'OPTIONS',
+          headers: {
+            Origin: productionOrigin,
+            'Access-Control-Request-Method': 'GET',
+            'Access-Control-Request-Headers': 'Authorization,Content-Type,X-Workspace-Id',
+          },
+        });
+        expect(res.status).toBe(204);
+        expectCredentialedCors(res);
+      }
+
+      const unauthorized = await app.request('/state/bootstrap?workspaceId=w123', {
+        method: 'GET',
+        headers: { Origin: productionOrigin },
+      });
+      expect(unauthorized.status).toBe(401);
+      expectCredentialedCors(unauthorized);
+
+      const missing = await app.request('/missing-production-route', {
+        method: 'GET',
+        headers: { Origin: productionOrigin },
+      });
+      expect(missing.status).toBe(404);
+      expectCredentialedCors(missing);
+
+      const error = await app.request('/boom', {
+        method: 'GET',
+        headers: { Origin: productionOrigin },
+      });
+      expect(error.status).toBe(500);
+      expectCredentialedCors(error);
+    });
   });
 });

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -87,6 +87,40 @@ describe('config.ts — validateRequiredApiKeys', () => {
     }
   });
 
+  test('logs sanitized CORS startup configuration without secrets', async () => {
+    const previousEnv = { ...process.env };
+
+    try {
+      process.env.OPENAI_API_KEY = 'sk-secret-openai';
+      process.env.SUPABASE_URL = 'https://test.supabase.co';
+      process.env.SUPABASE_SERVICE_ROLE_KEY = 'sb_secret_service_role';
+      process.env.NODE_ENV = 'production';
+      process.env.RAILWAY_PROJECT_ID = 'railway-project-test';
+      process.env.VOICELOG_ALLOWED_ORIGINS =
+        'https://voicelog-audiorecorder.vercel.app,https://audiorecorder-git-main-iwoczajka-2703s-projects.vercel.app';
+      process.env.VOICELOG_ALLOW_VERCEL_PREVIEWS = 'false';
+
+      const { validateRequiredApiKeys } = await import('../config.js');
+      validateRequiredApiKeys();
+
+      expect(logSpy).toHaveBeenCalledWith(
+        '[Config] CORS',
+        expect.objectContaining({
+          allowedOriginCount: 2,
+          allowVercelPreviews: false,
+          nodeEnv: 'production',
+          productionDeployment: true,
+        })
+      );
+      const serializedLogs = logSpy.mock.calls.map((args) => JSON.stringify(args)).join('\n');
+      expect(serializedLogs).toContain('https://voicelog-audiorecorder.vercel.app');
+      expect(serializedLogs).not.toContain('sk-secret-openai');
+      expect(serializedLogs).not.toContain('sb_secret_service_role');
+    } finally {
+      process.env = previousEnv;
+    }
+  });
+
   test('blocks Railway production when SUPABASE_URL is a Postgres URL instead of project API URL', async () => {
     const previousEnv = { ...process.env };
 


### PR DESCRIPTION
## Issue

Closes #1305.

## Changes

- Apply one shared CORS header writer to normal responses, preflights, `notFound`, and `onError` paths.
- Add regression coverage for production Vercel origin CORS on `/health`, `/state/bootstrap`, `/integrations/google/status`, auth failures, missing routes, and thrown errors.
- Add sanitized startup CORS configuration logging without secrets.
- Update production CORS documentation and `.env.example` with the stable Vercel frontend origin.

## Deployment/env changes

Railway production should set an exact frontend allowlist, for example:

```bash
VOICELOG_ALLOWED_ORIGINS=https://voicelog-audiorecorder.vercel.app
VOICELOG_ALLOW_VERCEL_PREVIEWS=false
```

If the main-branch Vercel preview is intentionally used for production verification, include it explicitly:

```bash
VOICELOG_ALLOWED_ORIGINS=https://voicelog-audiorecorder.vercel.app,https://audiorecorder-git-main-iwoczajka-2703s-projects.vercel.app
```

Do not use `VOICELOG_ALLOWED_ORIGINS=*` in production.

## Tests run

- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\config.test.ts --coverage.enabled=false` ? RED before fix for missing sanitized CORS startup log.
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\app-security.test.ts server\\tests\\serverUtils.test.ts server\\tests\\config.test.ts --coverage.enabled=false` ? passed, 23 tests.
- `node_modules\\.bin\\prettier.cmd --check server/http/app-security.ts server/config.ts server/tests/app-security.test.ts server/tests/config.test.ts docs/PRODUCTION_CORS.md .env.example` ? passed.
- `node_modules\\.bin\\tsc.cmd --noEmit` ? passed.
- `node scripts\\audit-mojibake.mjs` ? passed.
- `corepack pnpm run test:server:retry` ? passed outside sandbox after sandbox blocked audio temp-file writes; 90 passed / 2 skipped files, 1286 passed / 82 skipped tests.
- Pre-push release guard ? passed: server retry suite, extra targeted Vitest suite, and build warning audit.
- Local runtime smoke ? backend started on `127.0.0.1:4025` and `GET /health` returned `200`.

## CI evidence

Passed on PR #1322 so far:

- Backend Vitest
- Quality Gates
- Security Audit
- E2E Playwright Tests
- eslint-review
- security-scan
- Vercel deployment status

Known CI blockers unrelated to this CORS patch and fixed by PR #1321 once merged:

- Deploy Preview still runs `pnpm install -g vercel@latest` and fails with `ERR_PNPM_NO_GLOBAL_BIN_DIR`.
- Code Review bundle-size still lacks `build-script` and fails with `Input required and not supplied: build-script`.
- Bundle Size Monitor has the same stale workflow family until #1321 reaches main.\n- Code Review coverage-check still uses the old full pnpm run test:coverage path and fails with Node/Vitest heap OOM plus itest-pool worker timeouts; #1321 replaces this with the bounded coverage command.

## Known risks

- I did not modify real Railway/Vercel environment variables; deployment still needs the allowlist above applied in Railway.
- One attempted local smoke used an already occupied port after a prior run; the stale smoke process was stopped and generated runtime artifacts were removed.
- #1306 liveness/readiness split and #1307 API URL strategy are intentionally left for separate PRs to keep this CORS fix focused.

## Follow-up tasks

- Merge or otherwise land #1321 first so PR #1322 can rerun with the fixed workflow definitions.
- Run #1306 next: split liveness/readiness and move frontend probe to liveness.
- Run #1307 next after #1306: make the Vercel/Railway API URL strategy explicit in code and docs.
- Add #1308 post-deploy CORS smoke after the endpoint contract is stable.
