### PR TITLE
feat(profiles): add operational metadata

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -220,6 +220,35 @@ function _buildPersistentAudioStorageError(error?: unknown): Error {
 }
 
 const WORKER_QUERY_TIMEOUT_MS = 15000;
+const DEFAULT_VOICE_PROFILE_SOURCE = 'unknown';
+const DEFAULT_VOICE_PROFILE_MODEL = 'unknown';
+const DEFAULT_VOICE_PROFILE_VERSION = '1';
+
+function normalizeVoiceProfileMetadata({
+  source,
+  model,
+  version,
+  createdBy,
+  userId,
+}: {
+  source?: unknown;
+  model?: unknown;
+  version?: unknown;
+  createdBy?: unknown;
+  userId?: unknown;
+}) {
+  const normalizeText = (value: unknown, fallback: string) => {
+    const text = typeof value === 'string' ? value.trim() : '';
+    return text || fallback;
+  };
+
+  return {
+    source: normalizeText(source, DEFAULT_VOICE_PROFILE_SOURCE),
+    model: normalizeText(model, DEFAULT_VOICE_PROFILE_MODEL),
+    version: normalizeText(version, DEFAULT_VOICE_PROFILE_VERSION),
+    createdBy: normalizeText(createdBy, normalizeText(userId, '')),
+  };
+}
 
 export function isAddColumnAlreadyAppliedMigrationError(query: string, error: unknown): boolean {
   if (!/\badd\s+column\b/i.test(query)) return false;
@@ -3309,17 +3338,59 @@ export class Database {
     ]);
   }
 
