### PR TITLE
ci(vercel): provide Google client id to deploy job

### DIFF
--- a/.github/workflows/vercel-production.yml
+++ b/.github/workflows/vercel-production.yml
@@ -21,6 +21,7 @@ jobs:
       VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
       VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+      VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
       PNPM_HOME: /home/runner/.local/share/pnpm
     # Skip if triggered by a failed CI run (workflow_dispatch always runs)
     if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
@@ -68,7 +69,6 @@ jobs:
       - name: Build Project Artifacts
         env:
           VITE_BUILD_ID: ${{ github.event.workflow_run.head_sha || github.sha }}
-          VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}
         run: vercel build --prod --token="$VERCEL_TOKEN"
 
       - name: Deploy Project Artifacts to Vercel Production

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -260,6 +260,7 @@ describe('GitHub workflows validation', () => {
     expect(vercelWorkflow).toContain('VITE_GOOGLE_CLIENT_ID');
     expect(vercelWorkflow).toContain('missing+=("VITE_GOOGLE_CLIENT_ID")');
     expect(vercelWorkflow).toContain('VITE_GOOGLE_CLIENT_ID: ${{ secrets.VITE_GOOGLE_CLIENT_ID }}');
+    expect(vercelWorkflow).toContain('VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}');
   });
 
   it('retries Railway metadata variable writes before failing the release gate', () => {


### PR DESCRIPTION
## Issue
The production Vercel workflow validates VITE_GOOGLE_CLIENT_ID but the secret was not exposed at job scope, so manual production deploy stopped before build.

## Changes
- Expose VITE_GOOGLE_CLIENT_ID at the Vercel production job env level.
- Keep the build using the job-level environment.
- Keep workflow validation coverage for the Google Tasks client id.

## Tests run
- node_modules\\.bin\\vitest.cmd run -c vitest.scripts.config.ts scripts\\validate-github-workflows.test.ts --coverage.enabled=false
- push release guard: test:server:retry, targeted frontend/script tests, audit:build-warnings

## Known risks
- Google Cloud Console must still allow the production origin and Google Tasks scope.

## Follow-up tasks
- Rerun Production Deployment (Vercel) from main and verify the production bundle includes a Google OAuth client id.