### PR TITLE
fix(vercel): allow Google Identity Services CSP

### DIFF
--- a/src/config/vercel-permissions.test.ts
+++ b/src/config/vercel-permissions.test.ts
@@ -49,4 +49,12 @@ describe('Regression: #0 — Permissions-Policy must allow microphone and camera
     const csp = getContentSecurityPolicy();
     expect(csp).toContain("media-src 'self' blob:");
   });
+
+  test('CSP allows Google Identity Services for Google Tasks OAuth', () => {
+    const csp = getContentSecurityPolicy();
+
+    expect(csp).toContain('script-src');
+    expect(csp).toContain('frame-src');
+    expect(csp).toContain('https://accounts.google.com');
+  });
 });

--- a/vercel.json
+++ b/vercel.json
@@ -71,7 +71,7 @@
         },
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' blob: https://vercel.live https://www.clarity.ms; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' blob: wss: https: https://api.openai.com https://api.anthropic.com https://api.google.com https://generativelanguage.googleapis.com https://api.groq.com https://api.together.xyz https://*.up.railway.app https://*.railway.app https://vercel.live https://*.datadoghq.eu https://*.datadoghq.com https://browser-intake-datadoghq.eu; frame-src 'self' https://vercel.live; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
+          "value": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval' 'wasm-unsafe-eval' blob: https://accounts.google.com https://vercel.live https://www.clarity.ms; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: blob:; media-src 'self' blob:; connect-src 'self' blob: wss: https: https://api.openai.com https://api.anthropic.com https://api.google.com https://generativelanguage.googleapis.com https://api.groq.com https://api.together.xyz https://*.up.railway.app https://*.railway.app https://vercel.live https://*.datadoghq.eu https://*.datadoghq.com https://browser-intake-datadoghq.eu; frame-src 'self' https://accounts.google.com https://vercel.live; worker-src 'self' blob:; object-src 'none'; base-uri 'self'; form-action 'self';"
         }
       ]
     },


### PR DESCRIPTION
## Issue
Google Tasks production connect is blocked by Content Security Policy before OAuth can start. Browser error: loading https://accounts.google.com/gsi/client violates script-src.

## Changes
- Allow https://accounts.google.com in Vercel script-src.
- Allow https://accounts.google.com in frame-src for Google Identity Services OAuth flow.
- Add regression coverage for the CSP requirement.

## Tests run
- node_modules\\.bin\\vitest.cmd run src\\config\\vercel-permissions.test.ts --coverage.enabled=false

## Known risks
- Google Cloud Console must still have Google Tasks API enabled, the tasks scope approved, and the production origin authorized.

## Follow-up tasks
- Deploy Vercel production after merge and verify the CSP header allows accounts.google.com.