### PR TITLE
fix(profiles): enforce sample storage policy

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -223,6 +223,7 @@ const WORKER_QUERY_TIMEOUT_MS = 15000;
 const DEFAULT_VOICE_PROFILE_SOURCE = 'unknown';
 const DEFAULT_VOICE_PROFILE_MODEL = 'unknown';
 const DEFAULT_VOICE_PROFILE_VERSION = '1';
+const VOICE_PROFILE_SAMPLE_STORAGE_POLICY = 'durable_until_profile_delete_or_replaced';
 
 function normalizeVoiceProfileMetadata({
   source,
@@ -248,6 +249,16 @@ function normalizeVoiceProfileMetadata({
     version: normalizeText(version, DEFAULT_VOICE_PROFILE_VERSION),
     createdBy: normalizeText(createdBy, normalizeText(userId, '')),
   };
+}
+
+function localFileExists(filePath: unknown): boolean {
+  const resolved = typeof filePath === 'string' ? filePath.trim() : '';
+  if (!resolved) return false;
+  try {
+    return fs.existsSync(resolved);
+  } catch {
+    return false;
+  }
 }
 
 export function isAddColumnAlreadyAppliedMigrationError(query: string, error: unknown): boolean {
@@ -2542,36 +2553,51 @@ export class Database {
     if (!safeWorkspaceId) throw new Error('Brakuje workspaceId.');
 
     const exportedAt = this.nowIso();
-    const [workspace, members, state, mediaAssets, ragChunks, auditLogs, transcriptionJobs] =
-      await Promise.all([
-        this._get('SELECT * FROM workspaces WHERE id = ?', [safeWorkspaceId]),
-        this._query(
-          `SELECT workspace_members.workspace_id, workspace_members.user_id,
+    const [
+      workspace,
+      members,
+      state,
+      mediaAssets,
+      ragChunks,
+      voiceProfiles,
+      auditLogs,
+      transcriptionJobs,
+    ] = await Promise.all([
+      this._get('SELECT * FROM workspaces WHERE id = ?', [safeWorkspaceId]),
+      this._query(
+        `SELECT workspace_members.workspace_id, workspace_members.user_id,
                   workspace_members.member_role, workspace_members.joined_at,
                   users.email, users.name
            FROM workspace_members
            LEFT JOIN users ON users.id = workspace_members.user_id
            WHERE workspace_members.workspace_id = ?
            ORDER BY workspace_members.joined_at ASC`,
-          [safeWorkspaceId]
-        ),
-        this.getWorkspaceState(safeWorkspaceId),
-        this._query(`SELECT * FROM media_assets WHERE workspace_id = ? ORDER BY created_at ASC`, [
-          safeWorkspaceId,
-        ]),
-        this._query(
-          `SELECT id, workspace_id, recording_id, speaker_name, text, embedding_json, created_at
+        [safeWorkspaceId]
+      ),
+      this.getWorkspaceState(safeWorkspaceId),
+      this._query(`SELECT * FROM media_assets WHERE workspace_id = ? ORDER BY created_at ASC`, [
+        safeWorkspaceId,
+      ]),
+      this._query(
+        `SELECT id, workspace_id, recording_id, speaker_name, text, embedding_json, created_at
            FROM rag_chunks WHERE workspace_id = ? ORDER BY created_at ASC`,
-          [safeWorkspaceId]
-        ),
-        this._query(`SELECT * FROM audit_logs WHERE workspace_id = ? ORDER BY created_at ASC`, [
-          safeWorkspaceId,
-        ]),
-        this._query(
-          `SELECT * FROM transcription_jobs WHERE workspace_id = ? ORDER BY created_at ASC`,
-          [safeWorkspaceId]
-        ),
-      ]);
+        [safeWorkspaceId]
+      ),
+      this._query(
+        `SELECT id, user_id, workspace_id, speaker_name, audio_path, sample_count, threshold,
+                  created_at, updated_at, profile_source, embedding_model, embedding_version,
+                  created_by
+           FROM voice_profiles WHERE workspace_id = ? ORDER BY created_at ASC`,
+        [safeWorkspaceId]
+      ),
+      this._query(`SELECT * FROM audit_logs WHERE workspace_id = ? ORDER BY created_at ASC`, [
+        safeWorkspaceId,
+      ]),
+      this._query(
+        `SELECT * FROM transcription_jobs WHERE workspace_id = ? ORDER BY created_at ASC`,
+        [safeWorkspaceId]
+      ),
+    ]);
 
     const payload = {
       schemaVersion: 'workspace-export-v1',
@@ -2615,6 +2641,25 @@ export class Database {
         embedding: this._safeJsonParse(chunk.embedding_json, []),
         createdAt: String(chunk.created_at || ''),
       })),