-  async saveVoiceProfile({ id, userId, workspaceId, speakerName, audioPath, embedding }: any) {
+  async saveVoiceProfile({
+    id,
+    userId,
+    workspaceId,
+    speakerName,
+    audioPath,
+    embedding,
+    source,
+    model,
+    version,
+    createdBy,
+  }: any) {
     const validEmbedding = requireVoiceProfileEmbedding(embedding);
     const timestamp = this.nowIso();
+    const metadata = normalizeVoiceProfileMetadata({
+      source,
+      model,
+      version,
+      createdBy,
+      userId,
+    });
     await this._execute(
-      'INSERT INTO voice_profiles (id, user_id, workspace_id, speaker_name, audio_path, embedding_json, created_at) VALUES (?, ?, ?, ?, ?, ?, ?)',
-      [id, userId, workspaceId, speakerName, audioPath, JSON.stringify(validEmbedding), timestamp]
+      'INSERT INTO voice_profiles (id, user_id, workspace_id, speaker_name, audio_path, embedding_json, created_at, updated_at, profile_source, embedding_model, embedding_version, created_by) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)',
+      [
+        id,
+        userId,
+        workspaceId,
+        speakerName,
+        audioPath,
+        JSON.stringify(validEmbedding),
+        timestamp,
+        timestamp,
+        metadata.source,
+        metadata.model,
+        metadata.version,
+        metadata.createdBy,
+      ]
     );
     return this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
   }
 
-  async upsertVoiceProfile({ id, userId, workspaceId, speakerName, audioPath, embedding }: any) {
+  async upsertVoiceProfile({
+    id,
+    userId,
+    workspaceId,
+    speakerName,
+    audioPath,
+    embedding,
+    source,
+    model,
+    version,
+    createdBy,
+  }: any) {
     const MAX_SAMPLES = 5;
     const validEmbedding = requireVoiceProfileEmbedding(embedding);
     const existing = await this._get(
@@ -3340,9 +3411,10 @@ export class Database {
           );
         }
         const averaged = addToAverageEmbedding(existingEmb, existingCount, validEmbedding);
+        const timestamp = this.nowIso();
         await this._execute(
-          'UPDATE voice_profiles SET embedding_json = ?, sample_count = ?, audio_path = ? WHERE id = ?',
-          [JSON.stringify(averaged), existingCount + 1, audioPath, existing.id]
+          'UPDATE voice_profiles SET embedding_json = ?, sample_count = ?, audio_path = ?, updated_at = ? WHERE id = ?',
+          [JSON.stringify(averaged), existingCount + 1, audioPath, timestamp, existing.id]
         );
       }
       return {
@@ -3351,8 +3423,15 @@ export class Database {
       };
     }
     const timestamp = this.nowIso();
+    const metadata = normalizeVoiceProfileMetadata({
+      source,
+      model,
+      version,
+      createdBy,
+      userId,
+    });
     await this._execute(
-      'INSERT INTO voice_profiles (id, user_id, workspace_id, speaker_name, audio_path, embedding_json, sample_count, created_at) VALUES (?, ?, ?, ?, ?, ?, 1, ?)',
+      'INSERT INTO voice_profiles (id, user_id, workspace_id, speaker_name, audio_path, embedding_json, sample_count, created_at, updated_at, profile_source, embedding_model, embedding_version, created_by) VALUES (?, ?, ?, ?, ?, ?, 1, ?, ?, ?, ?, ?, ?)',
       [
         id,
         userId,
@@ -3361,6 +3440,11 @@ export class Database {
         audioPath,
         JSON.stringify(validEmbedding),
         timestamp,
+        timestamp,
+        metadata.source,
+        metadata.model,
+        metadata.version,
+        metadata.createdBy,
       ]
     );
     return this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
@@ -3368,9 +3452,10 @@ export class Database {
 
   async updateVoiceProfileThreshold(id: string, workspaceId: string, threshold: number) {
     const clamped = Math.max(0.5, Math.min(0.99, threshold));
+    const timestamp = this.nowIso();
     await this._execute(
-      'UPDATE voice_profiles SET threshold = ? WHERE id = ? AND workspace_id = ?',
-      [clamped, id, workspaceId]
+      'UPDATE voice_profiles SET threshold = ?, updated_at = ? WHERE id = ? AND workspace_id = ?',
+      [clamped, timestamp, id, workspaceId]
     );
     return this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
   }

--- a/server/migrations/001_initial_schema.sql
+++ b/server/migrations/001_initial_schema.sql
@@ -123,5 +123,10 @@ CREATE TABLE IF NOT EXISTS voice_profiles (
   speaker_name TEXT NOT NULL,
   audio_path TEXT NOT NULL,
   embedding_json TEXT NOT NULL DEFAULT '[]',
-  created_at TEXT NOT NULL
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  profile_source TEXT NOT NULL DEFAULT 'unknown',
+  embedding_model TEXT NOT NULL DEFAULT 'unknown',
+  embedding_version TEXT NOT NULL DEFAULT '1',
+  created_by TEXT
 );

--- a/server/migrations/20260701_voice_profile_operational_metadata.sql
+++ b/server/migrations/20260701_voice_profile_operational_metadata.sql
@@ -1,0 +1,6 @@
+-- Add operational metadata for voice profile provenance and refresh tracking.
+ALTER TABLE voice_profiles ADD COLUMN updated_at TEXT;
+ALTER TABLE voice_profiles ADD COLUMN profile_source TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE voice_profiles ADD COLUMN embedding_model TEXT NOT NULL DEFAULT 'unknown';
+ALTER TABLE voice_profiles ADD COLUMN embedding_version TEXT NOT NULL DEFAULT '1';
+ALTER TABLE voice_profiles ADD COLUMN created_by TEXT;

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -368,6 +368,20 @@ function hasVoiceProfileEmbedding(profile: any) {
   }
 }
 
+const VOICE_PROFILE_EMBEDDING_VERSION = '1';
+
+function voiceProfileMetadata(profile: any) {
+  const fallbackCreatedAt = profile?.created_at ?? profile?.createdAt;
+  const fallbackUserId = profile?.user_id ?? profile?.userId ?? '';
+  return {
+    source: profile?.profile_source ?? profile?.source ?? 'unknown',
+    model: profile?.embedding_model ?? profile?.model ?? 'unknown',
+    version: profile?.embedding_version ?? profile?.version ?? VOICE_PROFILE_EMBEDDING_VERSION,
+    createdBy: profile?.created_by ?? profile?.createdBy ?? fallbackUserId,
+    updatedAt: profile?.updated_at ?? profile?.updatedAt ?? fallbackCreatedAt,
+  };
+}
+
 function buildVoiceProfileResponse(profile: any) {
   const sampleCount = Number.isFinite(Number(profile?.sample_count ?? profile?.sampleCount))
     ? Number(profile?.sample_count ?? profile?.sampleCount)
@@ -381,6 +395,7 @@ function buildVoiceProfileResponse(profile: any) {
     sampleCount,
     threshold: typeof profile?.threshold === 'number' ? profile.threshold : 0.82,
     isUpdate: Boolean(profile?.isUpdate),
+    ...voiceProfileMetadata(profile),
   };
 }
 

--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -291,6 +291,22 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
     }
   };
 
+  const VOICE_PROFILE_EMBEDDING_MODEL = 'voice-profile-embedding';
+  const VOICE_PROFILE_EMBEDDING_VERSION = '1';
+  const VOICE_PROFILE_MANUAL_SOURCE = 'manual_upload';
+
+  const voiceProfileMetadata = (profile: any) => {
+    const fallbackCreatedAt = profile?.created_at ?? profile?.createdAt;
+    const fallbackUserId = profile?.user_id ?? profile?.userId ?? '';
+    return {
+      source: profile?.profile_source ?? profile?.source ?? 'unknown',
+      model: profile?.embedding_model ?? profile?.model ?? 'unknown',
+      version: profile?.embedding_version ?? profile?.version ?? VOICE_PROFILE_EMBEDDING_VERSION,
+      createdBy: profile?.created_by ?? profile?.createdBy ?? fallbackUserId,
+      updatedAt: profile?.updated_at ?? profile?.updatedAt ?? fallbackCreatedAt,
+    };
+  };
+
   // --- Voice Profiles ---
   router.use('/voice-profiles', authMiddleware);
   router.use('/voice-profiles/*', authMiddleware);
@@ -306,6 +322,7 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
       hasEmbedding: hasVoiceProfileEmbedding(p),
       sampleCount: Number.isFinite(Number(p.sample_count)) ? Number(p.sample_count) : 1,
       threshold: typeof p.threshold === 'number' ? p.threshold : 0.82,
+      ...voiceProfileMetadata(p),
     }));
     const payload: VoiceProfilesListPayload = { profiles };
     return c.json(payload, 200);
