### PR TITLE
fix(profiles): expose label diagnostics

### DIFF
--- a/docs/VOICE_PROFILE_LABELING_DIAGNOSTICS.md
+++ b/docs/VOICE_PROFILE_LABELING_DIAGNOSTICS.md
@@ -1,0 +1,33 @@
+# Voice Profile Labeling Diagnostics
+
+Issue #1332 adds a small diagnostics contract for profile-based speaker labels:
+`transcriptionDiagnostics.voiceProfileLabeling`.
+
+The same object can also be exposed as top-level `voiceProfileLabeling` in media
+responses so older and newer clients can read the status without guessing from
+speaker names.
+
+## Fields
+
+| Field                   | Meaning                                                                              |
+| ----------------------- | ------------------------------------------------------------------------------------ |
+| `applied`               | `true` when at least one speaker label came from a matched voice profile.            |
+| `reason`                | Machine-readable reason for the current status.                                      |
+| `mode`                  | Processing mode that produced the status: `fast`, `full`, `segmented`, or `unknown`. |
+| `profileCount`          | Number of voice profiles available to the pipeline.                                  |
+| `attemptedSpeakerCount` | Number of speakers with enough audio to compare against profiles.                    |
+| `matchedSpeakerCount`   | Number of speakers that matched a profile.                                           |
+| `partCount`             | Present for segmented results; total processed and failed parts.                     |
+| `appliedPartCount`      | Present for segmented results; parts where at least one profile label was applied.   |
+
+## Processing Modes
+
+| Mode        | Behavior                                                                                                                                                                        |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `full`      | Attempts profile matching when profiles exist and speaker audio is eligible. Returns `matched`, `no_match`, `no_voice_profiles`, `no_speakers`, or `no_eligible_speaker_audio`. |
+| `fast`      | Skips profile matching by design. Returns `disabled_by_processing_mode`.                                                                                                        |
+| `segmented` | Per-part transcriptions skip profile matching by design. The merged result returns `disabled_by_processing_mode` when all completed parts were skipped.                         |
+
+The Studio UI should treat this as diagnostics, not as an error. A skipped status
+means the selected processing mode did not run profile labeling; it does not mean
+the transcription failed.

--- a/docs/testing/ui-action-contracts.json
+++ b/docs/testing/ui-action-contracts.json
@@ -45,7 +45,7 @@
       "screen": "Studio",
       "file": "src/studio/StudioMeetingView.tsx",
       "expectedActionCount": 84,