+      voiceProfileSamples: voiceProfiles.map((profile: any) => {
+        const audioPath = String(profile.audio_path || '');
+        return {
+          id: String(profile.id || ''),
+          speakerName: String(profile.speaker_name || ''),
+          userId: String(profile.user_id || ''),
+          audioPath,
+          sampleStoragePolicy: VOICE_PROFILE_SAMPLE_STORAGE_POLICY,
+          sampleFileExists: localFileExists(audioPath),
+          sampleCount: Number(profile.sample_count || 1),
+          threshold: Number.isFinite(Number(profile.threshold)) ? Number(profile.threshold) : 0.82,
+          source: String(profile.profile_source || DEFAULT_VOICE_PROFILE_SOURCE),
+          model: String(profile.embedding_model || DEFAULT_VOICE_PROFILE_MODEL),
+          version: String(profile.embedding_version || DEFAULT_VOICE_PROFILE_VERSION),
+          createdBy: String(profile.created_by || profile.user_id || ''),
+          createdAt: String(profile.created_at || ''),
+          updatedAt: String(profile.updated_at || profile.created_at || ''),
+        };
+      }),
       operational: {
         auditLogs: auditLogs.map((entry: any) => ({
           id: String(entry.id || ''),
@@ -2653,6 +2698,10 @@ export class Database {
         exportedAt,
         mediaAssetCount: payload.mediaAssets.length,
         ragChunkCount: payload.ragChunks.length,
+        voiceProfileSampleCount: payload.voiceProfileSamples.length,
+        missingVoiceProfileSampleCount: payload.voiceProfileSamples.filter(
+          (sample: any) => sample.audioPath && !sample.sampleFileExists
+        ).length,
       },
     });
 
@@ -3416,6 +3465,14 @@ export class Database {
           'UPDATE voice_profiles SET embedding_json = ?, sample_count = ?, audio_path = ?, updated_at = ? WHERE id = ?',
           [JSON.stringify(averaged), existingCount + 1, audioPath, timestamp, existing.id]
         );
+        if (existing.audio_path && existing.audio_path !== audioPath) {
+          _deleteFileIfPresent(
+            existing.audio_path,
+            '[database] Failed to delete replaced voice profile audio'
+          );
+        }
+      } else if (audioPath && existing.audio_path !== audioPath) {
+        _deleteFileIfPresent(audioPath, '[database] Failed to delete unused voice profile audio');
       }
       return {
         ...(await this._get('SELECT * FROM voice_profiles WHERE id = ?', [existing.id])),

--- a/server/tests/database.test.ts
+++ b/server/tests/database.test.ts
@@ -503,6 +503,29 @@ describe('Database (Async Worker SQLite)', () => {
         '2026-06-20T09:00:00.000Z',
       ]
     );
+    await db._execute(
+      `INSERT INTO voice_profiles (
+        id, user_id, workspace_id, speaker_name, audio_path, embedding_json, sample_count,
+        threshold, created_at, updated_at, profile_source, embedding_model, embedding_version,
+        created_by
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        'vp_export_missing_sample',
+        'user_export',
+        'ws_export',
+        'Anna',
+        path.join(testUploadDir, 'missing-voice-profile-sample.wav'),
+        JSON.stringify([0.1, 0.2, 0.3]),
+        2,
+        0.87,
+        '2026-06-20T09:10:00.000Z',
+        '2026-06-20T09:20:00.000Z',
+        'manual_upload',
+        'voice-profile-embedding',
+        '1',
+        'user_export',
+      ]
+    );
     await db.writeAuditLog({
       workspaceId: 'ws_export',
       actorUserId: 'user_export',
@@ -512,10 +535,20 @@ describe('Database (Async Worker SQLite)', () => {
       metadata: { source: 'test' },
     });
 
-    const payload = await db.exportWorkspaceData('ws_export', {
-      actorUserId: 'user_export',
-      source: 'test-export',
-    });
+    const previousFsState = { ...(global as any).__TEST_FS_STATE__ };
+    (global as any).__TEST_FS_STATE__ = {
+      ...previousFsState,
+      existsSync: false,
+    };
+    let payload;
+    try {
+      payload = await db.exportWorkspaceData('ws_export', {
+        actorUserId: 'user_export',
+        source: 'test-export',
+      });
+    } finally {
+      (global as any).__TEST_FS_STATE__ = previousFsState;
+    }
 
     expect(payload).toMatchObject({
       schemaVersion: 'workspace-export-v1',
@@ -535,6 +568,27 @@ describe('Database (Async Worker SQLite)', () => {
         recordingConsent: { policyVersion: 'recording-consent-v1' },
       }),
     });
+    expect(payload.voiceProfileSamples).toEqual([
+      expect.objectContaining({
+        id: 'vp_export_missing_sample',
+        speakerName: 'Anna',
+        userId: 'user_export',
+        audioPath: expect.stringContaining('missing-voice-profile-sample.wav'),
+        sampleStoragePolicy: 'durable_until_profile_delete_or_replaced',
+        sampleFileExists: false,
+        sampleCount: 2,
+        threshold: 0.87,
+        source: 'manual_upload',
+        model: 'voice-profile-embedding',
+        version: '1',
+        createdBy: 'user_export',
+        createdAt: '2026-06-20T09:10:00.000Z',
+        updatedAt: '2026-06-20T09:20:00.000Z',
+      }),
+    ]);
+    expect(payload.voiceProfileSamples[0]).not.toHaveProperty('embedding');
+    expect(payload.voiceProfileSamples[0]).not.toHaveProperty('embeddingJson');
+    expect(payload.voiceProfileSamples[0]).not.toHaveProperty('embedding_json');
     expect(payload.operational.auditLogs).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ action: 'recording.created', entityId: 'rec_export' }),
@@ -547,6 +601,8 @@ describe('Database (Async Worker SQLite)', () => {
     expect(JSON.parse(exportAudit.metadata_json)).toMatchObject({
       source: 'test-export',
       mediaAssetCount: 1,
+      voiceProfileSampleCount: 1,
+      missingVoiceProfileSampleCount: 1,
     });
   });
 

--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -1260,6 +1260,117 @@ describe('Database - Additional Coverage Tests', () => {
       expect(result.isUpdate).toBe(true);
     });
 
+    // ---------------------------------------------------------------
+    // Issue #1334 - durable voice profile sample storage policy
+    // Date: 2026-07-01
+    // Bug: replacing a voice profile sample left the previous local sample orphaned.
+    // Fix: profile samples are durable until the profile is deleted or replaced.
+    // ---------------------------------------------------------------
+    test('Regression: Issue #1334 - upsertVoiceProfile deletes replaced durable sample file', async () => {
+      const originalPath = path.join(testUploadDir, 'vp_issue_1334_original.wav');
+      const replacementPath = path.join(testUploadDir, 'vp_issue_1334_replacement.wav');
+      fs.writeFileSync(originalPath, Buffer.from('old voice sample'));
+      fs.writeFileSync(replacementPath, Buffer.from('new voice sample'));
+
+      await db.upsertVoiceProfile({
+        id: 'vp_issue_1334_original',
+        userId: 'u1',
+        workspaceId: 'ws_issue_1334_update',
+        speakerName: 'Durable Sample',
+        audioPath: originalPath,
+        embedding: [0.1, 0.2, 0.3],
+      });
+      expect(fs.existsSync(originalPath)).toBe(true);
+
+      const result = await db.upsertVoiceProfile({
+        id: 'vp_issue_1334_replacement',
+        userId: 'u1',
+        workspaceId: 'ws_issue_1334_update',
+        speakerName: 'Durable Sample',
+        audioPath: replacementPath,
+        embedding: [0.4, 0.5, 0.6],
+      });
+
+      expect(result).toMatchObject({
+        id: 'vp_issue_1334_original',
+        audio_path: replacementPath,
+        sample_count: 2,
+        isUpdate: true,
+      });
+      expect(fs.existsSync(originalPath)).toBe(false);
+      expect(fs.existsSync(replacementPath)).toBe(true);
+    });
+
+    test('Regression: Issue #1334 - missing replaced voice profile sample is ignored without warning noise', async () => {
+      const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => {});
+      const missingPath = path.join(testUploadDir, 'vp_issue_1334_missing.wav');
+      const replacementPath = path.join(testUploadDir, 'vp_issue_1334_missing_replacement.wav');
+      fs.writeFileSync(replacementPath, Buffer.from('replacement voice sample'));
+
+      await db.upsertVoiceProfile({
+        id: 'vp_issue_1334_missing_original',
+        userId: 'u1',
+        workspaceId: 'ws_issue_1334_missing',
+        speakerName: 'Missing Durable Sample',
+        audioPath: missingPath,
+        embedding: [0.1, 0.2, 0.3],
+      });
+
+      const result = await db.upsertVoiceProfile({
+        id: 'vp_issue_1334_missing_replacement',
+        userId: 'u1',
+        workspaceId: 'ws_issue_1334_missing',
+        speakerName: 'Missing Durable Sample',
+        audioPath: replacementPath,
+        embedding: [0.4, 0.5, 0.6],
+      });
+
+      expect(result.audio_path).toBe(replacementPath);
+      expect(warnSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining('Failed to delete voice profile audio'),
+        expect.anything(),
+        expect.anything()
+      );
+      warnSpy.mockRestore();
+    });
+
+    test('Regression: Issue #1334 - rejects overflow samples without leaving an unused file', async () => {
+      let currentPath = '';
+      for (let index = 1; index <= 5; index += 1) {
+        currentPath = path.join(testUploadDir, `vp_issue_1334_cap_${index}.wav`);
+        fs.writeFileSync(currentPath, Buffer.from(`sample ${index}`));
+        await db.upsertVoiceProfile({
+          id: `vp_issue_1334_cap_${index}`,
+          userId: 'u1',
+          workspaceId: 'ws_issue_1334_cap',
+          speakerName: 'Capped Durable Sample',
+          audioPath: currentPath,
+          embedding: [index, index + 0.1, index + 0.2],
+        });
+      }
+
+      const overflowPath = path.join(testUploadDir, 'vp_issue_1334_cap_overflow.wav');
+      fs.writeFileSync(overflowPath, Buffer.from('overflow sample'));
+
+      const result = await db.upsertVoiceProfile({
+        id: 'vp_issue_1334_cap_overflow',
+        userId: 'u1',
+        workspaceId: 'ws_issue_1334_cap',
+        speakerName: 'Capped Durable Sample',
+        audioPath: overflowPath,
+        embedding: [9, 9.1, 9.2],
+      });
+
+      expect(result).toMatchObject({
+        id: 'vp_issue_1334_cap_1',
+        sample_count: 5,
+        audio_path: currentPath,
+        isUpdate: true,
+      });
+      expect(fs.existsSync(currentPath)).toBe(true);
+      expect(fs.existsSync(overflowPath)).toBe(false);
+    });
+
     test('Regression: Issue #1333 - upsertVoiceProfile preserves creation metadata and refreshes updated_at', async () => {
       const nowSpy = vi
         .spyOn(db, 'nowIso')
@@ -1454,6 +1565,32 @@ describe('Database - Additional Coverage Tests', () => {
       expect(profiles.filter((p: any) => p.id === 'vp_test5')).toHaveLength(0);
 
       unlinkSpy.mockRestore();
+    });
+
+    test('Regression: Issue #1334 - deleteVoiceProfile removes the current durable sample file', async () => {
+      const unlinkSpy = vi.spyOn(fs, 'unlinkSync').mockImplementation(() => {});
+      const samplePath = path.join(testUploadDir, 'vp_issue_1334_delete.wav');
+      fs.writeFileSync(samplePath, Buffer.from('voice sample'));
+
+      try {
+        await db.upsertVoiceProfile({
+          id: 'vp_issue_1334_delete',
+          userId: 'u1',
+          workspaceId: 'ws_issue_1334_delete',
+          speakerName: 'Delete Durable Sample',
+          audioPath: samplePath,
+          embedding: [0.1, 0.2, 0.3],
+        });
+
+        await db.deleteVoiceProfile('vp_issue_1334_delete', 'ws_issue_1334_delete');
+
+        expect(unlinkSpy).toHaveBeenCalledWith(samplePath);
+        await expect(
+          db._get('SELECT * FROM voice_profiles WHERE id = ?', ['vp_issue_1334_delete'])
+        ).resolves.toBeNull();
+      } finally {
+        unlinkSpy.mockRestore();
+      }
     });
 
     test('Regression: #0 — ignores missing voice profile files without Sentry noise', async () => {


### PR DESCRIPTION
## Issue
Closes #1334

## Changes
- Define the voice profile sample policy as `durable_until_profile_delete_or_replaced`.
- Delete the previous local sample when a profile is updated with a replacement sample.
- Delete unused overflow sample files when a profile already reached the sample cap.
- Keep delete cleanup tolerant of missing local files.
- Extend workspace export with `voiceProfileSamples` sample policy/availability metadata without exposing voice embeddings or raw audio bytes.

## Tests run
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/database/database.additional.test.ts server/tests/database.test.ts --coverage.enabled=false`
- `node_modules\\.bin\\prettier.cmd --check server/database.ts server/tests/database/database.additional.test.ts server/tests/database.test.ts`
- `node_modules\\.bin\\tsc.cmd --project server/tsconfig.server.json --noEmit`
- `node_modules\\.bin\\tsc.cmd --noEmit`
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts --retry=3`
- Pre-push release guard: `test:server:retry`, targeted frontend/script tests, and `audit:build-warnings`

## Known risks
- Export reports sample path and existence metadata only; it intentionally does not bundle raw sample audio.
- Retention/audit policy for profile metadata remains for #1335.

## Follow-up tasks
- #1335 should decide owner/admin profile export fields, retention behavior, and audit logging around profile metadata lifecycle.