### PR TITLE
fix(profiles): standardize voice profile errors

### DIFF
--- a/docs/testing/ui-action-contracts.json
+++ b/docs/testing/ui-action-contracts.json
@@ -45,7 +45,7 @@
       "screen": "Studio",
       "file": "src/studio/StudioMeetingView.tsx",
       "expectedActionCount": 84,
-      "fingerprint": "9f053ad43ad843e1",
+      "fingerprint": "594827a76cd40983",
       "contractStatus": "covered",
       "testFiles": ["src/studio/StudioMeetingView.test.tsx"],
       "testEvidence": [

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -287,11 +287,16 @@ function buildVoiceProfileErrorBody(input: {
   segmentCount?: number;
   matchedSegmentCount?: number;
   requestId?: string;
+  retryable?: boolean;
+  userAction?: string;
 }) {
+  const defaults = getVoiceProfileErrorDefaults(input.code);
   return {
     code: input.code,
     message: input.message,
     stage: input.stage,
+    retryable: input.retryable ?? defaults.retryable,
+    userAction: input.userAction || defaults.userAction,
     recordingId: input.recordingId,
     speakerId: input.speakerId || undefined,
     speakerName: input.speakerName || undefined,
@@ -301,7 +306,30 @@ function buildVoiceProfileErrorBody(input: {
   };
 }
 
-function classifyVoiceProfileEnrollmentError(error: any) {
+function getVoiceProfileErrorDefaults(code: string) {
+  const defaults: Record<string, { retryable: boolean; userAction: string }> = {
+    missing_speaker_id: { retryable: false, userAction: 'select_speaker' },
+    missing_speaker_name: { retryable: false, userAction: 'select_speaker' },
+    recording_not_found: { retryable: false, userAction: 'refresh_recording' },
+    transcription_not_ready: { retryable: true, userAction: 'wait_for_transcription' },
+    speaker_segment_not_found: { retryable: false, userAction: 'select_speaker_segment' },
+    audio_source_unavailable: { retryable: false, userAction: 'reimport_audio' },
+    embedding_failed: { retryable: true, userAction: 'retry_later' },
+    profile_save_failed: { retryable: true, userAction: 'retry' },
+  };
+  return defaults[code] || { retryable: false, userAction: 'contact_support' };
+}
+
+type VoiceProfileEnrollmentErrorDetails = {
+  code: string;
+  stage: string;
+  status: number;
+  message: string;
+  retryable?: boolean;
+  userAction?: string;
+};
+
+function classifyVoiceProfileEnrollmentError(error: any): VoiceProfileEnrollmentErrorDetails {
   const message = String(error?.message || '');
   const lower = message.toLowerCase();
   if (error?.code && error?.stage) {
@@ -310,6 +338,8 @@ function classifyVoiceProfileEnrollmentError(error: any) {
       stage: String(error.stage),
       status: Number(error.statusCode || error.status || 500) || 500,
       message,
+      retryable: typeof error.retryable === 'boolean' ? error.retryable : undefined,
+      userAction: typeof error.userAction === 'string' ? error.userAction : undefined,
     };
   }
   if (
@@ -1536,6 +1566,8 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
         segmentCount,
         matchedSegmentCount,
         requestId,
+        retryable: details.retryable,
+        userAction: details.userAction,
       });
       console.warn('[voice-profile] Enrollment failed', body);
       return c.json(body, details.status as any);

--- a/server/tests/routes/media.additional.test.ts
+++ b/server/tests/routes/media.additional.test.ts
@@ -1334,6 +1334,8 @@ describe('Media Routes - Additional Coverage', () => {
         ready: false,
         code: 'audio_source_unavailable',
         stage: 'audio_source',
+        retryable: false,
+        userAction: 'reimport_audio',
         recordingId: 'rec_vp_stale_audio',
         speakerId: '0',
         speakerName: 'Anna',
@@ -1559,6 +1561,8 @@ describe('Media Routes - Additional Coverage', () => {
       expect(data.message).toContain('speakerId');
       expect(data.code).toBe('missing_speaker_id');
       expect(data.stage).toBe('validation');
+      expect(data.retryable).toBe(false);
+      expect(data.userAction).toBe('select_speaker');
       expect(data.recordingId).toBe('rec_vp_missing_speaker');
       expect(data.requestId).toEqual(expect.any(String));
       expect(mockTranscriptionService.createVoiceProfileFromSpeaker).not.toHaveBeenCalled();
@@ -1592,6 +1596,8 @@ describe('Media Routes - Additional Coverage', () => {
         expect.objectContaining({
           code: 'missing_speaker_name',
           stage: 'validation',
+          retryable: false,
+          userAction: 'select_speaker',
           recordingId: 'rec_vp_missing_name',
           speakerId: '0',
         })
@@ -1623,6 +1629,15 @@ describe('Media Routes - Additional Coverage', () => {
       expect(res.status).toBe(409);
       const data = await res.json();
       expect(data.message).toContain('transkrypcji');
+      expect(data).toEqual(
+        expect.objectContaining({
+          code: 'transcription_not_ready',
+          stage: 'transcript',
+          retryable: true,
+          userAction: 'wait_for_transcription',
+          requestId: expect.any(String),
+        })
+      );
       expect(mockTranscriptionService.createVoiceProfileFromSpeaker).not.toHaveBeenCalled();
     });
 
@@ -1656,6 +1671,8 @@ describe('Media Routes - Additional Coverage', () => {
         expect.objectContaining({
           code: 'speaker_segment_not_found',
           stage: 'transcript',
+          retryable: false,
+          userAction: 'select_speaker_segment',
           recordingId: 'rec_vp_wrong_speaker',
           speakerId: '99',
           speakerName: 'Nobody',
@@ -1755,6 +1772,8 @@ describe('Media Routes - Additional Coverage', () => {
           code: 'audio_source_unavailable',
           message: 'Audio nie jest dostepne na serwerze. Zaimportuj nagranie ponownie.',
           stage: 'audio_source',
+          retryable: false,
+          userAction: 'reimport_audio',
           recordingId: 'rec_vp_fail',
           speakerId: '99',
           speakerName: 'Nobody',
@@ -1801,6 +1820,8 @@ describe('Media Routes - Additional Coverage', () => {
         expect.objectContaining({
           code: 'embedding_failed',
           stage: 'embedding',
+          retryable: true,
+          userAction: 'retry_later',
           recordingId: 'rec_vp_embedding_fail',
           speakerId: '2',
           speakerName: 'Barbara',

--- a/src/hooks/useRecordingActions.test.ts
+++ b/src/hooks/useRecordingActions.test.ts
@@ -645,6 +645,8 @@ describe('useRecordingActions', () => {
           code: 'audio_source_unavailable',
           stage: 'audio_source',
           requestId: 'req-voice-1',
+          retryable: false,
+          userAction: 'reimport_audio',
         })
       );
       const readyRecording = {
@@ -667,6 +669,8 @@ describe('useRecordingActions', () => {
         code: 'audio_source_unavailable',
         stage: 'audio_source',
         requestId: 'req-voice-1',
+        retryable: false,
+        userAction: 'reimport_audio',
       });
     });
 
@@ -679,6 +683,8 @@ describe('useRecordingActions', () => {
         stage: 'audio_source',
         message: 'Audio nie jest dostepne na serwerze. Zaimportuj nagranie ponownie.',
         requestId: 'req-preflight-424',
+        retryable: false,
+        userAction: 'reimport_audio',
       });
       const readyRecording = {
         ...baseMeeting.recordings[0],
@@ -700,6 +706,8 @@ describe('useRecordingActions', () => {
         code: 'audio_source_unavailable',
         stage: 'audio_source',
         requestId: 'req-preflight-424',
+        retryable: false,
+        userAction: 'reimport_audio',
       });
       expect(apiRequestMock).toHaveBeenCalledTimes(1);
       expect(apiRequestMock).toHaveBeenCalledWith(
@@ -709,6 +717,44 @@ describe('useRecordingActions', () => {
           body: { speakerId: '0', speakerName: 'Anna' },
         }
       );
+    });
+
+    test('preserves not-ready retry guidance from voice profile preflight', async () => {
+      remoteApiEnabledMock.mockReturnValue(true);
+      apiRequestMock.mockResolvedValueOnce({
+        ready: false,
+        code: 'transcription_not_ready',
+        status: 409,
+        stage: 'transcript',
+        message: 'Profil glosu mozna zapisac dopiero po gotowej transkrypcji.',
+        requestId: 'req-preflight-409',
+        retryable: true,
+        userAction: 'wait_for_transcription',
+      });
+      const readyRecording = {
+        ...baseMeeting.recordings[0],
+        id: 'recording_ready',
+        pipelineStatus: 'done',
+        transcript: [{ id: 's1', speakerId: '0', text: 'Dobra probka glosu', timestamp: 0 }],
+      };
+
+      const { result } = setupHook(
+        { ...baseMeeting, recordings: [readyRecording] },
+        readyRecording
+      );
+
+      const error = await result.current.autoCreateVoiceProfile('0', 'Anna').catch((e) => e);
+
+      expect(error).toMatchObject({
+        message: 'Profil glosu mozna zapisac dopiero po gotowej transkrypcji.',
+        status: 409,
+        code: 'transcription_not_ready',
+        stage: 'transcript',
+        requestId: 'req-preflight-409',
+        retryable: true,
+        userAction: 'wait_for_transcription',
+      });
+      expect(apiRequestMock).toHaveBeenCalledTimes(1);
     });
 
     test('uses explicit display recording id when selectedRecording is missing', async () => {

--- a/src/hooks/useRecordingActions.ts
+++ b/src/hooks/useRecordingActions.ts
@@ -604,11 +604,15 @@ export default function useRecordingActions({
           code?: string;
           stage?: string;
           requestId?: string;
+          retryable?: boolean;
+          userAction?: string;
         };
         if (error?.status) voiceProfileError.status = error.status;
         if (error?.code) voiceProfileError.code = String(error.code);
         if (error?.stage) voiceProfileError.stage = String(error.stage);
         if (error?.requestId) voiceProfileError.requestId = String(error.requestId);
+        if (typeof error?.retryable === 'boolean') voiceProfileError.retryable = error.retryable;
+        if (error?.userAction) voiceProfileError.userAction = String(error.userAction);
         return voiceProfileError;
       };
       try {
@@ -642,11 +646,15 @@ export default function useRecordingActions({
         code?: string;
         stage?: string;
         requestId?: string;
+        retryable?: boolean;
+        userAction?: string;
       };
       if (error?.status) voiceProfileError.status = error.status;
       if (error?.code) voiceProfileError.code = String(error.code);
       if (error?.stage) voiceProfileError.stage = String(error.stage);
       if (error?.requestId) voiceProfileError.requestId = String(error.requestId);
+      if (typeof error?.retryable === 'boolean') voiceProfileError.retryable = error.retryable;
+      if (error?.userAction) voiceProfileError.userAction = String(error.userAction);
       throw voiceProfileError;
     }
   }

--- a/src/services/httpClient.test.ts
+++ b/src/services/httpClient.test.ts
@@ -871,6 +871,8 @@ describe('Regression: Issue #0 - apiRequest preserves structured API error field
           message: 'Audio nie jest dostepne na serwerze. Zaimportuj nagranie ponownie.',
           stage: 'audio_source',
           requestId: 'req-voice-1',
+          retryable: false,
+          userAction: 'reimport_audio',
         }),
       text: () => Promise.resolve(''),
       headers: new Headers({ 'content-type': 'application/json' }),
@@ -888,6 +890,8 @@ describe('Regression: Issue #0 - apiRequest preserves structured API error field
       code: 'audio_source_unavailable',
       stage: 'audio_source',
       requestId: 'req-voice-1',
+      retryable: false,
+      userAction: 'reimport_audio',
     });
   });
 
@@ -901,6 +905,8 @@ describe('Regression: Issue #0 - apiRequest preserves structured API error field
           message: 'Audio nie jest dostepne na serwerze. Zaimportuj nagranie ponownie.',
           stage: 'audio_source',
           requestId: 'req-voice-424',
+          retryable: false,
+          userAction: 'reimport_audio',
         }),
       text: () => Promise.resolve(''),
       headers: new Headers({ 'content-type': 'application/json' }),
@@ -918,6 +924,8 @@ describe('Regression: Issue #0 - apiRequest preserves structured API error field
       code: 'audio_source_unavailable',
       stage: 'audio_source',
       requestId: 'req-voice-424',
+      retryable: false,
+      userAction: 'reimport_audio',
     });
   });
 });

--- a/src/services/httpClient.ts
+++ b/src/services/httpClient.ts
@@ -408,12 +408,16 @@ export async function apiRequest(path: string, options: ApiOptions = {}) {
       code?: string;
       stage?: string;
       requestId?: string;
+      retryable?: boolean;
+      userAction?: string;
     };
     error.status = response.status;
     if (errorBody && typeof errorBody === 'object') {
       if (errorBody.code) error.code = String(errorBody.code);
       if (errorBody.stage) error.stage = String(errorBody.stage);
       if (errorBody.requestId) error.requestId = String(errorBody.requestId);
+      if (typeof errorBody.retryable === 'boolean') error.retryable = errorBody.retryable;
+      if (errorBody.userAction) error.userAction = String(errorBody.userAction);
     }
     throw error;
   }

--- a/src/studio/StudioMeetingView.test.tsx
+++ b/src/studio/StudioMeetingView.test.tsx
@@ -1455,6 +1455,12 @@ describe('StudioMeetingView', () => {
   });
 
   test.each([
+    ['missing_speaker_id', 400, /Wybierz mowce i osobe przed zapisaniem probki glosu\./i],
+    [
+      'transcription_not_ready',
+      409,
+      /Profil glosu mozna zapisac dopiero po gotowej transkrypcji\./i,
+    ],
     [
       'speaker_segment_not_found',
       422,

--- a/src/studio/StudioMeetingView.tsx
+++ b/src/studio/StudioMeetingView.tsx
@@ -1579,6 +1579,9 @@ export default function StudioMeetingView({
     if (code === 'missing_speaker_id' || code === 'missing_speaker_name') {
       return 'Wybierz mowce i osobe przed zapisaniem probki glosu.';
     }
+    if (code === 'transcription_not_ready') {
+      return 'Profil glosu mozna zapisac dopiero po gotowej transkrypcji.';
+    }
 
     return hasActionableMessage
       ? rawMessage


### PR DESCRIPTION
## Issue
Closes #1337

## Changes
- Add stable `retryable` and `userAction` fields to voice profile API error payloads while preserving existing `code`, `message`, `stage`, and `requestId`.
- Carry `retryable` and `userAction` through `apiRequest` and `autoCreateVoiceProfile` error objects.
- Add Studio mapping for `transcription_not_ready` so not-ready profile enrollment has actionable UI copy.
- Cover validation, missing audio source, not-ready transcript, speaker segment, and processing failure cases.

## Tests run
- `pnpm run tdd issue-1337-profile-api-errors` (blocked by local pnpm no-TTY module purge under Node 24/pnpm 11; proceeded with direct runners)
- `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts server/tests/routes/media.additional.test.ts --coverage.enabled=false` (RED before fix, GREEN after fix)
- `node_modules\.bin\vitest.cmd run src/services/httpClient.test.ts src/hooks/useRecordingActions.test.ts src/studio/StudioMeetingView.test.tsx --coverage.enabled=false` (RED before fix, GREEN after fix)
- `node_modules\.bin\tsc.cmd --project server/tsconfig.server.json --noEmit`
- `node_modules\.bin\tsc.cmd --noEmit`
- `node_modules\.bin\prettier.cmd --check server/routes/media.ts server/tests/routes/media.additional.test.ts src/services/httpClient.ts src/services/httpClient.test.ts src/hooks/useRecordingActions.ts src/hooks/useRecordingActions.test.ts src/studio/StudioMeetingView.tsx src/studio/StudioMeetingView.test.tsx`
- `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts --coverage.enabled=false --retry=3`
- `git push` release guard: `pnpm run test:server:retry`, focused frontend/hook guard tests, `pnpm run audit:build-warnings`

## Known risks
- This expands JSON error bodies and thrown Error metadata, but does not change successful API payloads or HTTP status codes.
- `userAction` values are stable machine-readable strings intended for frontend mapping, not localized UI copy.

## Follow-up tasks
- Use the standardized profile errors in #1336 profile management UI.