-      "fingerprint": "0a3b9161a9cc56a8",
+      "fingerprint": "9f053ad43ad843e1",
       "contractStatus": "covered",
       "testFiles": ["src/studio/StudioMeetingView.test.tsx"],
       "testEvidence": [

--- a/server/pipeline.ts
+++ b/server/pipeline.ts
@@ -130,6 +130,25 @@ function shouldRetryWithEnhancedProfile(
   return Number(outcome?.transcriptionDiagnostics?.chunksFailedAtStt || 0) > 0;
 }
 
+function resolveProfileLabelingMode(options: any) {
+  if (options?.segmentedPart) return 'segmented';
+  if (options?.processingMode === 'fast' || options?.processingMode === 'full') {
+    return options.processingMode;
+  }
+  return 'unknown';
+}
+
+function createProfileLabelingDiagnostics(options: any, profileCount: number) {
+  return {
+    applied: false,
+    reason: 'not_attempted',
+    mode: resolveProfileLabelingMode(options),
+    profileCount,
+    attemptedSpeakerCount: 0,
+    matchedSpeakerCount: 0,
+  };
+}
+
 // ── Single transcription attempt ──────────────────────────────────────────────
 
 async function runTranscriptionAttempt(
@@ -659,7 +678,14 @@ async function runTranscriptionAttempt(
         ...(diarization as any).speakerGenders,
       };
       const voiceProfiles = options.voiceProfiles || [];
-      if (voiceProfiles.length && diarization.speakerCount > 0 && !options.skipVoiceProfileMatch) {
+      const voiceProfileLabeling = createProfileLabelingDiagnostics(options, voiceProfiles.length);
+      if (options.skipVoiceProfileMatch) {
+        voiceProfileLabeling.reason = 'disabled_by_processing_mode';
+      } else if (!voiceProfiles.length) {
+        voiceProfileLabeling.reason = 'no_voice_profiles';
+      } else if (diarization.speakerCount <= 0) {
+        voiceProfileLabeling.reason = 'no_speakers';
+      } else {
         const speakerSegmentMap = new Map<string, any[]>();
         for (const seg of diarization.segments) {
           const sid = String(seg.speakerId);
@@ -679,6 +705,7 @@ async function runTranscriptionAttempt(
               return Number.isFinite(t) && Number.isFinite(e) && e > t && t >= 0;
             });
             if (!safeSegments.length) continue;
+            voiceProfileLabeling.attemptedSpeakerCount += 1;
             const selectFilter = safeSegments
               .map(
                 (s) =>
@@ -695,6 +722,7 @@ async function runTranscriptionAttempt(
             );
             const matchResult = await matchSpeakerToProfile(clipPath, voiceProfiles);
             if (matchResult) {
+              voiceProfileLabeling.matchedSpeakerCount += 1;
               identifiedNames[speakerId] = matchResult.name;
               const { inferGenderFromPolishName } = await import('./diarization.ts');
               identifiedGenders[speakerId] = inferGenderFromPolishName(matchResult.name);
@@ -710,6 +738,12 @@ async function runTranscriptionAttempt(
             } catch (_) {}
           }
         }
+        voiceProfileLabeling.applied = voiceProfileLabeling.matchedSpeakerCount > 0;
+        voiceProfileLabeling.reason = voiceProfileLabeling.applied
+          ? 'matched'
+          : voiceProfileLabeling.attemptedSpeakerCount > 0
+            ? 'no_match'
+            : 'no_eligible_speaker_audio';
       }
 
       // ── Post-processing: hallucination removal → dedup → merge → LLM ─────
@@ -792,6 +826,10 @@ async function runTranscriptionAttempt(
         werProxy: computeWerProxy(referenceTranscript, hypothesisTranscript),
         diarizationConfidence: verificationResult.confidence,
       };
+      const transcriptionDiagnosticsWithProfileLabeling = {
+        ...transcriptionDiagnostics,
+        voiceProfileLabeling,
+      };
 
       return {
         providerId: sttProviderInfo?.providerId || 'stt-pipeline',
@@ -801,7 +839,8 @@ async function runTranscriptionAttempt(
         emptyReason: '',
         userMessage: '',
         audioQuality: attemptAudioQuality,
-        transcriptionDiagnostics,
+        transcriptionDiagnostics: transcriptionDiagnosticsWithProfileLabeling,
+        voiceProfileLabeling,
         qualityMetrics,
         diarization: {
           speakerNames: identifiedNames,
@@ -813,7 +852,7 @@ async function runTranscriptionAttempt(
           emptyReason: '',
           userMessage: '',
           audioQuality: attemptAudioQuality,
-          transcriptionDiagnostics,
+          transcriptionDiagnostics: transcriptionDiagnosticsWithProfileLabeling,
           qualityMetrics,
         },
         segments: processedSegments,

--- a/server/services/TranscriptionService.ts
+++ b/server/services/TranscriptionService.ts
@@ -421,6 +421,49 @@ export default class TranscriptionService extends EventEmitter {
     const confidence = confidences.length
       ? confidences.reduce((sum, value) => sum + value, 0) / confidences.length
       : 0;
+    const profileLabelingParts = partResults
+      .map(({ result }) => result?.transcriptionDiagnostics?.voiceProfileLabeling)
+      .filter((value) => value && typeof value === 'object');
+    const matchedSpeakerCount = profileLabelingParts.reduce(
+      (sum, item) => sum + Number(item.matchedSpeakerCount || 0),
+      0
+    );
+    const attemptedSpeakerCount = profileLabelingParts.reduce(
+      (sum, item) => sum + Number(item.attemptedSpeakerCount || 0),
+      0
+    );
+    const profileCount = profileLabelingParts.reduce(
+      (max, item) => Math.max(max, Number(item.profileCount || 0)),
+      0
+    );
+    const appliedPartCount = profileLabelingParts.filter((item) => Boolean(item.applied)).length;
+    const skippedPartCount = profileLabelingParts.filter(
+      (item) => item.reason === 'disabled_by_processing_mode'
+    ).length;
+    const profileLabelingReason =
+      appliedPartCount > 0
+        ? 'matched'
+        : profileLabelingParts.length === 0
+          ? 'not_attempted'
+          : skippedPartCount === profileLabelingParts.length
+            ? 'disabled_by_processing_mode'
+            : profileLabelingParts.some((item) => item.reason === 'no_eligible_speaker_audio')
+              ? 'no_eligible_speaker_audio'
+              : profileLabelingParts.some((item) => item.reason === 'no_speakers')
+                ? 'no_speakers'
+                : profileLabelingParts.some((item) => item.reason === 'no_voice_profiles')
+                  ? 'no_voice_profiles'
+                  : 'no_match';
+    const voiceProfileLabeling = {
+      applied: appliedPartCount > 0,
+      reason: profileLabelingReason,
+      mode: 'segmented',
+      profileCount,
+      attemptedSpeakerCount,
+      matchedSpeakerCount,
+      partCount: partResults.length + failedParts,
+      appliedPartCount,
+    };
     return {
       segments,
       diarization: {
@@ -433,6 +476,7 @@ export default class TranscriptionService extends EventEmitter {
         partCount: partResults.length + failedParts,
         completedParts: partResults.length,
         failedParts,
+        voiceProfileLabeling,
       },
     };
   }

--- a/server/tests/audio-pipeline.unit.test.ts
+++ b/server/tests/audio-pipeline.unit.test.ts
@@ -4,10 +4,16 @@ import path from 'node:path';
 import { EventEmitter } from 'events';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-async function loadAudioPipeline({ openAiKey = '', baseUrl = 'https://api.example.test/v1' } = {}) {
+async function loadAudioPipeline({
+  openAiKey = '',
+  baseUrl = 'https://api.example.test/v1',
+  profileMatch = null,
+} = {}) {
   vi.resetModules();
   (globalThis as any).__audioPipelineExecCalls = 0;
   (globalThis as any).__audioPipelineExecCommands = [];
+  const matchSpeakerToProfileMock = vi.fn().mockResolvedValue(profileMatch);
+  (globalThis as any).__audioPipelineMatchSpeakerToProfile = matchSpeakerToProfileMock;
 
   // Set environment variables BEFORE importing any modules
   process.env.VOICELOG_OPENAI_API_KEY = openAiKey;
@@ -25,7 +31,7 @@ async function loadAudioPipeline({ openAiKey = '', baseUrl = 'https://api.exampl
     },
   }));
   vi.doMock('../speakerEmbedder.ts', () => ({
-    matchSpeakerToProfile: vi.fn().mockResolvedValue(null),
+    matchSpeakerToProfile: matchSpeakerToProfileMock,
   }));
   vi.doMock('node:child_process', () => ({
     exec: vi.fn((cmd, opts, callback) => {
@@ -58,6 +64,57 @@ async function loadAudioPipeline({ openAiKey = '', baseUrl = 'https://api.exampl
   }));
 
   return import('../audioPipeline.ts');
+}
+
+function mockProfileLabelingFetches() {
+  const sttPayload = {
+    text: 'Anna omawia plan',
+    segments: [
+      {
+        text: 'Anna omawia plan',
+        start: 0,
+        end: 3,
+        words: [
+          { word: 'Anna', start: 0, end: 0.8 },
+          { word: 'omawia', start: 0.9, end: 1.8 },
+          { word: 'plan', start: 1.9, end: 3 },
+        ],
+      },
+    ],
+    words: [
+      { word: 'Anna', start: 0, end: 0.8 },
+      { word: 'omawia', start: 0.9, end: 1.8 },
+      { word: 'plan', start: 1.9, end: 3 },
+    ],
+  };
+  const diarizationPayload = {
+    choices: [
+      {
+        message: {
+          content: JSON.stringify({
+            segments: [{ i: 0, s: 'A' }],
+          }),
+        },
+      },
+    ],
+  };
+
+  (global.fetch as any).mockImplementation((url: string) => {
+    if (String(url).includes('/audio/transcriptions')) {
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        text: vi.fn().mockResolvedValue(JSON.stringify(sttPayload)),
+        json: vi.fn().mockResolvedValue(sttPayload),
+      });
+    }
+    return Promise.resolve({
+      ok: true,
+      status: 200,
+      text: vi.fn().mockResolvedValue(JSON.stringify(diarizationPayload)),
+      json: vi.fn().mockResolvedValue(diarizationPayload),
+    });
+  });
 }
 
 describe('audioPipeline exports', () => {
@@ -236,6 +293,128 @@ describe('audioPipeline exports', () => {
       pipeline.diarizeFromTranscript([{ text: 'Ala', start: 0, end: 1 }])
     ).resolves.toBeNull();
   });
+
+  // ---------------------------------------------------------------
+  // Issue #1332 - profile label provenance hidden across processing modes
+  // Date: 2026-06-30
+  // Bug: result payload showed final speaker labels without saying if profiles were used.
+  // Fix: transcriptionDiagnostics.voiceProfileLabeling exposes applied/skipped state.
+  // ---------------------------------------------------------------
+  it('Regression: Issue #1332 - full mode reports voice profile labels as applied when a profile matches', async () => {
+    const pipeline = await loadAudioPipeline({
+      openAiKey: 'key-1',
+      profileMatch: { name: 'Anna', confidence: 0.91 },
+    });
+
+    mockProfileLabelingFetches();
+
+    const result = await pipeline.transcribeRecording(
+      {
+        id: 'rec_profile_full',
+        file_path: '/tmp/profile-full.wav',
+        content_type: 'audio/wav',
+        diarization_json: JSON.stringify({
+          audioQuality: { qualityLabel: 'good', enhancementRecommended: false },
+        }),
+      },
+      {
+        processingMode: 'full',
+        skipEarlyPyannote: true,
+        skipChunkVAD: true,
+        transcriptCorrection: false,
+        voiceProfiles: [{ id: 'vp_anna', speaker_name: 'Anna', embedding_json: '[0.1]' }],
+      }
+    );
+
+    expect((globalThis as any).__audioPipelineMatchSpeakerToProfile).toHaveBeenCalled();
+    expect(result.speakerNames).toMatchObject({ '0': 'Anna' });
+    expect(result.transcriptionDiagnostics.voiceProfileLabeling).toMatchObject({
+      applied: true,
+      reason: 'matched',
+      mode: 'full',
+      profileCount: 1,
+      attemptedSpeakerCount: 1,
+      matchedSpeakerCount: 1,
+    });
+    expect(result.diarization.transcriptionDiagnostics.voiceProfileLabeling).toMatchObject({
+      applied: true,
+      reason: 'matched',
+    });
+  }, 30000);
+
+  it('Regression: Issue #1332 - fast mode reports voice profile labels as skipped', async () => {
+    const pipeline = await loadAudioPipeline({
+      openAiKey: 'key-1',
+      profileMatch: { name: 'Anna', confidence: 0.91 },
+    });
+
+    mockProfileLabelingFetches();
+
+    const result = await pipeline.transcribeRecording(
+      {
+        id: 'rec_profile_fast',
+        file_path: '/tmp/profile-fast.wav',
+        content_type: 'audio/wav',
+        diarization_json: JSON.stringify({
+          audioQuality: { qualityLabel: 'good', enhancementRecommended: false },
+        }),
+      },
+      {
+        processingMode: 'fast',
+        skipEarlyPyannote: true,
+        skipChunkVAD: true,
+        skipVoiceProfileMatch: true,
+        transcriptCorrection: false,
+        voiceProfiles: [{ id: 'vp_anna', speaker_name: 'Anna', embedding_json: '[0.1]' }],
+      }
+    );
+
+    expect((globalThis as any).__audioPipelineMatchSpeakerToProfile).not.toHaveBeenCalled();
+    expect(result.transcriptionDiagnostics.voiceProfileLabeling).toMatchObject({
+      applied: false,
+      reason: 'disabled_by_processing_mode',
+      mode: 'fast',
+      profileCount: 1,
+      attemptedSpeakerCount: 0,
+      matchedSpeakerCount: 0,
+    });
+  }, 30000);
+
+  it('Regression: Issue #1332 - segmented mode reports voice profile labels as skipped per part', async () => {
+    const pipeline = await loadAudioPipeline({
+      openAiKey: 'key-1',
+      profileMatch: { name: 'Anna', confidence: 0.91 },
+    });
+
+    mockProfileLabelingFetches();
+
+    const result = await pipeline.transcribeRecording(
+      {
+        id: 'rec_profile_segmented',
+        file_path: '/tmp/profile-segmented.wav',
+        content_type: 'audio/wav',
+        diarization_json: JSON.stringify({
+          audioQuality: { qualityLabel: 'good', enhancementRecommended: false },
+        }),
+      },
+      {
+        segmentedPart: { index: 0 },
+        skipEarlyPyannote: true,
+        skipChunkVAD: true,
+        skipVoiceProfileMatch: true,
+        transcriptCorrection: false,
+        voiceProfiles: [{ id: 'vp_anna', speaker_name: 'Anna', embedding_json: '[0.1]' }],
+      }
+    );
+
+    expect((globalThis as any).__audioPipelineMatchSpeakerToProfile).not.toHaveBeenCalled();
+    expect(result.transcriptionDiagnostics.voiceProfileLabeling).toMatchObject({
+      applied: false,
+      reason: 'disabled_by_processing_mode',
+      mode: 'segmented',
+      profileCount: 1,
+    });
+  }, 30000);
 
   it('analyzes meetings and embeds text chunks through OpenAI endpoints', async () => {
     const pipeline = await loadAudioPipeline({ openAiKey: 'key-1' });

--- a/server/tests/database.test.ts
+++ b/server/tests/database.test.ts
@@ -92,6 +92,16 @@ describe('Database (Async Worker SQLite)', () => {
         transcriptOutcome: 'empty',
         emptyReason: 'no_segments_from_stt',
         userMessage: 'Nie wykryto wypowiedzi w nagraniu.',
+        transcriptionDiagnostics: {
+          voiceProfileLabeling: {
+            applied: false,
+            reason: 'no_speakers',
+            mode: 'full',
+            profileCount: 2,
+            attemptedSpeakerCount: 0,
+            matchedSpeakerCount: 0,
+          },
+        },
         qualityMetrics: {
           sttProviderId: 'groq',
           sttProviderLabel: 'Groq Whisper',
@@ -110,6 +120,12 @@ describe('Database (Async Worker SQLite)', () => {
       expect(diarization.pipelineVersion).toBe('3.1.4');
       expect(diarization.pipelineBuildTime).toBe('2026-03-21T20:40:00.000Z');
       expect(diarization.transcriptOutcome).toBe('empty');
+      expect(diarization.transcriptionDiagnostics.voiceProfileLabeling).toMatchObject({
+        applied: false,
+        reason: 'no_speakers',
+        mode: 'full',
+        profileCount: 2,
+      });
       expect(diarization.qualityMetrics).toMatchObject({
         sttProviderId: 'groq',
         werProxy: 0.18,

--- a/server/tests/transcription.test.ts
+++ b/server/tests/transcription.test.ts
@@ -181,12 +181,30 @@ describe('TranscriptionService', () => {
     const completedPartResult = {
       segments: [{ id: 'part0_seg', timestamp: 1, start: 1, end: 3, text: 'Gotowa czesc.' }],
       diarization: { speakerNames: { '0': 'Anna' }, speakerCount: 1, confidence: 0.9 },
+      transcriptionDiagnostics: {
+        voiceProfileLabeling: {
+          applied: false,
+          reason: 'disabled_by_processing_mode',
+          mode: 'segmented',
+          profileCount: 1,
+          attemptedSpeakerCount: 0,
+          matchedSpeakerCount: 0,
+        },
+      },
     };
     const pendingPartResult = {
       segments: [{ id: 'part1_seg', timestamp: 2, start: 2, end: 4, text: 'Nowa czesc.' }],
       diarization: { speakerNames: { '0': 'Anna' }, speakerCount: 1, confidence: 0.8 },
       transcriptionDiagnostics: {
         sttProviderInfo: { providerId: 'openai', model: 'gpt-4o-transcribe' },
+        voiceProfileLabeling: {
+          applied: false,
+          reason: 'disabled_by_processing_mode',
+          mode: 'segmented',
+          profileCount: 1,
+          attemptedSpeakerCount: 0,
+          matchedSpeakerCount: 0,
+        },
       },
     };
     const manifest = buildSegmentedMediaManifest({
@@ -241,7 +259,10 @@ describe('TranscriptionService', () => {
     expect(mockAudioPipeline.transcribeRecording).toHaveBeenCalledTimes(1);
     expect(mockAudioPipeline.transcribeRecording).toHaveBeenCalledWith(
       expect.objectContaining({ file_path: 'ws_1/rec_segmented/part-001.webm' }),
-      expect.objectContaining({ segmentedPart: expect.objectContaining({ index: 1 }) })
+      expect.objectContaining({
+        segmentedPart: expect.objectContaining({ index: 1 }),
+        skipVoiceProfileMatch: true,
+      })
     );
     expect(mockDb.saveMediaPartTranscript).toHaveBeenCalledWith(
       'rec_segmented',
@@ -262,6 +283,14 @@ describe('TranscriptionService', () => {
           partCount: 2,
           completedParts: 2,
           failedParts: 0,
+          voiceProfileLabeling: expect.objectContaining({
+            applied: false,
+            reason: 'disabled_by_processing_mode',
+            mode: 'segmented',
+            profileCount: 1,
+            partCount: 2,
+            appliedPartCount: 0,
+          }),
         }),
       })
     );

--- a/src/shared/contracts.test.ts
+++ b/src/shared/contracts.test.ts
@@ -152,6 +152,43 @@ describe('shared contracts', () => {
     });
   });
 
+  // ---------------------------------------------------------------
+  // Issue #1332 - profile label provenance was hidden from diagnostics
+  // Date: 2026-06-30
+  // Bug: UI/operator diagnostics could not tell if voice profiles labeled speakers.
+  // Fix: normalization preserves voiceProfileLabeling from stored transcription diagnostics.
+  // ---------------------------------------------------------------
+  test('Regression: Issue #1332 - preserves voice profile labeling diagnostics from storage rows', () => {
+    const profileLabeling = {
+      applied: true,
+      reason: 'matched',
+      mode: 'full',
+      profileCount: 2,
+      attemptedSpeakerCount: 1,
+      matchedSpeakerCount: 1,
+    };
+
+    expect(
+      normalizeTranscriptionStatusPayload({
+        id: 'rec_profile_labels',
+        transcription_status: 'completed',
+        transcript_json: JSON.stringify([{ id: 'seg1', text: 'hello' }]),
+        diarization_json: JSON.stringify({
+          transcriptOutcome: 'normal',
+          speakerCount: 1,
+          transcriptionDiagnostics: {
+            voiceProfileLabeling: profileLabeling,
+          },
+        }),
+      } as any)
+    ).toMatchObject({
+      voiceProfileLabeling: profileLabeling,
+      transcriptionDiagnostics: {
+        voiceProfileLabeling: profileLabeling,
+      },
+    });
+  });
+
   test('Regression: #0 - exposes segmented manifest duration in transcription status', () => {
     expect(
       normalizeTranscriptionStatusPayload({
@@ -239,6 +276,29 @@ describe('shared contracts', () => {
       transcriptOutcome: 'empty',
       emptyReason: 'no_segments_from_stt',
       userMessage: 'Brak wypowiedzi.',
+    });
+  });
+
+  test('Regression: Issue #1332 - preserves voice profile labeling diagnostics from remote responses', () => {
+    const profileLabeling = {
+      applied: false,
+      reason: 'disabled_by_processing_mode',
+      mode: 'fast',
+      profileCount: 3,
+      attemptedSpeakerCount: 0,
+      matchedSpeakerCount: 0,
+    };
+
+    expect(
+      normalizeMediaTranscriptionResponse({
+        recordingId: 'rec_profile_labels_remote',
+        pipelineStatus: 'completed',
+        segments: [{ id: 'seg2', text: 'hi' }],
+        voiceProfileLabeling: profileLabeling,
+      } as any)
+    ).toMatchObject({
+      pipelineStatus: 'done',
+      voiceProfileLabeling: profileLabeling,
     });
   });
 

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -6,6 +6,7 @@ import type {
   TranscriptSegment,
   TranscriptionDiagnostics,
   TranscriptionStatusPayload,
+  VoiceProfileLabelingDiagnostics,
   WorkspaceState,
 } from './types.js';
 
@@ -75,6 +76,7 @@ export interface MediaTranscriptionResponse {
   retryable?: boolean;
   audioValidation?: Record<string, unknown> | null;
   sttAttempts?: TranscriptionDiagnostics['sttAttempts'];
+  voiceProfileLabeling?: VoiceProfileLabelingDiagnostics;
   durationMs?: number;
   reviewSummary?: string | null;
   errorMessage?: string;
@@ -334,6 +336,16 @@ function resolveRetryAfterMs(primary: unknown, fallback: unknown = null): number
   if (Number.isFinite(value) && value > 0) return value;
   const fallbackValue = Number(fallback);
   return Number.isFinite(fallbackValue) && fallbackValue > 0 ? fallbackValue : null;
+}
+
+function resolveVoiceProfileLabeling(
+  diagnostics: TranscriptionDiagnostics | undefined,
+  fallback: unknown = null
+): VoiceProfileLabelingDiagnostics | undefined {
+  return (
+    optionalObject<VoiceProfileLabelingDiagnostics>(diagnostics?.voiceProfileLabeling) ||
+    optionalObject<VoiceProfileLabelingDiagnostics>(fallback)
+  );
 }
 
 function normalizeRetentionDays(value: unknown, fallback = 365): number {
@@ -692,6 +704,9 @@ export function normalizeTranscriptionStatusPayload(
   );
   const segments = parseJsonArray<TranscriptSegment>(asset?.transcript_json);
   const durationMs = resolveTranscriptionDurationMs(asset, diarization, segments);
+  const transcriptionDiagnostics = optionalObject<TranscriptionDiagnostics>(
+    diarization.transcriptionDiagnostics
+  );
 
   return {
     recordingId: String(asset?.id || ''),
@@ -706,8 +721,10 @@ export function normalizeTranscriptionStatusPayload(
     pipelineGitSha: stringValue(diarization.pipelineGitSha),
     pipelineBuildTime: stringValue(diarization.pipelineBuildTime),
     audioQuality: nullableObject<AudioQualityDiagnostics>(diarization.audioQuality),
-    transcriptionDiagnostics: optionalObject<TranscriptionDiagnostics>(
-      diarization.transcriptionDiagnostics
+    transcriptionDiagnostics,
+    voiceProfileLabeling: resolveVoiceProfileLabeling(
+      transcriptionDiagnostics,
+      diarization.voiceProfileLabeling
     ),
     qualityMetrics: nullableObject<TranscriptionQualityMetrics>(diarization.qualityMetrics),
     activeJob: Boolean(asset?.activeJob),
@@ -744,6 +761,10 @@ export function normalizeMediaTranscriptionResponse(
   );
   const segments = Array.isArray(response?.segments) ? response.segments : [];
   const durationMs = resolveRemoteTranscriptionDurationMs(response, diarization, segments);
+  const transcriptionDiagnostics =
+    optionalObject<TranscriptionDiagnostics>(diarization.transcriptionDiagnostics) ||
+    response?.transcriptionDiagnostics ||
+    undefined;
 
   return {
     recordingId: String(response?.recordingId || ''),
@@ -765,10 +786,11 @@ export function normalizeMediaTranscriptionResponse(
       nullableObject<AudioQualityDiagnostics>(diarization.audioQuality) ||
       response?.audioQuality ||
       null,
-    transcriptionDiagnostics:
-      optionalObject<TranscriptionDiagnostics>(diarization.transcriptionDiagnostics) ||
-      response?.transcriptionDiagnostics ||
-      undefined,
+    transcriptionDiagnostics,
+    voiceProfileLabeling: resolveVoiceProfileLabeling(
+      transcriptionDiagnostics,
+      response?.voiceProfileLabeling || diarization.voiceProfileLabeling
+    ),
     qualityMetrics:
       nullableObject<TranscriptionQualityMetrics>(diarization.qualityMetrics) ||
       response?.qualityMetrics ||

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -87,6 +87,25 @@ export interface TranscriptionDiagnostics {
     verificationStatus?: string;
     verificationReasons?: string[];
   }>;
+  voiceProfileLabeling?: VoiceProfileLabelingDiagnostics;
+}
+
+export interface VoiceProfileLabelingDiagnostics {
+  applied: boolean;
+  reason:
+    | 'matched'
+    | 'disabled_by_processing_mode'
+    | 'no_voice_profiles'
+    | 'no_speakers'
+    | 'no_eligible_speaker_audio'
+    | 'no_match'
+    | 'not_attempted';
+  mode: 'fast' | 'full' | 'segmented' | 'unknown';
+  profileCount: number;
+  attemptedSpeakerCount: number;
+  matchedSpeakerCount: number;
+  partCount?: number;
+  appliedPartCount?: number;
 }
 
 export interface SttProviderAttempt {
@@ -139,6 +158,7 @@ export interface TranscriptionStatusPayload {
   pipelineBuildTime?: string;
   audioQuality?: AudioQualityDiagnostics | null;
   transcriptionDiagnostics?: TranscriptionDiagnostics;
+  voiceProfileLabeling?: VoiceProfileLabelingDiagnostics;
   qualityMetrics?: TranscriptionQualityMetrics | null;
   activeJob?: boolean;
   queuedPosition?: number | null;

--- a/src/studio/StudioMeetingView.test.tsx
+++ b/src/studio/StudioMeetingView.test.tsx
@@ -188,6 +188,60 @@ describe('StudioMeetingView', () => {
     ).toEqual(['Adam', 'Ewa']);
   });
 
+  test('Regression: Issue #1332 - shows voice profile labeling diagnostics for completed transcripts', () => {
+    renderWithContext(
+      <StudioMeetingView
+        {...defaultProps}
+        displayRecording={{
+          id: 'rec-profile-labels',
+          transcript: [
+            {
+              id: 'seg-1',
+              speakerId: '0',
+              text: 'Profile diagnostics should be visible.',
+              timestamp: 0,
+              endTimestamp: 3,
+            },
+          ],
+          duration: 60,
+          voiceProfileLabeling: {
+            applied: true,
+            reason: 'matched',
+            mode: 'full',
+            profileCount: 1,
+            attemptedSpeakerCount: 1,
+            matchedSpeakerCount: 1,
+          },
+        }}
+      />
+    );
+
+    expect(screen.getByText(/Profile glosowe: uzyte/i)).toBeInTheDocument();
+  });
+
+  test('Regression: Issue #1332 - hides voice profile labeling diagnostics when no status is available', () => {
+    renderWithContext(
+      <StudioMeetingView
+        {...defaultProps}
+        displayRecording={{
+          id: 'rec-no-profile-labels',
+          transcript: [
+            {
+              id: 'seg-1',
+              speakerId: '0',
+              text: 'No diagnostics should stay quiet.',
+              timestamp: 0,
+              endTimestamp: 3,
+            },
+          ],
+          duration: 60,
+        }}
+      />
+    );
+
+    expect(screen.queryByText(/Profile glosowe:/i)).not.toBeInTheDocument();
+  });
+
   test('Regression: offers verified voice profiles as assignable transcript speaker names', async () => {
     remoteApiEnabledMock.mockReturnValue(true);
     apiRequestMock.mockImplementation((url: string) => {

--- a/src/studio/StudioMeetingView.tsx
+++ b/src/studio/StudioMeetingView.tsx
@@ -606,6 +606,48 @@ function formatEmptyTranscriptDiagnostics(recording) {
   return details.join(' · ');
 }
 
+function getVoiceProfileLabeling(recording) {
+  return (
+    recording?.voiceProfileLabeling ||
+    recording?.transcriptionDiagnostics?.voiceProfileLabeling ||
+    recording?.diarization?.transcriptionDiagnostics?.voiceProfileLabeling ||
+    recording?.diarization?.voiceProfileLabeling ||
+    null
+  );
+}
+
+function formatVoiceProfileLabelingStatus(recording) {
+  const labeling = getVoiceProfileLabeling(recording);
+  if (!labeling || typeof labeling !== 'object') return '';
+  const profileCount = Number(labeling.profileCount || 0);
+  const matchedSpeakerCount = Number(labeling.matchedSpeakerCount || 0);
+  const attemptedSpeakerCount = Number(labeling.attemptedSpeakerCount || 0);
+  const mode = String(labeling.mode || 'unknown');
+  const reason = String(labeling.reason || '');
+
+  if (!labeling.applied && profileCount <= 0) return '';
+  if (labeling.applied) {
+    const matchedLabel = matchedSpeakerCount > 0 ? ` (${matchedSpeakerCount} traf.)` : '';
+    return `Profile glosowe: uzyte${matchedLabel}.`;
+  }
+  if (reason === 'disabled_by_processing_mode') {
+    if (mode === 'fast') return 'Profile glosowe: pominiete w trybie szybkim.';
+    if (mode === 'segmented') return 'Profile glosowe: pominiete dla czesci nagrania.';
+    return 'Profile glosowe: pominiete w tym trybie przetwarzania.';
+  }
+  if (reason === 'no_match') {
+    const attemptedLabel = attemptedSpeakerCount > 0 ? ` (${attemptedSpeakerCount} sprawdz.)` : '';
+    return `Profile glosowe: sprawdzone bez trafienia${attemptedLabel}.`;
+  }
+  if (reason === 'no_eligible_speaker_audio') {
+    return 'Profile glosowe: brak wystarczajacej probki mowcy.';
+  }
+  if (reason === 'no_speakers') {
+    return 'Profile glosowe: brak wykrytych mowcow do porownania.';
+  }
+  return '';
+}
+
 function formatAudioQualityPanel(audioQuality) {
   if (!audioQuality || typeof audioQuality !== 'object') return '';
   const parts: string[] = [];
@@ -1438,6 +1480,10 @@ export default function StudioMeetingView({
   const transcript = useMemo(
     () => displayRecording?.transcript || [],
     [displayRecording?.transcript]
+  );
+  const voiceProfileLabelingStatus = useMemo(
+    () => formatVoiceProfileLabelingStatus(displayRecording || selectedRecording),
+    [displayRecording, selectedRecording]
   );
 
   const speakerStats = useMemo(
@@ -3903,6 +3949,12 @@ export default function StudioMeetingView({
           {voiceProfileError && !pendingNewSpeakerAssignment && !pendingVoiceProfileEnrollment ? (
             <p className="ff-voice-profile-toast ff-voice-profile-toast-error" role="status">
               {voiceProfileError}
+            </p>
+          ) : null}
+
+          {voiceProfileLabelingStatus ? (
+            <p className="ff-voice-profile-labeling-status" role="status">
+              {voiceProfileLabelingStatus}
             </p>
           ) : null}
 

--- a/src/studio/StudioMeetingViewStyles.css
+++ b/src/studio/StudioMeetingViewStyles.css
@@ -1614,6 +1614,17 @@
   border-color: rgba(255, 75, 95, 0.28);
 }
 
+.ff-voice-profile-labeling-status {
+  margin: 0 4px 6px;
+  padding: 6px 8px;
+  border: 1px solid rgba(117, 214, 196, 0.22);
+  border-radius: 6px;
+  background: rgba(117, 214, 196, 0.08);
+  color: #6b7280;
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
 .ff-voice-coaching-btn {
   width: 100%;
   padding: 5px 0;


### PR DESCRIPTION
## Issue
Closes #1332

## Changes
- Add `transcriptionDiagnostics.voiceProfileLabeling` and top-level response normalization so operators can tell whether profile labels were applied.
- Report explicit skip reasons for fast and segmented processing modes, and aggregate segmented part diagnostics.
- Show a compact Studio diagnostic status for completed transcripts.
- Document the profile-label diagnostics contract and processing-mode behavior.

## Tests run
- `pnpm run typecheck`
- `pnpm exec vitest run -c server/vitest.config.ts server/tests/audio-pipeline.unit.test.ts server/tests/transcription.test.ts server/tests/database.test.ts --coverage.enabled=false`
- `pnpm exec vitest run src/shared/contracts.test.ts src/studio/StudioMeetingView.test.tsx --coverage.enabled=false --testNamePattern "Issue #1332"`
- `pnpm run typecheck:all`
- `git diff --check`
- `pnpm run audit:mojibake`
- `pnpm exec prettier --check server/pipeline.ts server/services/TranscriptionService.ts server/tests/audio-pipeline.unit.test.ts server/tests/database.test.ts server/tests/transcription.test.ts src/shared/contracts.test.ts src/shared/contracts.ts src/shared/types.ts src/studio/StudioMeetingView.test.tsx src/studio/StudioMeetingView.tsx src/studio/StudioMeetingViewStyles.css docs/VOICE_PROFILE_LABELING_DIAGNOSTICS.md`
- Pre-push `pnpm run test:release:guard` via Node 22 toolchain: backend 1302 passed / 82 skipped, targeted runtime 81 passed, build warning audit and Vite build passed.

## Known risks
- UI screenshot evidence was not collected in this pass; the visible change is covered by component tests and production build.
- Fast and segmented modes intentionally skip profile matching; the new status exposes that behavior rather than changing it.

## Follow-up tasks
- None required for #1332.
