### PR TITLE
fix(ci): isolate voice profile audit regression test

### DIFF
--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -6,6 +6,7 @@
 import { describe, test, expect, beforeAll, afterAll, vi } from 'vitest';
 import path from 'node:path';
 import fs from 'node:fs';
+import { randomUUID } from 'node:crypto';
 import {
   checkRemoteAudioAvailabilityWithTimeout,
   initDatabase,
@@ -1603,14 +1604,17 @@ describe('Database - Additional Coverage Tests', () => {
     // Fix: create/update/delete events record safe metadata without embeddings.
     // ---------------------------------------------------------------
     test('Regression: Issue #1335 - voice profile lifecycle writes safe audit metadata', async () => {
-      const workspaceId = 'ws_issue_1335_audit';
-      const originalPath = path.join(testUploadDir, 'vp_issue_1335_original.wav');
-      const replacementPath = path.join(testUploadDir, 'vp_issue_1335_replacement.wav');
+      const suffix = randomUUID();
+      const profileId = `vp_issue_1335_audit_${suffix}`;
+      const replacementProfileId = `vp_issue_1335_audit_replacement_${suffix}`;
+      const workspaceId = `ws_issue_1335_audit_${suffix}`;
+      const originalPath = path.join(testUploadDir, `${profileId}_original.wav`);
+      const replacementPath = path.join(testUploadDir, `${profileId}_replacement.wav`);
       fs.writeFileSync(originalPath, Buffer.from('original sample'));
       fs.writeFileSync(replacementPath, Buffer.from('replacement sample'));
 
       const created = await db.upsertVoiceProfile({
-        id: 'vp_issue_1335_audit',
+        id: profileId,
         userId: 'creator_1335',
         workspaceId,
         speakerName: 'Audited Speaker',
@@ -1622,7 +1626,7 @@ describe('Database - Additional Coverage Tests', () => {
         createdBy: 'creator_1335',
       });
       await db.upsertVoiceProfile({
-        id: 'vp_issue_1335_audit_replacement',
+        id: replacementProfileId,
         userId: 'updater_1335',
         workspaceId,
         speakerName: 'Audited Speaker',


### PR DESCRIPTION
## Issue
Follow-up for #1335 and main CI failure after PR #1345.

## Changes
- Isolate the #1335 voice profile lifecycle audit regression test with unique workspace/profile IDs per attempt.
- Prevent Vitest retry attempts from reusing audit rows left by a failed attempt.

## Tests run
- `node_modules\.bin\prettier.cmd --check server/tests/database/database.additional.test.ts`
- `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts server/tests/database/database.additional.test.ts --coverage.enabled=false --retry=3`
- `node_modules\.bin\tsc.cmd --project server/tsconfig.server.json --noEmit`
- `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts --coverage.enabled=false --retry=3`
- pre-push release guard: `pnpm run test:server:retry`, targeted frontend/script Vitest, `pnpm run audit:build-warnings`

## Known risks
- Test-only change; no runtime behavior change.
- Local `main` remains intentionally untouched because it is pre-existing divergent from `origin/main`.

## Follow-up tasks
- Confirm GitHub CI is green and merge to unblock production workflows.