@@ -365,6 +382,10 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
       speakerName: speakerName.trim(),
       audioPath,
       embedding,
+      source: VOICE_PROFILE_MANUAL_SOURCE,
+      model: VOICE_PROFILE_EMBEDDING_MODEL,
+      version: VOICE_PROFILE_EMBEDDING_VERSION,
+      createdBy: session.user_id,
     });
 
     const sampleCount = profile.sample_count || 1;
@@ -378,6 +399,7 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
         sampleCount,
         threshold: typeof profile.threshold === 'number' ? profile.threshold : 0.82,
         isUpdate: Boolean(profile.isUpdate),
+        ...voiceProfileMetadata(profile),
       },
       status
     );

--- a/server/services/TranscriptionService.ts
+++ b/server/services/TranscriptionService.ts
@@ -7,6 +7,10 @@ import {
 } from '../lib/mediaStoragePolicy.ts';
 import { requireVoiceProfileEmbedding } from '../lib/voiceProfileEmbedding.ts';
 
+const VOICE_PROFILE_EMBEDDING_MODEL = 'voice-profile-embedding';
+const VOICE_PROFILE_EMBEDDING_VERSION = '1';
+const VOICE_PROFILE_TRANSCRIPT_SOURCE = 'transcript_speaker';
+
 type VoiceProfileEnrollmentCode =
   | 'speaker_segment_not_found'
   | 'audio_source_unavailable'
