### PR TITLE
fix(transcript): preserve verified remote segments

### DIFF
--- a/src/services/mediaService.test.ts
+++ b/src/services/mediaService.test.ts
@@ -56,6 +56,7 @@ vi.mock('../shared/contracts', () => ({
 import {
   buildTranscriptionProgressRequest,
   createMediaService,
+  mapRemoteTranscriptionResult,
   REMOTE_TRANSCRIPTION_PROVIDER,
 } from './mediaService';
 
@@ -88,6 +89,27 @@ describe('mediaService', () => {
     expect(request.url).toBe('http://media-api.local/media/recordings/rec%201/progress');
     expect(request.url).not.toContain('session-token');
     expect(request.headers).toEqual({ Authorization: 'Bearer session-token' });
+  });
+
+  // -----------------------------------------------------------------
+  // Issue #0 - remote transcription result lost verifiedSegments
+  // Date: 2026-06-27
+  // Bug: Hosted preview/backend contract variants could return completed
+  //      transcript segments as verifiedSegments, but the media-service mapper
+  //      only copied response.segments. The queue then attached an empty
+  //      transcript even though processing had completed.
+  // Fix: Preserve verifiedSegments first, then fall back to segments.
+  // -----------------------------------------------------------------
+  it('Regression: #0 - preserves verifiedSegments from remote transcription responses', () => {
+    const segment = { id: 'seg-1', text: 'Widoczna transkrypcja', speakerId: 0, timestamp: 0 };
+
+    const result = mapRemoteTranscriptionResult({
+      pipelineStatus: 'done',
+      verifiedSegments: [segment],
+    });
+
+    expect(result.verifiedSegments).toEqual([segment]);
+    expect(result.pipelineStatus).toBe('done');
   });
 
   describe('local mode', () => {

--- a/src/services/mediaService.ts
+++ b/src/services/mediaService.ts
@@ -136,12 +136,17 @@ async function uploadChunkWithRetry({
   }
 }
 
-function mapRemoteTranscriptionResult(response: MediaTranscriptionResponse = {}) {
+export function mapRemoteTranscriptionResult(response: MediaTranscriptionResponse = {}) {
   const normalized = normalizeMediaTranscriptionResponse(response);
+  const verifiedSegments = Array.isArray(response?.verifiedSegments)
+    ? response.verifiedSegments
+    : Array.isArray(response?.segments)
+      ? response.segments
+      : [];
 
   return {
     diarization: response.diarization || {},
-    verifiedSegments: response.segments || [],
+    verifiedSegments,
     providerId: response.providerId || REMOTE_TRANSCRIPTION_PROVIDER.id,
     providerLabel: response.providerLabel || REMOTE_TRANSCRIPTION_PROVIDER.label,
     pipelineStatus: normalized.pipelineStatus || 'queued',

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -52,6 +52,7 @@ export interface MediaTranscriptionResponse {
   recordingId?: string;
   diarization?: unknown;
   segments?: TranscriptSegment[];
+  verifiedSegments?: TranscriptSegment[];
   providerId?: string;
   providerLabel?: string;
   pipelineStatus?: TranscriptionStatusPayload['pipelineStatus'] | 'completed';


### PR DESCRIPTION
## Issue
Follow-up to the reported case where a recording had a transcript on first open and then showed no transcript after returning to the recording.

## Changes
- Preserve remote \\erifiedSegments\\ when mapping media transcription responses.
- Keep \\segments\\ as a fallback for older backend/preview contract variants.
- Add a regression test for completed remote responses that expose only \\erifiedSegments\\.

## Tests run
- \\
ode_modules\\\\.bin\\\\vitest.cmd run src\\\\services\\\\mediaService.test.ts --coverage.enabled=false\\
- \\
ode_modules\\\\.bin\\\\prettier.cmd --check src/services/mediaService.ts src/services/mediaService.test.ts src/shared/contracts.ts\\
- \\
ode_modules\\\\.bin\\\\tsc.cmd --noEmit\\
- pre-push release guard: \\pnpm run test:server:retry\\, focused frontend guard tests, \\pnpm run audit:build-warnings\\

## Known risks
- This only fixes frontend mapping of existing remote response data; it does not change backend transcription generation.
- If a backend returns neither \\erifiedSegments\\ nor \\segments\\, the transcript remains intentionally empty.

## Follow-up tasks
- Continue issue #1315/#1317 work on durable audio status/retry/data-control flows.
