### PR TITLE
feat(profiles): audit export retention metadata

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -224,6 +224,7 @@ const DEFAULT_VOICE_PROFILE_SOURCE = 'unknown';
 const DEFAULT_VOICE_PROFILE_MODEL = 'unknown';
 const DEFAULT_VOICE_PROFILE_VERSION = '1';
 const VOICE_PROFILE_SAMPLE_STORAGE_POLICY = 'durable_until_profile_delete_or_replaced';
+const VOICE_PROFILE_RETENTION_POLICY = 'retained_until_profile_delete';
 
 function normalizeVoiceProfileMetadata({
   source,
@@ -259,6 +260,24 @@ function localFileExists(filePath: unknown): boolean {
   } catch {
     return false;
   }
+}
+
+function buildVoiceProfileAuditMetadata(profile: any, overrides: Record<string, unknown> = {}) {
+  const audioPath = String(profile?.audio_path || profile?.audioPath || '');
+  return {
+    source: String(profile?.profile_source || profile?.source || DEFAULT_VOICE_PROFILE_SOURCE),
+    model: String(profile?.embedding_model || profile?.model || DEFAULT_VOICE_PROFILE_MODEL),
+    version: String(
+      profile?.embedding_version || profile?.version || DEFAULT_VOICE_PROFILE_VERSION
+    ),
+    sampleStoragePolicy: VOICE_PROFILE_SAMPLE_STORAGE_POLICY,
+    retentionPolicy: VOICE_PROFILE_RETENTION_POLICY,
+    sampleCount: Number(profile?.sample_count || profile?.sampleCount || 1),
+    threshold: Number.isFinite(Number(profile?.threshold)) ? Number(profile.threshold) : 0.82,
+    sampleHasPath: Boolean(audioPath),
+    sampleFileExists: localFileExists(audioPath),
+    ...overrides,
+  };
 }
 
 export function isAddColumnAlreadyAppliedMigrationError(query: string, error: unknown): boolean {
@@ -2649,6 +2668,7 @@ export class Database {
           userId: String(profile.user_id || ''),
           audioPath,
           sampleStoragePolicy: VOICE_PROFILE_SAMPLE_STORAGE_POLICY,
+          retentionPolicy: VOICE_PROFILE_RETENTION_POLICY,
           sampleFileExists: localFileExists(audioPath),
           sampleCount: Number(profile.sample_count || 1),
           threshold: Number.isFinite(Number(profile.threshold)) ? Number(profile.threshold) : 0.82,
@@ -3425,7 +3445,16 @@ export class Database {
         metadata.createdBy,
       ]
     );
-    return this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
+    const row = await this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
+    await this.writeAuditLog({
+      workspaceId,
+      actorUserId: metadata.createdBy || userId || '',
+      action: 'voice_profile.created',
+      entityType: 'voice_profile',
+      entityId: id,
+      metadata: buildVoiceProfileAuditMetadata(row),
+    });
+    return row;
   }
 
   async upsertVoiceProfile({
@@ -3474,8 +3503,22 @@ export class Database {
       } else if (audioPath && existing.audio_path !== audioPath) {
         _deleteFileIfPresent(audioPath, '[database] Failed to delete unused voice profile audio');
       }
+      const row = await this._get('SELECT * FROM voice_profiles WHERE id = ?', [existing.id]);
+      if (existingCount < MAX_SAMPLES) {
+        await this.writeAuditLog({
+          workspaceId,
+          actorUserId: String(userId || ''),
+          action: 'voice_profile.updated',
+          entityType: 'voice_profile',
+          entityId: row.id,
+          metadata: buildVoiceProfileAuditMetadata(row, {
+            source: String(source || row.profile_source || DEFAULT_VOICE_PROFILE_SOURCE),
+            replacedSample: Boolean(existing.audio_path && existing.audio_path !== audioPath),
+          }),
+        });
+      }
       return {
-        ...(await this._get('SELECT * FROM voice_profiles WHERE id = ?', [existing.id])),
+        ...row,
         isUpdate: true,
       };
     }
@@ -3504,7 +3547,16 @@ export class Database {
         metadata.createdBy,
       ]
     );
-    return this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
+    const row = await this._get('SELECT * FROM voice_profiles WHERE id = ?', [id]);
+    await this.writeAuditLog({
+      workspaceId,
+      actorUserId: metadata.createdBy || userId || '',
+      action: 'voice_profile.created',
+      entityType: 'voice_profile',
+      entityId: id,
+      metadata: buildVoiceProfileAuditMetadata(row),
+    });
+    return row;
   }
 
   async updateVoiceProfileThreshold(id: string, workspaceId: string, threshold: number) {
@@ -3524,7 +3576,7 @@ export class Database {
     );
   }
 
