### PR TITLE
fix(google): surface Tasks API denial reason

### DIFF
--- a/src/hooks/useGoogleIntegrations.test.ts
+++ b/src/hooks/useGoogleIntegrations.test.ts
@@ -192,6 +192,26 @@ describe('useGoogleIntegrations', () => {
     expect(typeof result.current.googleEnabled).toBe('boolean');
   });
 
+  test('shows Google Tasks API setup guidance when task list loading is forbidden', async () => {
+    const forbidden = Object.assign(
+      new Error(
+        'Google Tasks API returned 403 while loading task lists. Reason: accessNotConfigured.'
+      ),
+      { status: 403, reason: 'accessNotConfigured' }
+    );
+    fetchGoogleTaskListsMock.mockRejectedValueOnce(forbidden);
+
+    const { result } = renderHook(() => useGoogleIntegrations(baseProps as any));
+
+    await act(async () => {
+      await result.current.connectGoogleTasks();
+    });
+
+    expect(result.current.googleTasksStatus).toBe('error');
+    expect(result.current.googleTasksMessage).toContain('Google Tasks API');
+    expect(result.current.googleTasksMessage).toContain('accessNotConfigured');
+  });
+
   test('keeps passive calendar status idle when local session token is not restored', async () => {
     const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
     const missingSessionError = new Error(

--- a/src/hooks/useGoogleIntegrations.ts
+++ b/src/hooks/useGoogleIntegrations.ts
@@ -32,6 +32,31 @@ function isAfter(reference: string, baseline: string) {
 const GOOGLE_BACKEND_SESSION_MESSAGE =
   'Sesja lokalna nie ma tokenu backendu. Zaloguj sie ponownie, aby polaczyc Google Calendar.';
 
+function getGoogleTasksConnectionErrorMessage(error: unknown) {
+  const reason =
+    error && typeof error === 'object' && 'reason' in error
+      ? String((error as { reason?: unknown }).reason || '')
+      : '';
+  const status =
+    error && typeof error === 'object' && 'status' in error
+      ? Number((error as { status?: unknown }).status || 0)
+      : 0;
+
+  if (status === 403 || reason) {
+    if (reason === 'accessNotConfigured' || reason === 'serviceDisabled') {
+      return `Google Tasks API jest wylaczone w Google Cloud albo wlaczone w innym projekcie. Powod Google: ${reason}.`;
+    }
+    if (reason === 'insufficientPermissions' || reason === 'forbidden') {
+      return `Token Google nie ma zakresu https://www.googleapis.com/auth/tasks albo zgoda jest stara. Powod Google: ${reason}.`;
+    }
+    return `Google Tasks API zwrocilo 403. Sprawdz Google Tasks API, scope https://www.googleapis.com/auth/tasks i test usera. Powod Google: ${
+      reason || 'brak reason w odpowiedzi'
+    }.`;
+  }
+
+  return 'Nie udalo sie polaczyc z Google Tasks.';
+}
+
 export default function useGoogleIntegrations({
   currentUser,
   currentWorkspaceId,
@@ -404,7 +429,7 @@ export default function useGoogleIntegrations({
     } catch (error) {
       console.error('Google Tasks connect failed.', error);
       setGoogleTasksStatus('error');
-      setGoogleTasksMessage('Nie udalo sie polaczyc z Google Tasks.');
+      setGoogleTasksMessage(getGoogleTasksConnectionErrorMessage(error));
     }
   }
 

--- a/src/lib/google.ts
+++ b/src/lib/google.ts
@@ -325,6 +325,62 @@ export async function updateGoogleCalendarEvent(accessToken, eventId, updates) {
   );
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object');
+}
+
+async function readGoogleApiErrorPayload(response: Response): Promise<unknown> {
+  try {
+    const text = await response.text();
+    return text ? JSON.parse(text) : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function getNestedRecord(source: unknown, key: string): Record<string, unknown> | undefined {
+  if (!isRecord(source)) return undefined;
+  const value = source[key];
+  return isRecord(value) ? value : undefined;
+}
+
+function getGoogleApiReason(payload: unknown): string {
+  const error = getNestedRecord(payload, 'error');
+  const errors = Array.isArray(error?.errors) ? error.errors : [];
+  const firstError = errors.find(isRecord);
+  const reason = firstError?.reason || error?.status;
+  return typeof reason === 'string' ? reason : '';
+}
+
+function getGoogleApiMessage(payload: unknown): string {
+  const error = getNestedRecord(payload, 'error');
+  const message = error?.message;
+  return typeof message === 'string' ? message : '';
+}
+
+async function createGoogleApiError(response: Response, service: string, action: string) {
+  const payload = await readGoogleApiErrorPayload(response);
+  const reason = getGoogleApiReason(payload);
+  const apiMessage = getGoogleApiMessage(payload);
+  const details = [
+    reason ? `Reason: ${reason}` : '',
+    apiMessage && apiMessage !== reason ? `Message: ${apiMessage}` : '',
+  ].filter(Boolean);
+
+  return Object.assign(
+    new Error(
+      `${service} API returned ${response.status} while ${action}.${
+        details.length ? ` ${details.join(' ')}` : ''
+      }`
+    ),
+    {
+      status: response.status,
+      reason,
+      details: payload,
+    }
+  );
+}
+
 export async function fetchGoogleTaskLists(accessToken: string) {
   const response = await fetch(
     'https://tasks.googleapis.com/tasks/v1/users/@me/lists?maxResults=100',
@@ -336,7 +392,7 @@ export async function fetchGoogleTaskLists(accessToken: string) {
   );
 
   if (!response.ok) {
-    throw new Error(`Google Tasks API returned ${response.status} while loading task lists.`);
+    throw await createGoogleApiError(response, 'Google Tasks', 'loading task lists');
   }
 
   return response.json();
@@ -358,7 +414,7 @@ export async function fetchGoogleTasks(accessToken: string, taskListId: string) 
   );
 
   if (!response.ok) {
-    throw new Error(`Google Tasks API returned ${response.status} while loading tasks.`);
+    throw await createGoogleApiError(response, 'Google Tasks', 'loading tasks');
   }
 
   return response.json();
@@ -375,7 +431,7 @@ export async function createGoogleTask(accessToken: string, taskListId: string, 
   });
 
   if (!response.ok) {
-    throw new Error(`Google Tasks API returned ${response.status} while creating a task.`);
+    throw await createGoogleApiError(response, 'Google Tasks', 'creating a task');
   }
 
   return response.json();
@@ -400,7 +456,7 @@ export async function updateGoogleTask(
   );
 
   if (!response.ok) {
-    throw new Error(`Google Tasks API returned ${response.status} while updating a task.`);
+    throw await createGoogleApiError(response, 'Google Tasks', 'updating a task');
   }
 
   return response.json();

--- a/src/lib/googleTasksApiError.test.ts
+++ b/src/lib/googleTasksApiError.test.ts
@@ -1,0 +1,49 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+import { fetchGoogleTaskLists } from './google';
+
+describe('Google Tasks API errors', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  test('includes Google API reason when task lists request is forbidden', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            error: {
+              code: 403,
+              message: 'Google Tasks API has not been used in project.',
+              errors: [
+                {
+                  domain: 'usageLimits',
+                  reason: 'accessNotConfigured',
+                  message: 'Google Tasks API has not been used in project.',
+                },
+              ],
+              status: 'PERMISSION_DENIED',
+            },
+          }),
+          {
+            status: 403,
+            headers: { 'Content-Type': 'application/json' },
+          }
+        )
+      )
+    );
+
+    const error = await fetchGoogleTaskLists('token').catch((caught: unknown) => caught);
+
+    expect(error).toMatchObject({
+      status: 403,
+      reason: 'accessNotConfigured',
+    });
+    expect(error).toBeInstanceOf(Error);
+    expect((error as Error).message).toMatch(/accessNotConfigured/);
+  });
+});


