### PR TITLE
fix(profiles): upsert transcript enrollments

### DIFF
--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -355,6 +355,35 @@ function classifyVoiceProfileEnrollmentError(error: any) {
   };
 }
 
+function hasVoiceProfileEmbedding(profile: any) {
+  if (Array.isArray(profile?.embedding)) return profile.embedding.length > 0;
+  const raw = profile?.embedding_json ?? profile?.embeddingJson;
+  if (Array.isArray(raw)) return raw.length > 0;
+  if (typeof raw !== 'string') return false;
+  try {
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) && parsed.length > 0;
+  } catch (_) {
+    return false;
+  }
+}
+
+function buildVoiceProfileResponse(profile: any) {
+  const sampleCount = Number.isFinite(Number(profile?.sample_count ?? profile?.sampleCount))
+    ? Number(profile?.sample_count ?? profile?.sampleCount)
+    : 1;
+
+  return {
+    id: profile?.id,
+    speakerName: profile?.speaker_name ?? profile?.speakerName,
+    hasEmbedding: hasVoiceProfileEmbedding(profile),
+    createdAt: profile?.created_at ?? profile?.createdAt,
+    sampleCount,
+    threshold: typeof profile?.threshold === 'number' ? profile.threshold : 0.82,
+    isUpdate: Boolean(profile?.isUpdate),
+  };
+}
+
 export function buildRemoteAudioStorageCandidates(
   recordingId: string,
   asset: Pick<MediaAsset, 'file_path' | 'content_type'>
@@ -1477,7 +1506,9 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
         session.user_id,
         options
       );