-  async deleteVoiceProfile(id, workspaceId) {
+  async deleteVoiceProfile(id, workspaceId, options: any = {}) {
     const row = await this._get('SELECT * FROM voice_profiles WHERE id = ? AND workspace_id = ?', [
       id,
       workspaceId,
@@ -3536,6 +3588,19 @@ export class Database {
       id,
       workspaceId,
     ]);
+    if (row) {
+      await this.writeAuditLog({
+        workspaceId,
+        actorUserId: String(options.actorUserId || row.user_id || ''),
+        action: 'voice_profile.deleted',
+        entityType: 'voice_profile',
+        entityId: row.id,
+        metadata: buildVoiceProfileAuditMetadata(row, {
+          source: String(options.source || 'api'),
+          sampleHadPath: Boolean(row.audio_path),
+        }),
+      });
+    }
   }
 
   async getHealth() {

--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -428,7 +428,10 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
 
   router.delete('/voice-profiles/:id', async (c) => {
     const session = c.get('session') as any;
-    await workspaceService.deleteVoiceProfile(c.req.param('id'), session.workspace_id);
+    await workspaceService.deleteVoiceProfile(c.req.param('id'), session.workspace_id, {
+      actorUserId: String(session?.user_id || ''),
+      source: 'api',
+    });
     return new Response(null, { status: 204 });
   });
 

--- a/server/services/WorkspaceService.ts
+++ b/server/services/WorkspaceService.ts
@@ -72,8 +72,8 @@ export default class WorkspaceService {
     return await this.db.upsertVoiceProfile(data);
   }
 
-  async deleteVoiceProfile(id: string, workspaceId: string) {
-    return await this.db.deleteVoiceProfile(id, workspaceId);
+  async deleteVoiceProfile(id: string, workspaceId: string, options: any = {}) {
+    return await this.db.deleteVoiceProfile(id, workspaceId, options);
   }
 
   async updateVoiceProfileThreshold(id: string, workspaceId: string, threshold: number) {

--- a/server/tests/database.test.ts
+++ b/server/tests/database.test.ts
@@ -575,6 +575,7 @@ describe('Database (Async Worker SQLite)', () => {
         userId: 'user_export',
         audioPath: expect.stringContaining('missing-voice-profile-sample.wav'),
         sampleStoragePolicy: 'durable_until_profile_delete_or_replaced',
+        retentionPolicy: 'retained_until_profile_delete',
         sampleFileExists: false,
         sampleCount: 2,
         threshold: 0.87,

--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -1375,7 +1375,9 @@ describe('Database - Additional Coverage Tests', () => {
       const nowSpy = vi
         .spyOn(db, 'nowIso')
         .mockReturnValueOnce('2026-07-01T11:00:00.000Z')
-        .mockReturnValueOnce('2026-07-01T11:05:00.000Z');
+        .mockReturnValueOnce('2026-07-01T11:01:00.000Z')
+        .mockReturnValueOnce('2026-07-01T11:05:00.000Z')
+        .mockReturnValueOnce('2026-07-01T11:06:00.000Z');
 
       try {
         await db.upsertVoiceProfile({
@@ -1513,6 +1515,7 @@ describe('Database - Additional Coverage Tests', () => {
       const nowSpy = vi
         .spyOn(db, 'nowIso')
         .mockReturnValueOnce('2026-07-01T12:00:00.000Z')
+        .mockReturnValueOnce('2026-07-01T12:01:00.000Z')
         .mockReturnValueOnce('2026-07-01T12:10:00.000Z');
 
       try {
@@ -1590,6 +1593,90 @@ describe('Database - Additional Coverage Tests', () => {
         ).resolves.toBeNull();
       } finally {
         unlinkSpy.mockRestore();
+      }
+    });
+
+    // ---------------------------------------------------------------
+    // Issue #1335 - voice profile export, retention, and audit model
+    // Date: 2026-07-01
+    // Bug: profile lifecycle changes were not visible in workspace audit logs.
+    // Fix: create/update/delete events record safe metadata without embeddings.
+    // ---------------------------------------------------------------
+    test('Regression: Issue #1335 - voice profile lifecycle writes safe audit metadata', async () => {
+      const workspaceId = 'ws_issue_1335_audit';
+      const originalPath = path.join(testUploadDir, 'vp_issue_1335_original.wav');
+      const replacementPath = path.join(testUploadDir, 'vp_issue_1335_replacement.wav');
+      fs.writeFileSync(originalPath, Buffer.from('original sample'));
+      fs.writeFileSync(replacementPath, Buffer.from('replacement sample'));
+
+      const created = await db.upsertVoiceProfile({
+        id: 'vp_issue_1335_audit',
+        userId: 'creator_1335',
+        workspaceId,
+        speakerName: 'Audited Speaker',
+        audioPath: originalPath,
+        embedding: [0.1, 0.2, 0.3],
+        source: 'manual_upload',
+        model: 'voice-profile-embedding',
+        version: '1',
+        createdBy: 'creator_1335',
+      });
+      await db.upsertVoiceProfile({
+        id: 'vp_issue_1335_audit_replacement',
+        userId: 'updater_1335',
+        workspaceId,
+        speakerName: 'Audited Speaker',
+        audioPath: replacementPath,
+        embedding: [0.4, 0.5, 0.6],
+        source: 'manual_upload',
+        model: 'voice-profile-embedding',
+        version: '1',
+        createdBy: 'updater_1335',
+      });
+      await db.deleteVoiceProfile(created.id, workspaceId, {
+        actorUserId: 'deleter_1335',
+        source: 'test',
+      });
+
+      const rows = await db._query(
+        'SELECT * FROM audit_logs WHERE workspace_id = ? AND entity_id = ? ORDER BY created_at ASC',
+        [workspaceId, created.id]
+      );
+      expect(rows.map((row: any) => row.action)).toEqual([
+        'voice_profile.created',
+        'voice_profile.updated',
+        'voice_profile.deleted',
+      ]);
+      expect(rows.map((row: any) => row.actor_user_id)).toEqual([
+        'creator_1335',
+        'updater_1335',
+        'deleter_1335',
+      ]);
+
+      const metadata = rows.map((row: any) => JSON.parse(row.metadata_json));
+      expect(metadata[0]).toMatchObject({
+        source: 'manual_upload',
+        sampleStoragePolicy: 'durable_until_profile_delete_or_replaced',
+        retentionPolicy: 'retained_until_profile_delete',
+        sampleCount: 1,
+      });
+      expect(metadata[1]).toMatchObject({
+        source: 'manual_upload',
+        sampleStoragePolicy: 'durable_until_profile_delete_or_replaced',
+        retentionPolicy: 'retained_until_profile_delete',
+        sampleCount: 2,
+        replacedSample: true,
+      });
+      expect(metadata[2]).toMatchObject({
+        source: 'test',
+        sampleStoragePolicy: 'durable_until_profile_delete_or_replaced',
+        retentionPolicy: 'retained_until_profile_delete',
+        sampleHadPath: true,
+      });
+      for (const entry of metadata) {
+        expect(entry).not.toHaveProperty('embedding');
+        expect(entry).not.toHaveProperty('embeddingJson');
+        expect(entry).not.toHaveProperty('embedding_json');
       }
     });
 

--- a/server/tests/routes/voice-profiles.test.ts
+++ b/server/tests/routes/voice-profiles.test.ts
@@ -199,7 +199,10 @@ describe('Voice Profiles Routes', () => {
       headers: { Authorization: 'Bearer fake_token' },
     });
     expect(res.status).toBe(204);
-    expect(mockWorkspaceService.deleteVoiceProfile).toHaveBeenCalledWith('vp_1', 'w1');
+    expect(mockWorkspaceService.deleteVoiceProfile).toHaveBeenCalledWith('vp_1', 'w1', {
+      actorUserId: 'u1',
+      source: 'api',
+    });
   });
 
   it('DELETE /voice-profiles/:id - is idempotent on repeated deletes in parallel', async () => {
@@ -220,8 +223,14 @@ describe('Voice Profiles Routes', () => {
     expect(first.status).toBe(204);
     expect(second.status).toBe(204);
     expect(mockWorkspaceService.deleteVoiceProfile).toHaveBeenCalledTimes(2);
-    expect(mockWorkspaceService.deleteVoiceProfile).toHaveBeenNthCalledWith(1, 'vp_1', 'w1');
-    expect(mockWorkspaceService.deleteVoiceProfile).toHaveBeenNthCalledWith(2, 'vp_1', 'w1');
+    expect(mockWorkspaceService.deleteVoiceProfile).toHaveBeenNthCalledWith(1, 'vp_1', 'w1', {
+      actorUserId: 'u1',
+      source: 'api',
+    });
+    expect(mockWorkspaceService.deleteVoiceProfile).toHaveBeenNthCalledWith(2, 'vp_1', 'w1', {
+      actorUserId: 'u1',
+      source: 'api',
+    });
   });
 
   describe('PATCH /voice-profiles/:id/threshold', () => {


### PR DESCRIPTION
## Issue
Closes #1335

## Changes
- Add `retentionPolicy: retained_until_profile_delete` to exported voice profile sample metadata.
- Add safe voice profile lifecycle audit logs for create, update, and delete.
- Pass API delete actor/source through the workspace service into DB audit logging.
- Keep voice profile export/audit payloads free of raw embedding vectors and raw audio bytes.

## Tests run
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/database/database.additional.test.ts server/tests/database.test.ts server/tests/routes/voice-profiles.test.ts --coverage.enabled=false`
- `node_modules\\.bin\\prettier.cmd --check server/database.ts server/services/WorkspaceService.ts server/routes/workspaces.ts server/tests/database/database.additional.test.ts server/tests/database.test.ts server/tests/routes/voice-profiles.test.ts`
- `node_modules\\.bin\\tsc.cmd --project server/tsconfig.server.json --noEmit`
- `node_modules\\.bin\\tsc.cmd --noEmit`
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts --retry=3`
- Pre-push release guard: `test:server:retry`, targeted frontend/script tests, and `audit:build-warnings`

## Known risks
- Retention is explicit as profile-lifecycle based: profile metadata is retained until profile deletion, independent of recording retention cleanup.
- Export reports sample metadata/path/availability, not binary sample contents.

## Follow-up tasks
- None for #1335; future privacy work can add a dedicated sample binary export decision if product requires it.