### PR DESCRIPTION
## Issue
Google Tasks connect still returns 403, but the frontend hides the Google API error reason. Without the reason field we cannot tell whether the issue is accessNotConfigured, insufficientPermissions, forbidden, or another Google Cloud setup problem.

## Changes
- Parse Google API error JSON for Tasks requests.
- Attach status, reason, and sanitized details to thrown errors.
- Show Google Tasks setup guidance in the integration card when Google returns 403.
- Add regression tests for the API reason and hook message.

## Tests run
- node_modules\\.bin\\vitest.cmd run src\\lib\\googleTasksApiError.test.ts src\\hooks\\useGoogleIntegrations.test.ts --coverage.enabled=false
- pre-push backend release guard section: passed via hook before local worker timeout
- node_modules\\.bin\\vitest.cmd run src\\services\\httpClient.test.ts src\\hooks\\useWorkspaceData.test.tsx src\\store\\recorderStore.test.ts scripts\\validate-husky-hooks.test.ts scripts\\validate-node-runtime.test.ts --coverage.enabled=false --maxWorkers=1
- npx -y -p node@22 -p pnpm@9 pnpm run audit:build-warnings

## Known risks
- This improves diagnosis and UX; it does not bypass Google Cloud's 403.
- Final fix may still require changing Google Cloud API/scope/test-user configuration based on the surfaced reason.

## Follow-up tasks
- Deploy after merge and retry Google Tasks connect; use the surfaced reason to finish Google Cloud configuration.