### PR TITLE
fix(profiles): reject empty voice embeddings

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -9,6 +9,7 @@ import { logger } from './logger.ts';
 import { config } from './config.ts';
 import { resolveBuildMetadata } from './runtime.ts';
 import { isCreatedAtExpiredByRetention } from './lib/retentionPolicy.ts';
+import { requireVoiceProfileEmbedding } from './lib/voiceProfileEmbedding.ts';
 import type { SessionPayload, WorkspaceStatePayload } from '../src/shared/contracts.ts';
 import {
   STORAGE_CONTENT_TYPE,
@@ -3309,16 +3310,18 @@ export class Database {
   }
 
   async saveVoiceProfile({ id, userId, workspaceId, speakerName, audioPath, embedding }: any) {
+    const validEmbedding = requireVoiceProfileEmbedding(embedding);
     const timestamp = this.nowIso();
     await this._execute(
       'INSERT INTO voice_profiles (id, user_id, workspace_id, speaker_name, audio_path, embedding_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
-      [id, userId, workspaceId, speakerName, audioPath, JSON.stringify(embedding || []), timestamp]
+      [id, userId, workspaceId, speakerName, audioPath, JSON.stringify(validEmbedding), timestamp]
     );
     return this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
   }
 
   async upsertVoiceProfile({ id, userId, workspaceId, speakerName, audioPath, embedding }: any) {
     const MAX_SAMPLES = 5;
+    const validEmbedding = requireVoiceProfileEmbedding(embedding);
     const existing = await this._get(
       'SELECT * FROM voice_profiles WHERE workspace_id = ? AND LOWER(speaker_name) = LOWER(?)',
       [workspaceId, speakerName.trim()]
@@ -3336,9 +3339,7 @@ export class Database {
             error.message
           );
         }
-        const averaged = embedding?.length
-          ? addToAverageEmbedding(existingEmb, existingCount, embedding)
-          : existingEmb;
+        const averaged = addToAverageEmbedding(existingEmb, existingCount, validEmbedding);
         await this._execute(
           'UPDATE voice_profiles SET embedding_json = ?, sample_count = ?, audio_path = ? WHERE id = ?',
           [JSON.stringify(averaged), existingCount + 1, audioPath, existing.id]
@@ -3358,7 +3359,7 @@ export class Database {
         workspaceId,
         speakerName.trim(),
         audioPath,
-        JSON.stringify(embedding || []),
+        JSON.stringify(validEmbedding),
         timestamp,
       ]
     );

--- a/server/lib/voiceProfileEmbedding.ts
+++ b/server/lib/voiceProfileEmbedding.ts
@@ -9,7 +9,7 @@ export function normalizeVoiceProfileEmbedding(value: unknown): number[] {
   const values = Array.isArray(value)
     ? value
     : ArrayBuffer.isView(value)
-      ? Array.from(value as ArrayLike<number>)
+      ? Array.from(value as unknown as ArrayLike<number>)
       : [];
 
   return values.filter((item): item is number => typeof item === 'number' && Number.isFinite(item));

--- a/server/lib/voiceProfileEmbedding.ts
+++ b/server/lib/voiceProfileEmbedding.ts
@@ -1,0 +1,37 @@
+export type VoiceProfileEmbeddingFailure = Error & {
+  code: 'embedding_failed';
+  stage: 'embedding';
+  statusCode: 503;
+  cause?: unknown;
+};
+
+export function normalizeVoiceProfileEmbedding(value: unknown): number[] {
+  const values = Array.isArray(value)
+    ? value
+    : ArrayBuffer.isView(value)
+      ? Array.from(value as ArrayLike<number>)
+      : [];
+
+  return values.filter((item): item is number => typeof item === 'number' && Number.isFinite(item));
+}
+
+export function createVoiceProfileEmbeddingFailure(cause?: unknown): VoiceProfileEmbeddingFailure {
+  const error = new Error(
+    'Nie udalo sie utworzyc profilu glosu. Sprobuj ponownie za chwile.'
+  ) as VoiceProfileEmbeddingFailure;
+  error.code = 'embedding_failed';
+  error.stage = 'embedding';
+  error.statusCode = 503;
+  if (cause !== undefined) error.cause = cause;
+  return error;
+}
+
+export function requireVoiceProfileEmbedding(value: unknown): number[] {
+  const embedding = normalizeVoiceProfileEmbedding(value);
+  if (!embedding.length) {
+    throw createVoiceProfileEmbeddingFailure(
+      new Error('Embedding provider returned empty vector.')
+    );
+  }
+  return embedding;
+}

--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -6,6 +6,10 @@ import { AppServices, AppMiddlewares } from './middleware.ts';
 import { applyWorkspaceStateDelta, normalizeWorkspaceState } from '../../src/shared/contracts.ts';
 import type { VoiceProfileSummary, VoiceProfilesListPayload } from '../../src/shared/types.ts';
 import { buildFallbackRagAnswer, generateRagAnswer } from '../lib/ragAnswer.ts';
+import {
+  createVoiceProfileEmbeddingFailure,
+  requireVoiceProfileEmbedding,
+} from '../lib/voiceProfileEmbedding.ts';
 
 const workspaceStatePatchLocks = new Map<string, Promise<void>>();
 const DEFAULT_WORKSPACE_STATE_PATCH_LOCK_TIMEOUT_MS = 30_000;
@@ -331,7 +335,28 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
     const audioPath = path.join(config.uploadDir, `${profileId}${ext}`);
     fs.writeFileSync(audioPath, buffer);
 
-    const embedding = await transcriptionService.computeEmbedding(audioPath);
+    let embedding: number[];
+    try {
+      embedding = requireVoiceProfileEmbedding(
+        await transcriptionService.computeEmbedding(audioPath)
+      );
+    } catch (error) {
+      try {
+        fs.unlinkSync(audioPath);
+      } catch (_) {}
+      const failure =
+        (error as any)?.code === 'embedding_failed'
+          ? (error as ReturnType<typeof createVoiceProfileEmbeddingFailure>)
+          : createVoiceProfileEmbeddingFailure(error);
+      return c.json(
+        {
+          code: failure.code,
+          stage: failure.stage,
+          message: failure.message,
+        },
+        failure.statusCode
+      );
+    }
 
     const profile = await workspaceService.upsertVoiceProfile({
       id: profileId,
@@ -339,7 +364,7 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
       workspaceId: session.workspace_id,
       speakerName: speakerName.trim(),
       audioPath,
-      embedding: embedding || [],
+      embedding,
     });
 
     const sampleCount = profile.sample_count || 1;
@@ -348,7 +373,7 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
       {
         id: profile.id,
         speakerName: profile.speaker_name,
-        hasEmbedding: (embedding || []).length > 0,
+        hasEmbedding: embedding.length > 0,
         createdAt: profile.created_at,
         sampleCount,
         threshold: typeof profile.threshold === 'number' ? profile.threshold : 0.82,

--- a/server/services/TranscriptionService.ts
+++ b/server/services/TranscriptionService.ts
@@ -5,6 +5,7 @@ import {
   normalizePartTranscriptionCheckpoint,
   parseMediaManifest,
 } from '../lib/mediaStoragePolicy.ts';
+import { requireVoiceProfileEmbedding } from '../lib/voiceProfileEmbedding.ts';
 
 type VoiceProfileEnrollmentCode =
   | 'speaker_segment_not_found'
@@ -1044,9 +1045,9 @@ export default class TranscriptionService extends EventEmitter {
     }
 
     try {
-      let embedding: any[] = [];
+      let embedding: number[] = [];
       try {
-        embedding = await this.computeEmbedding(clipPath);
+        embedding = requireVoiceProfileEmbedding(await this.computeEmbedding(clipPath));
       } catch (error) {
         throw voiceProfileError(
           'embedding_failed',
@@ -1068,7 +1069,7 @@ export default class TranscriptionService extends EventEmitter {
           workspaceId: asset.workspace_id,
           speakerName,
           audioPath: newPath,
-          embedding: embedding || [],
+          embedding,
         });
       } catch (error) {
         throw voiceProfileError(

--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -1136,6 +1136,27 @@ describe('Database - Additional Coverage Tests', () => {
       expect(result.sample_count).toBe(1);
     });
 
+    test('saveVoiceProfile rejects empty embedding without inserting a profile', async () => {
+      await expect(
+        db.saveVoiceProfile({
+          id: 'vp_empty_save',
+          userId: 'u1',
+          workspaceId: 'ws1',
+          speakerName: 'Empty Save',
+          audioPath: '/tmp/empty-save.wav',
+          embedding: [],
+        })
+      ).rejects.toMatchObject({
+        code: 'embedding_failed',
+        stage: 'embedding',
+        statusCode: 503,
+      });
+
+      await expect(
+        db._get('SELECT * FROM voice_profiles WHERE id = ?', ['vp_empty_save'])
+      ).resolves.toBeNull();
+    });
+
     test('upsertVoiceProfile creates new profile when not exists', async () => {
       const profile = {
         id: 'vp_test2',
@@ -1149,6 +1170,27 @@ describe('Database - Additional Coverage Tests', () => {
       const result = await db.upsertVoiceProfile(profile);
       expect(result.speaker_name).toBe('Bob');
       expect(result.isUpdate).toBeUndefined();
+    });
+
+    test('upsertVoiceProfile rejects empty embedding without inserting a profile', async () => {
+      await expect(
+        db.upsertVoiceProfile({
+          id: 'vp_empty_upsert',
+          userId: 'u1',
+          workspaceId: 'ws1',
+          speakerName: 'Empty Upsert',
+          audioPath: '/tmp/empty-upsert.wav',
+          embedding: [],
+        })
+      ).rejects.toMatchObject({
+        code: 'embedding_failed',
+        stage: 'embedding',
+        statusCode: 503,
+      });
+
+      await expect(
+        db._get('SELECT * FROM voice_profiles WHERE id = ?', ['vp_empty_upsert'])
+      ).resolves.toBeNull();
     });
 
     test('upsertVoiceProfile updates existing profile with new sample', async () => {
@@ -1175,6 +1217,39 @@ describe('Database - Additional Coverage Tests', () => {
       const result = await db.upsertVoiceProfile(profile2);
       expect(result.sample_count).toBe(2);
       expect(result.isUpdate).toBe(true);
+    });
+
+    test('upsertVoiceProfile rejects empty embedding without mutating an existing profile', async () => {
+      await db.upsertVoiceProfile({
+        id: 'vp_existing_empty_guard',
+        userId: 'u1',
+        workspaceId: 'ws1',
+        speakerName: 'Guarded Existing',
+        audioPath: '/tmp/guarded-original.wav',
+        embedding: [0.11, 0.22, 0.33],
+      });
+
+      await expect(
+        db.upsertVoiceProfile({
+          id: 'vp_existing_empty_guard_new',
+          userId: 'u1',
+          workspaceId: 'ws1',
+          speakerName: 'Guarded Existing',
+          audioPath: '/tmp/guarded-new.wav',
+          embedding: [],
+        })
+      ).rejects.toMatchObject({
+        code: 'embedding_failed',
+        stage: 'embedding',
+        statusCode: 503,
+      });
+
+      const current = await db._get('SELECT * FROM voice_profiles WHERE id = ?', [
+        'vp_existing_empty_guard',
+      ]);
+      expect(current.sample_count).toBe(1);
+      expect(current.audio_path).toBe('/tmp/guarded-original.wav');
+      expect(JSON.parse(current.embedding_json)).toEqual([0.11, 0.22, 0.33]);
     });
 
     test('updateVoiceProfileThreshold clamps value between 0.5 and 0.99', async () => {

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -1227,6 +1227,44 @@ describe('Media Routes', () => {
     );
   });
 
+  it('POST /media/recordings/:recordingId/voice-profiles/from-speaker returns embedding_failed without saving unusable profile', async () => {
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_empty_embedding',
+      workspace_id: 'ws_1',
+      transcript_json: '[{"text":"hello","speakerId":"0","timestamp":0,"endTimestamp":1}]',
+    });
+    mockTranscriptionService.createVoiceProfileFromSpeaker.mockRejectedValue(
+      Object.assign(
+        new Error('Nie udalo sie utworzyc profilu glosu. Sprobuj ponownie za chwile.'),
+        {
+          code: 'embedding_failed',
+          stage: 'embedding',
+          statusCode: 503,
+        }
+      )
+    );
+
+    const res = await app.request(
+      '/media/recordings/rec_empty_embedding/voice-profiles/from-speaker',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ speakerId: '0', speakerName: 'Anna' }),
+      }
+    );
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual(
+      expect.objectContaining({
+        code: 'embedding_failed',
+        stage: 'embedding',
+        recordingId: 'rec_empty_embedding',
+        speakerId: '0',
+        speakerName: 'Anna',
+      })
+    );
+  });
+
   it('POST /media/recordings/:recordingId/rediarize returns no_changes when diarization fails', async () => {
     mockTranscriptionService.getMediaAsset.mockResolvedValue({
       id: 'rec_rediarize_fail',

--- a/server/tests/routes/voice-profiles.test.ts
+++ b/server/tests/routes/voice-profiles.test.ts
@@ -120,6 +120,37 @@ describe('Voice Profiles Routes', () => {
     );
   });
 
+  it.each([
+    ['empty array', []],
+    ['null', null],
+    ['undefined', undefined],
+  ])(
+    'POST /voice-profiles - rejects %s embedding before profile persistence',
+    async (_label, embeddingValue) => {
+      mockTranscriptionService.computeEmbedding.mockResolvedValue(embeddingValue);
+
+      const res = await app.request('/voice-profiles', {
+        method: 'POST',
+        headers: {
+          'X-Speaker-Name': 'Alice',
+          'Content-Type': 'audio/webm',
+          Authorization: 'Bearer fake_token',
+        },
+        body: Buffer.from('fake-audio-data-at-least-1k-bytes'.repeat(40)),
+      });
+
+      expect(res.status).toBe(503);
+      await expect(res.json()).resolves.toEqual(
+        expect.objectContaining({
+          code: 'embedding_failed',
+          stage: 'embedding',
+          message: expect.any(String),
+        })
+      );
+      expect(mockWorkspaceService.upsertVoiceProfile).not.toHaveBeenCalled();
+    }
+  );
+
   it('DELETE /voice-profiles/:id', async () => {
     mockWorkspaceService.deleteVoiceProfile.mockResolvedValue(undefined);
 

--- a/server/tests/services/TranscriptionService.additional.test.ts
+++ b/server/tests/services/TranscriptionService.additional.test.ts
@@ -453,6 +453,44 @@ describe('TranscriptionService - Additional Coverage', () => {
       expect((globalThis as any).__mockFs.unlinkSync).toHaveBeenCalledWith(tempClipPath);
     });
 
+    test.each([
+      ['empty array', []],
+      ['null', null],
+      ['undefined', undefined],
+    ])('rejects %s embedding without saving a voice profile', async (_label, embeddingValue) => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+
+      const tempClipPath = path.join(mockDb.uploadDir, `clip_vp_empty_embedding_${_label}.wav`);
+      fs.writeFileSync(tempClipPath, Buffer.from('audio'));
+      mockAudioPipeline.extractSpeakerAudioClip.mockResolvedValue(tempClipPath);
+      mockSpeakerEmbedder.computeEmbedding.mockResolvedValue(embeddingValue);
+
+      const service = new TranscriptionService(
+        mockDb,
+        mockWorkspaceService,
+        mockAudioPipeline,
+        mockSpeakerEmbedder
+      );
+      const asset = {
+        id: 'rec1',
+        workspace_id: 'ws1',
+        transcript_json: JSON.stringify([
+          { text: 'Voice sample', speakerId: '1', timestamp: 0, endTimestamp: 4 },
+        ]),
+      };
+
+      await expect(
+        service.createVoiceProfileFromSpeaker(asset, '1', 'Barbara', 'user1')
+      ).rejects.toMatchObject({
+        code: 'embedding_failed',
+        stage: 'embedding',
+        statusCode: 503,
+      });
+
+      expect(mockWorkspaceService.saveVoiceProfile).not.toHaveBeenCalled();
+    });
+
     test('classifies profile persistence failures as profile_save_failed', async () => {
       const fs = await import('node:fs');
       const path = await import('node:path');


### PR DESCRIPTION
## Issue
Fixes #1330

## Changes
- Added a shared voice-profile embedding guard for null, undefined, empty, and non-finite vectors.
- Blocked direct `/voice-profiles` uploads before persistence when embedding generation returns no usable vector.
- Blocked transcript-speaker enrollment before `saveVoiceProfile` when embedding generation returns no usable vector.
- Added a database-level guard so future callers cannot insert `embedding_json=[]` or mutate existing profile `sample_count`/`audio_path` with an empty vector.

## Tests run
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\routes\\voice-profiles.test.ts server\\tests\\routes\\media.test.ts server\\tests\\services\\TranscriptionService.additional.test.ts server\\tests\\database\\database.additional.test.ts --coverage.enabled=false`
- `npx -y -p node@22 -p pnpm@9 pnpm run typecheck`
- `npx -y -p node@22 -p pnpm@9 pnpm exec vitest run -c server/vitest.config.ts server/tests/routes/voice-profiles.test.ts --coverage.enabled=false`
- `npx -y -p node@22 -p pnpm@9 pnpm exec vitest run -c server/vitest.config.ts server/tests/routes/media.test.ts --coverage.enabled=false`
- `npx -y -p node@22 -p pnpm@9 pnpm run test:server:retry`
- `npx -y -p node@22 -p pnpm@9 pnpm exec prettier --check server/lib/voiceProfileEmbedding.ts server/database.ts server/routes/workspaces.ts server/services/TranscriptionService.ts server/tests/database/database.additional.test.ts server/tests/routes/media.test.ts server/tests/routes/voice-profiles.test.ts server/tests/services/TranscriptionService.additional.test.ts`
- Pre-push `test:release:guard` passed, including server retry, targeted runtime tests, and build warning audit.

## Known risks
- Local full `format:check` still reports unrelated pre-existing formatting/line-ending issues on many untouched files in this Windows checkout; touched files pass Prettier check.
- This PR intentionally treats an empty vector as provider failure rather than trying to create a low-confidence profile.

## Follow-up tasks
- #1331 should reuse existing profile rows during transcript enrollment, building on the stronger empty-vector guard here.