### PR TITLE
ci(vercel): expose Google Tasks client id

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -51,6 +51,7 @@ jobs:
           [[ -n "${VERCEL_TOKEN}" ]] || missing+=("VERCEL_TOKEN")
           [[ -n "${VERCEL_ORG_ID}" ]] || missing+=("VERCEL_ORG_ID")
           [[ -n "${VERCEL_PROJECT_ID}" ]] || missing+=("VERCEL_PROJECT_ID")
+          [[ -n "${VITE_GOOGLE_CLIENT_ID}" ]] || missing+=("VITE_GOOGLE_CLIENT_ID")
 
           if [ ${#missing[@]} -gt 0 ]; then
             echo "## Missing Vercel secrets" >> "$GITHUB_STEP_SUMMARY"
@@ -67,6 +68,7 @@ jobs:
       - name: Build Project Artifacts
         env:
           VITE_BUILD_ID: ${{ github.event.workflow_run.head_sha || github.sha }}
+          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: vercel build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy Project Artifacts to Vercel Production

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -254,6 +254,14 @@ describe('GitHub workflows validation', () => {
     expect(vercelWorkflow).toContain("workflows: ['Railway Build Metadata']");
   });
 
+  it('passes Google Tasks client id into the production Vercel build', () => {
+    const vercelWorkflow = readFileSync(path.join(workflowDir, 'vercel-production.yml'), 'utf8');
+
+    expect(vercelWorkflow).toContain('VITE_GOOGLE_CLIENT_ID');
+    expect(vercelWorkflow).toContain('missing+=("VITE_GOOGLE_CLIENT_ID")');
+    expect(vercelWorkflow).toContain('VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}');
+  });
+
   it('retries Railway metadata variable writes before failing the release gate', () => {
     const railwayWorkflow = readFileSync(
       path.join(workflowDir, 'railway-build-metadata.yml'),


### PR DESCRIPTION
## Issue
Google Tasks production integration needs the Vite Google OAuth client id in the frontend bundle.

## Changes
- Add VITE_GOOGLE_CLIENT_ID validation to the Vercel production workflow.
- Pass VITE_GOOGLE_CLIENT_ID from GitHub Actions secrets into vercel build.
- Add workflow validation coverage so future deploy changes keep the Google Tasks client id.

## Tests run
- node_modules\\.bin\\vitest.cmd run -c vitest.scripts.config.ts scripts\\validate-github-workflows.test.ts --coverage.enabled=false
- push release guard: test:server:retry, targeted frontend/script tests, audit:build-warnings

## Known risks
- Google Cloud Console still must have Google Tasks API enabled, the tasks scope approved, and the production origin authorized.
- This config applies to the repository production workflow; direct Vercel dashboard deploys must also include equivalent env configuration if used outside GitHub Actions.

## Follow-up tasks
- Dispatch Vercel Production after merge and verify the production bundle contains a Google OAuth client id.