@@ -1114,6 +1118,10 @@ export default class TranscriptionService extends EventEmitter {
           speakerName,
           audioPath: newPath,
           embedding,
+          source: VOICE_PROFILE_TRANSCRIPT_SOURCE,
+          model: VOICE_PROFILE_EMBEDDING_MODEL,
+          version: VOICE_PROFILE_EMBEDDING_VERSION,
+          createdBy: userId,
         });
       } catch (error) {
         throw voiceProfileError(

--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -1116,7 +1116,12 @@ describe('Database - Additional Coverage Tests', () => {
           embedding_json TEXT,
           sample_count INTEGER DEFAULT 1,
           threshold REAL DEFAULT 0.82,
-          created_at TEXT
+          created_at TEXT,
+          updated_at TEXT,
+          profile_source TEXT DEFAULT 'unknown',
+          embedding_model TEXT DEFAULT 'unknown',
+          embedding_version TEXT DEFAULT '1',
+          created_by TEXT
         )
       `);
     });
@@ -1134,6 +1139,42 @@ describe('Database - Additional Coverage Tests', () => {
       const result = await db.saveVoiceProfile(profile);
       expect(result.speaker_name).toBe('Alice');
       expect(result.sample_count).toBe(1);
+    });
+
+    // ---------------------------------------------------------------
+    // Issue #1333 - voice profile operational metadata
+    // Date: 2026-07-01
+    // Bug: voice profile rows had no source/model/version/creator/update metadata.
+    // Fix: profile writes persist metadata while keeping old rows readable.
+    // ---------------------------------------------------------------
+    test('Regression: Issue #1333 - saveVoiceProfile writes operational metadata', async () => {
+      const nowSpy = vi.spyOn(db, 'nowIso').mockReturnValueOnce('2026-07-01T10:00:00.000Z');
+
+      try {
+        const result = await db.saveVoiceProfile({
+          id: 'vp_issue_1333_save',
+          userId: 'creator_1333',
+          workspaceId: 'ws_issue_1333',
+          speakerName: 'Metadata Save',
+          audioPath: '/tmp/metadata-save.wav',
+          embedding: [0.1, 0.2, 0.3],
+          source: 'manual_upload',
+          model: 'voice-profile-embedding',
+          version: '1',
+          createdBy: 'creator_1333',
+        });
+
+        expect(result).toMatchObject({
+          profile_source: 'manual_upload',
+          embedding_model: 'voice-profile-embedding',
+          embedding_version: '1',
+          created_by: 'creator_1333',
+          created_at: '2026-07-01T10:00:00.000Z',
+          updated_at: '2026-07-01T10:00:00.000Z',
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     test('saveVoiceProfile rejects empty embedding without inserting a profile', async () => {
@@ -1217,6 +1258,55 @@ describe('Database - Additional Coverage Tests', () => {
       const result = await db.upsertVoiceProfile(profile2);
       expect(result.sample_count).toBe(2);
       expect(result.isUpdate).toBe(true);
+    });
+
+    test('Regression: Issue #1333 - upsertVoiceProfile preserves creation metadata and refreshes updated_at', async () => {
+      const nowSpy = vi
+        .spyOn(db, 'nowIso')
+        .mockReturnValueOnce('2026-07-01T11:00:00.000Z')
+        .mockReturnValueOnce('2026-07-01T11:05:00.000Z');
+
+      try {
+        await db.upsertVoiceProfile({
+          id: 'vp_issue_1333_original',
+          userId: 'creator_1333',
+          workspaceId: 'ws_issue_1333_upsert',
+          speakerName: 'Metadata Upsert',
+          audioPath: '/tmp/metadata-original.wav',
+          embedding: [0.1, 0.2, 0.3],
+          source: 'manual_upload',
+          model: 'voice-profile-embedding',
+          version: '1',
+          createdBy: 'creator_1333',
+        });
+
+        const result = await db.upsertVoiceProfile({
+          id: 'vp_issue_1333_second',
+          userId: 'other_user',
+          workspaceId: 'ws_issue_1333_upsert',
+          speakerName: 'Metadata Upsert',
+          audioPath: '/tmp/metadata-second.wav',
+          embedding: [0.4, 0.5, 0.6],
+          source: 'transcript_speaker',
+          model: 'voice-profile-embedding',
+          version: '1',
+          createdBy: 'other_user',
+        });
+
+        expect(result).toMatchObject({
+          id: 'vp_issue_1333_original',
+          sample_count: 2,
+          profile_source: 'manual_upload',
+          embedding_model: 'voice-profile-embedding',
+          embedding_version: '1',
+          created_by: 'creator_1333',
+          created_at: '2026-07-01T11:00:00.000Z',
+          updated_at: '2026-07-01T11:05:00.000Z',
+          isUpdate: true,
+        });
+      } finally {
+        nowSpy.mockRestore();
+      }
     });
 
     // ---------------------------------------------------------------
@@ -1308,6 +1398,39 @@ describe('Database - Additional Coverage Tests', () => {
       expect(result.threshold).toBe(0.99);
     });
 
+    test('Regression: Issue #1333 - updateVoiceProfileThreshold refreshes updated_at metadata', async () => {
+      const nowSpy = vi
+        .spyOn(db, 'nowIso')
+        .mockReturnValueOnce('2026-07-01T12:00:00.000Z')
+        .mockReturnValueOnce('2026-07-01T12:10:00.000Z');
+
+      try {
+        await db.upsertVoiceProfile({
+          id: 'vp_issue_1333_threshold',
+          userId: 'u1',
+          workspaceId: 'ws_issue_1333_threshold',
+          speakerName: 'Threshold Metadata',
+          audioPath: '/tmp/threshold-metadata.wav',
+          embedding: [0.1, 0.2, 0.3],
+        });
+
+        await db.updateVoiceProfileThreshold(
+          'vp_issue_1333_threshold',
+          'ws_issue_1333_threshold',
+          0.9
+        );
+        const result = await db._get(
+          'SELECT threshold, updated_at FROM voice_profiles WHERE id = ?',
+          ['vp_issue_1333_threshold']
+        );
+
+        expect(result.threshold).toBe(0.9);
+        expect(result.updated_at).toBe('2026-07-01T12:10:00.000Z');
+      } finally {
+        nowSpy.mockRestore();
+      }
+    });
+
     test('getWorkspaceVoiceProfiles returns profiles', async () => {
       const profiles = await db.getWorkspaceVoiceProfiles('ws1');
       expect(profiles.length).toBeGreaterThan(0);
@@ -1336,10 +1459,11 @@ describe('Database - Additional Coverage Tests', () => {
     test('Regression: #0 — ignores missing voice profile files without Sentry noise', async () => {
       const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
       const missingPath = path.join(testUploadDir, 'missing-voice-profile.wav');
+      const createdAt = new Date().toISOString();
 
       await db._execute(
-        `INSERT INTO voice_profiles (id, user_id, workspace_id, speaker_name, audio_path, embedding_json, sample_count, threshold, created_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        `INSERT INTO voice_profiles (id, user_id, workspace_id, speaker_name, audio_path, embedding_json, sample_count, threshold, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
         [
           'vp_missing_audio',
           'u1',
@@ -1349,7 +1473,8 @@ describe('Database - Additional Coverage Tests', () => {
           '[]',
           1,
           0.82,
-          new Date().toISOString(),
+          createdAt,
+          createdAt,
         ]
       );
 

--- a/server/tests/database/migration-contract.test.ts
+++ b/server/tests/database/migration-contract.test.ts
@@ -14,6 +14,14 @@ const segmentedStorageColumns = [
   'normalized_size_bytes',
 ] as const;
 
+const voiceProfileMetadataColumns = [
+  'updated_at',
+  'profile_source',
+  'embedding_model',
+  'embedding_version',
+  'created_by',
+] as const;
+
 function readMigration(fileName: string) {
   return fs.readFileSync(path.join(migrationsDir, fileName), 'utf8');
 }
@@ -55,5 +63,27 @@ describe('Database migration contracts', () => {
     expect(migration).toContain("where status in ('queued', 'running', 'retryable_failed')");
     expect(migration).not.toContain('autoincrement');
     expect(migration).not.toContain('serial');
+  });
+
+  test('Regression: Issue #1333 - voice profile metadata migration includes operational columns', () => {
+    const migration = readMigration('20260701_voice_profile_operational_metadata.sql')
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+
+    for (const column of voiceProfileMetadataColumns) {
+      expect(migration).toContain(`add column ${column}`);
+    }
+
+    expect(migration).toContain("profile_source text not null default 'unknown'");
+    expect(migration).toContain("embedding_model text not null default 'unknown'");
+    expect(migration).toContain("embedding_version text not null default '1'");
+  });
+
+  test('initial schema contains voice profile operational metadata columns for fresh databases', () => {
+    const initialSchema = readMigration('001_initial_schema.sql').toLowerCase();
+
+    for (const column of voiceProfileMetadataColumns) {
+      expect(initialSchema).toContain(column);
+    }
   });
 });

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -1190,6 +1190,11 @@ describe('Media Routes', () => {
       id: 'vp_1',
       speaker_name: 'Anna',
       created_at: '2026-06-30T20:00:00.000Z',
+      updated_at: '2026-06-30T20:01:00.000Z',
+      profile_source: 'transcript_speaker',
+      embedding_model: 'voice-profile-embedding',
+      embedding_version: '1',
+      created_by: 'user_1',
       sample_count: 1,
       threshold: 0.82,
       embedding_json: '[0.1,0.2,0.3]',
@@ -1215,15 +1220,25 @@ describe('Media Routes', () => {
       body: JSON.stringify({ speakerId: '0', speakerName: 'Anna' }),
     });
     expect(voiceRes.status).toBe(201);
-    expect(await voiceRes.json()).toEqual({
+    const voicePayload = await voiceRes.json();
+    expect(voicePayload).toEqual({
       id: 'vp_1',
       speakerName: 'Anna',
       hasEmbedding: true,
       createdAt: '2026-06-30T20:00:00.000Z',
+      updatedAt: '2026-06-30T20:01:00.000Z',
+      source: 'transcript_speaker',
+      model: 'voice-profile-embedding',
+      version: '1',
+      createdBy: 'user_1',
       sampleCount: 1,
       threshold: 0.82,
       isUpdate: false,
     });
+    expect(voicePayload).not.toHaveProperty('embedding_json');
+    expect(voicePayload).not.toHaveProperty('embeddingJson');
+    expect(voicePayload).not.toHaveProperty('embedding');
+    expect(voicePayload).not.toHaveProperty('vector');
 
     const noTranscriptRes = await app.request('/media/recordings/rec_rediarize_missing/rediarize', {
       method: 'POST',
@@ -1258,6 +1273,11 @@ describe('Media Routes', () => {
       id: 'vp_existing',
       speaker_name: 'Anna',
       created_at: '2026-06-30T20:00:00.000Z',
+      updated_at: '2026-06-30T20:05:00.000Z',
+      profile_source: 'transcript_speaker',
+      embedding_model: 'voice-profile-embedding',
+      embedding_version: '1',
+      created_by: 'user_1',
       sample_count: 2,
       threshold: 0.91,
       isUpdate: true,
@@ -1279,6 +1299,11 @@ describe('Media Routes', () => {
       speakerName: 'Anna',
       hasEmbedding: true,
       createdAt: '2026-06-30T20:00:00.000Z',
+      updatedAt: '2026-06-30T20:05:00.000Z',
+      source: 'transcript_speaker',
+      model: 'voice-profile-embedding',
+      version: '1',
+      createdBy: 'user_1',
       sampleCount: 2,
       threshold: 0.91,
       isUpdate: true,

--- a/server/tests/routes/voice-profiles.test.ts
+++ b/server/tests/routes/voice-profiles.test.ts
@@ -38,6 +38,11 @@ describe('Voice Profiles Routes', () => {
         speaker_name: 'John',
         user_id: 'u1',
         created_at: '2024-01-01',
+        updated_at: '2024-01-03',
+        profile_source: 'manual_upload',
+        embedding_model: 'voice-profile-embedding',
+        embedding_version: '1',
+        created_by: 'creator_1',
         embedding_json: JSON.stringify([0.1, 0.2, 0.3]),
         sample_count: 3,
         threshold: 0.87,
@@ -66,13 +71,25 @@ describe('Voice Profiles Routes', () => {
       hasEmbedding: true,
       sampleCount: 3,
       threshold: 0.87,
+      source: 'manual_upload',
+      model: 'voice-profile-embedding',
+      version: '1',
+      createdBy: 'creator_1',
+      updatedAt: '2024-01-03',
     });
     expect(data.profiles[0]).not.toHaveProperty('embedding_json');
+    expect(data.profiles[0]).not.toHaveProperty('embeddingJson');
     expect(data.profiles[0]).not.toHaveProperty('embedding');
+    expect(data.profiles[0]).not.toHaveProperty('vector');
     expect(data.profiles[1]).toMatchObject({
       hasEmbedding: false,
       sampleCount: 0,
       threshold: 0.82,
+      source: 'unknown',
+      model: 'unknown',
+      version: '1',
+      createdBy: 'u1',
+      updatedAt: '2024-01-02',
     });
     expect(mockWorkspaceService.getWorkspaceVoiceProfiles).toHaveBeenCalledWith('w1');
   });
@@ -94,6 +111,11 @@ describe('Voice Profiles Routes', () => {
       workspace_id: 'w1',
       speaker_name: 'Alice',
       created_at: '2024',
+      updated_at: '2024-01-04',
+      profile_source: 'manual_upload',
+      embedding_model: 'voice-profile-embedding',
+      embedding_version: '1',
+      created_by: 'u1',
       sample_count: 1,
       threshold: 0.82,
       isUpdate: false,
@@ -112,11 +134,29 @@ describe('Voice Profiles Routes', () => {
     if (res.status !== 201) console.log('POST /voice-profiles error:', await res.clone().json());
     expect(res.status).toBe(201);
     const data = await res.json();
-    expect(data.id).toBe('vp_new');
-    expect(data.speakerName).toBe('Alice');
+    expect(data).toMatchObject({
+      id: 'vp_new',
+      speakerName: 'Alice',
+      source: 'manual_upload',
+      model: 'voice-profile-embedding',
+      version: '1',
+      createdBy: 'u1',
+      updatedAt: '2024-01-04',
+    });
+    expect(data).not.toHaveProperty('embedding_json');
+    expect(data).not.toHaveProperty('embeddingJson');
+    expect(data).not.toHaveProperty('embedding');
+    expect(data).not.toHaveProperty('vector');
     expect(mockTranscriptionService.computeEmbedding).toHaveBeenCalled();
     expect(mockWorkspaceService.upsertVoiceProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ speakerName: 'Alice', workspaceId: 'w1' })
+      expect.objectContaining({
+        speakerName: 'Alice',
+        workspaceId: 'w1',
+        source: 'manual_upload',
+        model: 'voice-profile-embedding',
+        version: '1',
+        createdBy: 'u1',
+      })
     );
   });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -204,6 +204,11 @@ export interface VoiceProfileSummary {
   speakerName: string;
   userId: string;
   createdAt: string;
+  updatedAt?: string;
+  source?: string;
+  model?: string;
+  version?: string;
+  createdBy?: string;
   hasEmbedding?: boolean;
   sampleCount?: number;
   threshold?: number;


### PR DESCRIPTION
## Issue
Closes #1333

## Changes
- Add voice profile operational metadata columns for `updated_at`, `profile_source`, `embedding_model`, `embedding_version`, and `created_by`.
- Persist metadata for manual uploads and transcript speaker enrollment while preserving original provenance on repeated upserts.
- Expose safe metadata fields in voice profile API responses and keep raw embeddings out of responses.
- Add migration contract, route, and database regression coverage for old-row fallbacks and refresh timestamps.

## Tests run
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/routes/voice-profiles.test.ts server/tests/routes/media.test.ts server/tests/database/database.additional.test.ts server/tests/database/migration-contract.test.ts --coverage.enabled=false`
- `node_modules\\.bin\\prettier.cmd --check server/database.ts server/routes/workspaces.ts server/routes/media.ts server/services/TranscriptionService.ts src/shared/types.ts server/tests/routes/voice-profiles.test.ts server/tests/routes/media.test.ts server/tests/database/database.additional.test.ts server/tests/database/migration-contract.test.ts`
- `node_modules\\.bin\\tsc.cmd --noEmit`
- `node_modules\\.bin\\tsc.cmd --project server/tsconfig.server.json --noEmit`
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts --retry=3`
- Pre-push release guard: `test:server:retry`, targeted frontend/script tests, and `audit:build-warnings`

## Known risks
- Existing profiles receive neutral metadata defaults from migration; API falls back to `created_at`/`user_id` when old rows have no `updated_at`/creator values.
- The metadata model label is intentionally app-level (`voice-profile-embedding`) rather than a vendor model name because the embedding provider details are not part of the current persisted contract.

## Follow-up tasks
- #1334 can define durable storage policy for profile samples now that profile rows have provenance metadata.
- #1335 can use these metadata fields for export/retention behavior.