### PR TITLE
fix(profiles): enforce voice profile role permissions

### DIFF
--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -408,7 +408,7 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
   router.patch('/voice-profiles/:id/threshold', async (c) => {
     const session = c.get('session') as any;
     const membership = await ensureWorkspaceAccess(c, session.workspace_id);
-    if (membership?.member_role === 'viewer') {
+    if (!requireWorkspaceAdmin(membership)) {
       return c.json({ message: 'Tylko owner lub admin moze zmieniac threshold.' }, 403);
     }
 
@@ -428,6 +428,11 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
 
   router.delete('/voice-profiles/:id', async (c) => {
     const session = c.get('session') as any;
+    const membership = await ensureWorkspaceAccess(c, session.workspace_id);
+    if (!requireWorkspaceAdmin(membership)) {
+      return c.json({ message: 'Tylko owner lub admin moze usunac profil glosowy.' }, 403);
+    }
+
     await workspaceService.deleteVoiceProfile(c.req.param('id'), session.workspace_id, {
       actorUserId: String(session?.user_id || ''),
       source: 'api',

--- a/server/tests/routes/voice-profiles.test.ts
+++ b/server/tests/routes/voice-profiles.test.ts
@@ -191,7 +191,8 @@ describe('Voice Profiles Routes', () => {
     }
   );
 
-  it('DELETE /voice-profiles/:id', async () => {
+  it.each(['owner', 'admin'])('DELETE /voice-profiles/:id - allows %s role', async (role) => {
+    mockWorkspaceService.getMembership.mockResolvedValueOnce({ member_role: role });
     mockWorkspaceService.deleteVoiceProfile.mockResolvedValue(undefined);
 
     const res = await app.request('/voice-profiles/vp_1', {
@@ -203,6 +204,26 @@ describe('Voice Profiles Routes', () => {
       actorUserId: 'u1',
       source: 'api',
     });
+  });
+
+  // -----------------------------------------------------------------
+  // Issue #1338 - voice profile delete permissions
+  // Date: 2026-07-01
+  // Bug: member/viewer roles could delete voice profiles without admin rights.
+  // Fix: delete requires owner/admin membership before mutating profile data.
+  // -----------------------------------------------------------------
+  it.each(['member', 'viewer'])('DELETE /voice-profiles/:id - blocks %s role', async (role) => {
+    mockWorkspaceService.getMembership.mockResolvedValueOnce({ member_role: role });
+
+    const res = await app.request('/voice-profiles/vp_1', {
+      method: 'DELETE',
+      headers: { Authorization: 'Bearer fake_token' },
+    });
+
+    expect(res.status).toBe(403);
+    const data = await res.json();
+    expect(data.message).toBe('Tylko owner lub admin moze usunac profil glosowy.');
+    expect(mockWorkspaceService.deleteVoiceProfile).not.toHaveBeenCalled();
   });
 
   it('DELETE /voice-profiles/:id - is idempotent on repeated deletes in parallel', async () => {
@@ -234,6 +255,40 @@ describe('Voice Profiles Routes', () => {
   });
 
   describe('PATCH /voice-profiles/:id/threshold', () => {
+    it.each(['owner', 'admin'])(
+      'PATCH /voice-profiles/:id/threshold - allows %s role',
+      async (role) => {
+        mockWorkspaceService.getMembership.mockResolvedValueOnce({ member_role: role });
+        mockWorkspaceService.updateVoiceProfileThreshold.mockResolvedValue({
+          id: 'vp_1',
+          threshold: 0.92,
+        });
+
+        const res = await app.request('/voice-profiles/vp_1/threshold', {
+          method: 'PATCH',
+          headers: {
+            Authorization: 'Bearer fake_token',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ threshold: 0.92 }),
+        });
+
+        expect(res.status).toBe(200);
+        const data = await res.json();
+        expect(data).toEqual(
+          expect.objectContaining({
+            id: 'vp_1',
+            threshold: 0.92,
+          })
+        );
+        expect(mockWorkspaceService.updateVoiceProfileThreshold).toHaveBeenCalledWith(
+          'vp_1',
+          'w1',
+          0.92
+        );
+      }
+    );
+
     it('PATCH /voice-profiles/:id/threshold - happy path updates threshold', async () => {
       mockWorkspaceService.updateVoiceProfileThreshold.mockResolvedValue({
         id: 'vp_1',
@@ -573,22 +628,31 @@ describe('Voice Profiles Routes', () => {
       );
     });
 
-    it('PATCH /voice-profiles/:id/threshold - viewer role is blocked from threshold edits', async () => {
-      mockWorkspaceService.getMembership.mockResolvedValueOnce({ member_role: 'viewer' });
+    // -----------------------------------------------------------------
+    // Issue #1338 - voice profile threshold permissions
+    // Date: 2026-07-01
+    // Bug: member role could update threshold while only viewer was blocked.
+    // Fix: threshold update requires owner/admin membership consistently.
+    // -----------------------------------------------------------------
+    it.each(['member', 'viewer'])(
+      'PATCH /voice-profiles/:id/threshold - blocks %s role',
+      async (role) => {
+        mockWorkspaceService.getMembership.mockResolvedValueOnce({ member_role: role });
 
-      const res = await app.request('/voice-profiles/vp_1/threshold', {
-        method: 'PATCH',
-        headers: {
-          Authorization: 'Bearer fake_token',
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ threshold: 0.83 }),
-      });
+        const res = await app.request('/voice-profiles/vp_1/threshold', {
+          method: 'PATCH',
+          headers: {
+            Authorization: 'Bearer fake_token',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ threshold: 0.83 }),
+        });
 
-      expect(res.status).toBe(403);
-      const data = await res.json();
-      expect(data.message).toBe('Tylko owner lub admin moze zmieniac threshold.');
-      expect(mockWorkspaceService.updateVoiceProfileThreshold).not.toHaveBeenCalled();
-    });
+        expect(res.status).toBe(403);
+        const data = await res.json();
+        expect(data.message).toBe('Tylko owner lub admin moze zmieniac threshold.');
+        expect(mockWorkspaceService.updateVoiceProfileThreshold).not.toHaveBeenCalled();
+      }
+    );
   });
 });


### PR DESCRIPTION
## Issue
Closes #1338

## Changes
- Require owner/admin membership for voice profile threshold updates; member/viewer receive 403.
- Require owner/admin membership for voice profile deletes; member/viewer receive 403.
- Add regression tests covering owner, admin, member, and viewer roles for delete and threshold operations.

## Tests run
- `pnpm run tdd issue-1338-profile-permissions` (blocked by local pnpm no-TTY module purge under Node 24/pnpm 11; proceeded with direct runners)
- `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts server/tests/routes/voice-profiles.test.ts --coverage.enabled=false` (RED before fix, GREEN after fix)
- `node_modules\.bin\tsc.cmd --project server/tsconfig.server.json --noEmit`
- `node_modules\.bin\prettier.cmd --check server/routes/workspaces.ts server/tests/routes/voice-profiles.test.ts`
- `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts --coverage.enabled=false --retry=3`
- `git push` release guard: `pnpm run test:server:retry`, focused frontend/hook guard tests, `pnpm run audit:build-warnings`

## Known risks
- No public API shape change; authorization is stricter. Existing member users who could previously mutate profile thresholds or delete profiles will now receive 403.

## Follow-up tasks
- Continue with #1337 API error normalization before wiring profile management UI in #1336.