-      return c.json(profile, 201);
+      const payload = buildVoiceProfileResponse(profile);
+      const status = payload.isUpdate || payload.sampleCount > 1 ? 200 : 201;
+      return c.json(payload, status);
     } catch (err: any) {
       const details = classifyVoiceProfileEnrollmentError(err);
       const body = buildVoiceProfileErrorBody({

--- a/server/services/TranscriptionService.ts
+++ b/server/services/TranscriptionService.ts
@@ -1063,7 +1063,7 @@ export default class TranscriptionService extends EventEmitter {
       fs.renameSync(clipPath, newPath);
       let profile;
       try {
-        profile = await this.workspaceService.saveVoiceProfile({
+        profile = await this.workspaceService.upsertVoiceProfile({
           id: profileId,
           userId,
           workspaceId: asset.workspace_id,

--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -1219,6 +1219,43 @@ describe('Database - Additional Coverage Tests', () => {
       expect(result.isUpdate).toBe(true);
     });
 
+    // ---------------------------------------------------------------
+    // Issue #1331 - transcript enrollment duplicated existing profiles
+    // Date: 2026-06-30
+    // Bug: repeated enrollment could create a second row for the same display name.
+    // Fix: upsert keeps one row and returns update metadata.
+    // ---------------------------------------------------------------
+    test('Regression: Issue #1331 - upsertVoiceProfile reuses existing row when new sample has a different id', async () => {
+      await db.upsertVoiceProfile({
+        id: 'vp_issue_1331_original',
+        userId: 'u1',
+        workspaceId: 'ws_issue_1331',
+        speakerName: 'Repeated Speaker',
+        audioPath: '/tmp/repeated-original.wav',
+        embedding: [0.1, 0.2, 0.3],
+      });
+
+      const result = await db.upsertVoiceProfile({
+        id: 'vp_issue_1331_duplicate',
+        userId: 'u1',
+        workspaceId: 'ws_issue_1331',
+        speakerName: ' repeated speaker ',
+        audioPath: '/tmp/repeated-new.wav',
+        embedding: [0.4, 0.5, 0.6],
+      });
+
+      expect(result.id).toBe('vp_issue_1331_original');
+      expect(result.sample_count).toBe(2);
+      expect(result.audio_path).toBe('/tmp/repeated-new.wav');
+      expect(result.isUpdate).toBe(true);
+
+      const rows = await db._query(
+        'SELECT * FROM voice_profiles WHERE workspace_id = ? AND LOWER(speaker_name) = LOWER(?)',
+        ['ws_issue_1331', 'repeated speaker']
+      );
+      expect(rows).toHaveLength(1);
+    });
+
     test('upsertVoiceProfile rejects empty embedding without mutating an existing profile', async () => {
       await db.upsertVoiceProfile({
         id: 'vp_existing_empty_guard',

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -1186,7 +1186,14 @@ describe('Media Routes', () => {
         workspace_id: 'ws_1',
         transcript_json: '[{"id":"s1","text":"hello","timestamp":0,"endTimestamp":1}]',
       });
-    mockTranscriptionService.createVoiceProfileFromSpeaker.mockResolvedValue({ id: 'vp_1' });
+    mockTranscriptionService.createVoiceProfileFromSpeaker.mockResolvedValue({
+      id: 'vp_1',
+      speaker_name: 'Anna',
+      created_at: '2026-06-30T20:00:00.000Z',
+      sample_count: 1,
+      threshold: 0.82,
+      embedding_json: '[0.1,0.2,0.3]',
+    });
     mockTranscriptionService.diarizeFromTranscript.mockResolvedValue({
       speakerCount: 1,
       speakerNames: { '0': 'Speaker 1' },
@@ -1208,7 +1215,15 @@ describe('Media Routes', () => {
       body: JSON.stringify({ speakerId: '0', speakerName: 'Anna' }),
     });
     expect(voiceRes.status).toBe(201);
-    expect(await voiceRes.json()).toEqual({ id: 'vp_1' });
+    expect(await voiceRes.json()).toEqual({
+      id: 'vp_1',
+      speakerName: 'Anna',
+      hasEmbedding: true,
+      createdAt: '2026-06-30T20:00:00.000Z',
+      sampleCount: 1,
+      threshold: 0.82,
+      isUpdate: false,
+    });
 
     const noTranscriptRes = await app.request('/media/recordings/rec_rediarize_missing/rediarize', {
       method: 'POST',
@@ -1225,6 +1240,49 @@ describe('Media Routes', () => {
       'rec_rediarize_ok',
       expect.objectContaining({ pipelineStatus: 'completed' })
     );
+  });
+
+  // ---------------------------------------------------------------
+  // Issue #1331 - transcript enrollment duplicated existing profiles
+  // Date: 2026-06-30
+  // Bug: repeated transcript enrollment returned a new-profile response.
+  // Fix: reused profiles return update metadata and HTTP 200.
+  // ---------------------------------------------------------------
+  it('Regression: Issue #1331 - POST /media/recordings/:recordingId/voice-profiles/from-speaker returns update state for repeated enrollment', async () => {
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_voice_repeat',
+      workspace_id: 'ws_1',
+      transcript_json: '[{"text":"hello","speakerId":"0","timestamp":0,"endTimestamp":1}]',
+    });
+    mockTranscriptionService.createVoiceProfileFromSpeaker.mockResolvedValue({
+      id: 'vp_existing',
+      speaker_name: 'Anna',
+      created_at: '2026-06-30T20:00:00.000Z',
+      sample_count: 2,
+      threshold: 0.91,
+      isUpdate: true,
+      embedding_json: '[0.1,0.2,0.3]',
+    });
+
+    const res = await app.request(
+      '/media/recordings/rec_voice_repeat/voice-profiles/from-speaker',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ speakerId: '0', speakerName: 'Anna' }),
+      }
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      id: 'vp_existing',
+      speakerName: 'Anna',
+      hasEmbedding: true,
+      createdAt: '2026-06-30T20:00:00.000Z',
+      sampleCount: 2,
+      threshold: 0.91,
+      isUpdate: true,
+    });
   });
 
   it('POST /media/recordings/:recordingId/voice-profiles/from-speaker returns embedding_failed without saving unusable profile', async () => {

--- a/server/tests/services/TranscriptionService.additional.test.ts
+++ b/server/tests/services/TranscriptionService.additional.test.ts
@@ -31,6 +31,7 @@ describe('TranscriptionService - Additional Coverage', () => {
     mockWorkspaceService = {
       getWorkspaceMemberNames: vi.fn().mockResolvedValue(['Anna', 'Jan']),
       saveVoiceProfile: vi.fn().mockResolvedValue({ id: 'vp_new', speaker_name: 'Anna' }),
+      upsertVoiceProfile: vi.fn().mockResolvedValue({ id: 'vp_new', speaker_name: 'Anna' }),
     };
     mockSpeakerEmbedder = {
       computeEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
@@ -251,9 +252,74 @@ describe('TranscriptionService - Additional Coverage', () => {
       expect(profile).toEqual({ id: 'vp_new', speaker_name: 'Anna' });
       expect(mockAudioPipeline.extractSpeakerAudioClip).toHaveBeenCalled();
       expect(mockSpeakerEmbedder.computeEmbedding).toHaveBeenCalled();
-      expect(mockWorkspaceService.saveVoiceProfile).toHaveBeenCalled();
+      expect(mockWorkspaceService.upsertVoiceProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user1',
+          workspaceId: 'ws1',
+          speakerName: 'Test Speaker',
+          embedding: [0.1, 0.2, 0.3],
+        })
+      );
+      expect(mockWorkspaceService.saveVoiceProfile).not.toHaveBeenCalled();
 
       // Cleanup
+      try {
+        fs.unlinkSync(tempClipPath);
+      } catch (_) {}
+    });
+
+    // ---------------------------------------------------------------
+    // Issue #1331 - transcript enrollment duplicated existing profiles
+    // Date: 2026-06-30
+    // Bug: transcript enrollment used insert-only saveVoiceProfile.
+    // Fix: it reuses the upsert path and returns update metadata.
+    // ---------------------------------------------------------------
+    test('Regression: Issue #1331 - reuses an existing profile row for repeated speaker enrollment', async () => {
+      const fs = await import('node:fs');
+      const path = await import('node:path');
+
+      const tempClipPath = path.join(mockDb.uploadDir, 'clip_vp_existing.wav');
+      fs.writeFileSync(tempClipPath, Buffer.from('audio'));
+
+      mockAudioPipeline.extractSpeakerAudioClip.mockResolvedValue(tempClipPath);
+      mockWorkspaceService.upsertVoiceProfile.mockResolvedValue({
+        id: 'vp_existing',
+        speaker_name: 'Anna',
+        sample_count: 2,
+        isUpdate: true,
+      });
+
+      const service = new TranscriptionService(
+        mockDb,
+        mockWorkspaceService,
+        mockAudioPipeline,
+        mockSpeakerEmbedder
+      );
+      const asset = {
+        id: 'rec1',
+        workspace_id: 'ws1',
+        transcript_json: JSON.stringify([
+          { text: 'Hello again', speakerId: '1', timestamp: 0, endTimestamp: 1 },
+        ]),
+      };
+
+      const profile = await service.createVoiceProfileFromSpeaker(asset, '1', 'Anna', 'user1');
+
+      expect(profile).toMatchObject({
+        id: 'vp_existing',
+        sample_count: 2,
+        isUpdate: true,
+      });
+      expect(mockWorkspaceService.upsertVoiceProfile).toHaveBeenCalledWith(
+        expect.objectContaining({
+          userId: 'user1',
+          workspaceId: 'ws1',
+          speakerName: 'Anna',
+          embedding: [0.1, 0.2, 0.3],
+        })
+      );
+      expect(mockWorkspaceService.saveVoiceProfile).not.toHaveBeenCalled();
+
       try {
         fs.unlinkSync(tempClipPath);
       } catch (_) {}
@@ -498,7 +564,7 @@ describe('TranscriptionService - Additional Coverage', () => {
       const tempClipPath = path.join(mockDb.uploadDir, 'clip_vp_save_fail.wav');
       fs.writeFileSync(tempClipPath, Buffer.from('audio'));
       mockAudioPipeline.extractSpeakerAudioClip.mockResolvedValue(tempClipPath);
-      mockWorkspaceService.saveVoiceProfile.mockRejectedValue(new Error('database unavailable'));
+      mockWorkspaceService.upsertVoiceProfile.mockRejectedValue(new Error('database unavailable'));
 
       const service = new TranscriptionService(
         mockDb,

--- a/server/tests/transcription.test.ts
+++ b/server/tests/transcription.test.ts
@@ -40,6 +40,7 @@ describe('TranscriptionService', () => {
     mockWorkspaceService = {
       getWorkspaceMemberNames: vi.fn().mockResolvedValue(['Anna', 'Jan']),
       saveVoiceProfile: vi.fn().mockResolvedValue({ id: 'vp_new', speaker_name: 'Anna' }),
+      upsertVoiceProfile: vi.fn().mockResolvedValue({ id: 'vp_new', speaker_name: 'Anna' }),
     };
     mockSpeakerEmbedder = {
       computeEmbedding: vi.fn().mockResolvedValue([0.1, 0.2, 0.3]),
@@ -416,7 +417,7 @@ describe('TranscriptionService', () => {
       [expect.objectContaining({ text: 'hello', speakerId: '0', timestamp: 0, endTimestamp: 1 })],
       {}
     );
-    expect(mockWorkspaceService.saveVoiceProfile).toHaveBeenCalledWith(
+    expect(mockWorkspaceService.upsertVoiceProfile).toHaveBeenCalledWith(
       expect.objectContaining({
         userId: 'u1',
         workspaceId: 'ws_1',
@@ -424,6 +425,7 @@ describe('TranscriptionService', () => {
         audioPath: expect.stringMatching(/vp_.*\.wav$/),
       })
     );
+    expect(mockWorkspaceService.saveVoiceProfile).not.toHaveBeenCalled();
     expect(renameSync).toHaveBeenCalledTimes(1);
     expect(unlinkSync).toHaveBeenCalledWith('/tmp/clip.wav');
     expect(profile).toEqual({ id: 'vp_new', speaker_name: 'Anna' });


### PR DESCRIPTION
## Issue
Fixes #1331

## Changes
- Reuses `upsertVoiceProfile` for transcript-based speaker enrollment instead of insert-only `saveVoiceProfile`.
- Normalizes `from-speaker` API responses to the direct-upload shape with `speakerName`, `sampleCount`, `hasEmbedding`, `threshold`, and `isUpdate`.
- Returns `201` for new transcript profiles and `200` when an existing profile row is updated.
- Adds route, service, DB, and legacy transcription regressions proving duplicate-row prevention and sample count behavior.

## Tests run
- RED first: `pnpm exec vitest run -c server/vitest.config.ts server/tests/routes/media.test.ts server/tests/services/TranscriptionService.additional.test.ts --coverage.enabled=false` failed on old save/raw-response behavior.
- `npx -y -p node@22 -p pnpm@9 pnpm run typecheck`
- `npx -y -p node@22 -p pnpm@9 pnpm run typecheck:all`
- `npx -y -p node@22 -p pnpm@9 pnpm exec vitest run -c server/vitest.config.ts server/tests/routes/media.test.ts --coverage.enabled=false`
- `npx -y -p node@22 -p pnpm@9 pnpm exec vitest run -c server/vitest.config.ts server/tests/routes/media.test.ts server/tests/services/TranscriptionService.additional.test.ts server/tests/database/database.additional.test.ts server/tests/transcription.test.ts --coverage.enabled=false`
- Pre-push `test:release:guard`: `test:server:retry` 1299 passed / 82 skipped, targeted runtime 81 passed, `audit:build-warnings`, Vite build.

## Known risks
- Upsert is still application-level and can race without a unique DB constraint under concurrent identical enrollments.
- Existing duplicate rows, if already present, are not deduplicated by this PR.
- Existing direct-upload behavior still replaces `audio_path`, which can leave previous sample files to storage cleanup policy.

## Follow-up tasks
- Consider a DB uniqueness/index strategy for `(workspace_id, lower(speaker_name))` and a duplicate cleanup migration.
- Continue with #1332 to expose profile-label usage across processing modes.
