### PR TITLE
feat(profiles): add voice profile management UI

### DIFF
--- a/docs/testing/ui-action-contracts.json
+++ b/docs/testing/ui-action-contracts.json
@@ -125,10 +125,10 @@
       "screen": "Profile",
       "file": "src/ProfileTab.tsx",
       "expectedActionCount": 37,
-      "fingerprint": "5ae5c52d48f54aef",
+      "fingerprint": "f2f33d285234a017",
       "contractStatus": "covered",
       "testFiles": ["src/ProfileTab.test.tsx", "src/ProfileTab.auth.integration.test.tsx"],
-      "testEvidence": ["Zapisz profil", "Zmień hasło", "Ustawienia wyciszone"],
+      "testEvidence": ["Zapisz profil", "Zmień hasło", "Ustawienia wyciszone", "Voice Profiles Management"],
       "owner": "frontend-profile"
     },
     {

--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -1642,9 +1642,20 @@ describe('Database - Additional Coverage Tests', () => {
         source: 'test',
       });
 
-      const rows = await db._query(
-        'SELECT * FROM audit_logs WHERE workspace_id = ? AND entity_id = ? ORDER BY created_at ASC',
-        [workspaceId, created.id]
+      const lifecycleOrder = new Map([
+        ['voice_profile.created', 0],
+        ['voice_profile.updated', 1],
+        ['voice_profile.deleted', 2],
+      ]);
+      const rows = (
+        await db._query('SELECT * FROM audit_logs WHERE workspace_id = ? AND entity_id = ?', [
+          workspaceId,
+          created.id,
+        ])
+      ).sort(
+        (left: any, right: any) =>
+          (lifecycleOrder.get(left.action) ?? Number.MAX_SAFE_INTEGER) -
+          (lifecycleOrder.get(right.action) ?? Number.MAX_SAFE_INTEGER)
       );
       expect(rows.map((row: any) => row.action)).toEqual([
         'voice_profile.created',

--- a/src/ProfileTab.test.tsx
+++ b/src/ProfileTab.test.tsx
@@ -5,7 +5,7 @@
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { render, screen, within } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import ProfileTab from './ProfileTab';
 import { apiRequest } from './services/httpClient';
@@ -602,6 +602,144 @@ describe('ProfileTab', () => {
       await userEvent.click(screen.getByText(/Narz/));
 
       expect(await screen.findByText('Brak zapisanych próbek głosu')).toBeInTheDocument();
+    });
+  });
+
+  describe('Voice Profiles Management', () => {
+    it('renders a management table with profile status, samples, threshold, last update, and actions', async () => {
+      vi.mocked(apiRequest).mockResolvedValueOnce({
+        profiles: [
+          {
+            id: 'vp_adam',
+            speakerName: 'Adam',
+            userId: 'u1',
+            createdAt: '2026-05-21T10:00:00.000Z',
+            hasEmbedding: true,
+            sampleCount: 2,
+            threshold: 0.82,
+          },
+        ],
+      });
+
+      render(<ProfileTab {...baseProps} peopleProfiles={[{ name: 'Adam' }, { name: 'Ewa' }]} />);
+
+      await userEvent.click(screen.getByText(/Narz/));
+
+      const managementTable = await screen.findByRole('table', {
+        name: /Zarzadzanie profilami glosowymi/i,
+      });
+      expect(within(managementTable).getByRole('columnheader', { name: 'Osoba' })).toBeVisible();
+      expect(within(managementTable).getByRole('columnheader', { name: 'Probki' })).toBeVisible();
+      expect(within(managementTable).getByRole('columnheader', { name: 'Prog' })).toBeVisible();
+      expect(within(managementTable).getByRole('columnheader', { name: 'Status' })).toBeVisible();
+      expect(
+        within(managementTable).getByRole('columnheader', { name: 'Ostatnia aktualizacja' })
+      ).toBeVisible();
+      expect(within(managementTable).getByRole('columnheader', { name: 'Akcje' })).toBeVisible();
+
+      const adamRow = within(managementTable).getByRole('row', { name: /Adam/i });
+      expect(within(adamRow).getByText('2/5')).toBeInTheDocument();
+      expect(within(adamRow).getByTestId('voice-profile-management-status')).toHaveClass('ready');
+      expect(within(adamRow).getByLabelText('Prog rozpoznawania Adam')).toHaveValue('82');
+      expect(
+        within(adamRow).getByRole('button', { name: /Usun profil glosowy Adam/i })
+      ).toBeEnabled();
+    });
+
+    it('updates the profile threshold from the management row for workspace admins', async () => {
+      vi.mocked(apiRequest)
+        .mockResolvedValueOnce({
+          profiles: [
+            {
+              id: 'vp_adam',
+              speakerName: 'Adam',
+              userId: 'u1',
+              createdAt: '2026-05-21T10:00:00.000Z',
+              hasEmbedding: true,
+              sampleCount: 1,
+              threshold: 0.82,
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ id: 'vp_adam', threshold: 0.9 });
+
+      render(<ProfileTab {...baseProps} peopleProfiles={[{ name: 'Adam' }]} />);
+
+      await userEvent.click(screen.getByText(/Narz/));
+
+      const slider = await screen.findByLabelText('Prog rozpoznawania Adam');
+      fireEvent.change(slider, { target: { value: '90' } });
+      fireEvent.mouseUp(slider);
+
+      await waitFor(() => {
+        expect(apiRequest).toHaveBeenCalledWith('/voice-profiles/vp_adam/threshold', {
+          method: 'PATCH',
+          body: { threshold: 0.9 },
+        });
+      });
+    });
+
+    it('deletes a profile from the management row for workspace admins', async () => {
+      vi.mocked(apiRequest)
+        .mockResolvedValueOnce({
+          profiles: [
+            {
+              id: 'vp_adam',
+              speakerName: 'Adam',
+              userId: 'u1',
+              createdAt: '2026-05-21T10:00:00.000Z',
+              hasEmbedding: true,
+              sampleCount: 1,
+              threshold: 0.82,
+            },
+          ],
+        })
+        .mockResolvedValueOnce(undefined);
+
+      render(<ProfileTab {...baseProps} peopleProfiles={[{ name: 'Adam' }]} />);
+
+      await userEvent.click(screen.getByText(/Narz/));
+      await userEvent.click(
+        await screen.findByRole('button', { name: /Usun profil glosowy Adam/i })
+      );
+
+      await waitFor(() => {
+        expect(apiRequest).toHaveBeenCalledWith('/voice-profiles/vp_adam', {
+          method: 'DELETE',
+          parseAs: 'raw',
+        });
+      });
+      expect(
+        within(screen.getByTestId('voice-profile-person-adam')).getByTestId(
+          'voice-profile-management-status'
+        )
+      ).toHaveClass('empty');
+    });
+
+    it('keeps threshold and delete controls read-only for workspace members', async () => {
+      vi.mocked(apiRequest).mockResolvedValueOnce({
+        profiles: [
+          {
+            id: 'vp_adam',
+            speakerName: 'Adam',
+            userId: 'u1',
+            createdAt: '2026-05-21T10:00:00.000Z',
+            hasEmbedding: true,
+            sampleCount: 1,
+            threshold: 0.82,
+          },
+        ],
+      });
+
+      render(
+        <ProfileTab {...baseProps} workspaceRole="member" peopleProfiles={[{ name: 'Adam' }]} />
+      );
+
+      await userEvent.click(screen.getByText(/Narz/));
+
+      expect(await screen.findByLabelText('Prog rozpoznawania Adam')).toBeDisabled();
+      expect(screen.getByRole('button', { name: /Usun profil glosowy Adam/i })).toBeDisabled();
+      expect(screen.getByText(/Tylko owner lub admin/i)).toBeInTheDocument();
     });
   });
 

--- a/src/ProfileTab.tsx
+++ b/src/ProfileTab.tsx
@@ -13,6 +13,7 @@ import {
   RotateCw,
   ShieldCheck,
   Settings2,
+  Trash2,
   UserRound,
   UsersRound,
   Wrench,
@@ -176,9 +177,11 @@ function buildVoiceProfilePersonRows(
 function VoiceProfilesSection({
   peopleProfiles = [],
   sessionToken = '',
+  workspaceRole = 'member',
 }: {
   peopleProfiles?: Array<{ name: string }>;
   sessionToken?: string;
+  workspaceRole?: string;
 }) {
   const [profiles, setProfiles] = useState<VoiceProfileSummary[]>([]);
   const [isRecording, setIsRecording] = useState(false);
@@ -226,6 +229,10 @@ function VoiceProfilesSection({
   const selectedPersonRow = voiceProfileRows.find((row) => row.key === selectedPersonKey);
   const selectedPersonSampleCount = selectedPersonRow?.sampleCount ?? 0;
   const profiledPeopleCount = voiceProfileRows.filter((row) => row.sampleCount > 0).length;
+  const normalizedWorkspaceRole = String(workspaceRole || '').toLowerCase();
+  const canManageVoiceProfiles =
+    normalizedWorkspaceRole === 'owner' || normalizedWorkspaceRole === 'admin';
+  const voiceProfileReadonlyReason = 'Tylko owner lub admin moze zarzadzac profilami glosowymi.';
 
   async function startRecording() {
     if (!backendApiReady) {
@@ -309,25 +316,44 @@ function VoiceProfilesSection({
   }
 
   async function deleteProfile(id: string) {
+    if (!canManageVoiceProfiles) {
+      setStatus(voiceProfileReadonlyReason);
+      return;
+    }
     if (!sessionToken) {
       setStatus('Zaloguj sie ponownie, aby usunac profil glosowy.');
       return;
     }
-    await apiRequest(`/voice-profiles/${id}`, { method: 'DELETE', parseAs: 'raw' });
-    setProfiles((prev) => prev.filter((p: any) => p.id !== id));
+    try {
+      await apiRequest(`/voice-profiles/${id}`, { method: 'DELETE', parseAs: 'raw' });
+      setProfiles((prev) => prev.filter((p) => p.id !== id));
+      setStatus('Profil glosowy usuniety.');
+    } catch (err: any) {
+      setStatus(`Blad: ${err?.message || 'Nie udalo sie usunac profilu glosowego.'}`);
+    }
   }
 
   async function updateThreshold(id: string, threshold: number) {
-    if (!sessionToken) return;
+    if (!canManageVoiceProfiles) {
+      setStatus(voiceProfileReadonlyReason);
+      return;
+    }
+    if (!sessionToken) {
+      setStatus('Zaloguj sie ponownie, aby zmienic prog profilu glosowego.');
+      return;
+    }
     try {
       const updated = (await apiRequest(`/voice-profiles/${id}/threshold`, {
         method: 'PATCH',
         body: { threshold },
       })) as { id: string; threshold: number };
       setProfiles((prev) =>
-        prev.map((p: any) => (p.id === updated.id ? { ...p, threshold: updated.threshold } : p))
+        prev.map((p) => (p.id === updated.id ? { ...p, threshold: updated.threshold } : p))
       );
-    } catch (_) {}
+      setStatus('Prog profilu glosowego zapisany.');
+    } catch (err: any) {
+      setStatus(`Blad: ${err?.message || 'Nie udalo sie zapisac progu profilu glosowego.'}`);
+    }
   }
 
   function formatElapsed(s) {
@@ -335,7 +361,7 @@ function VoiceProfilesSection({
   }
 
   return (
-    <section className="panel">
+    <section className="panel profile-grid-span-two">
       <div className="panel-header compact">
         <div>
           <div className="eyebrow">AI</div>
@@ -408,17 +434,37 @@ function VoiceProfilesSection({
       </div>
 
       {voiceProfileRows.length > 0 ? (
-        <div className="voice-profiles-grouped">
+        <div
+          className="voice-profiles-grouped voice-profile-management"
+          role="table"
+          aria-label="Zarzadzanie profilami glosowymi"
+        >
+          <div className="voice-profile-management-header" role="row">
+            <span role="columnheader">Osoba</span>
+            <span role="columnheader">Probki</span>
+            <span role="columnheader">Prog</span>
+            <span role="columnheader">Status</span>
+            <span role="columnheader">Ostatnia aktualizacja</span>
+            <span role="columnheader">Akcje</span>
+          </div>
+          {!canManageVoiceProfiles ? (
+            <p className="voice-profile-permission-note">{voiceProfileReadonlyReason}</p>
+          ) : null}
           {voiceProfileRows.map((row) => {
             const lastSampleDate = formatVoiceProfileDate(row.lastSampleAt);
+            const statusLabelAscii = row.sampleCount > 0 ? 'Ma probke' : 'Brak probki';
 
             return (
               <div
                 key={row.key}
-                className={`voice-profile-person-group ${row.sampleCount > 0 ? 'has-sample' : 'no-sample'}`}
+                className={`voice-profile-person-group voice-profile-management-row ${
+                  row.sampleCount > 0 ? 'has-sample' : 'no-sample'
+                }`}
                 data-testid="voice-profile-person-row"
+                role="row"
+                aria-label={`${row.name} ${row.sampleCount}/5 ${statusLabelAscii}`}
               >
-                <div data-testid={row.testId}>
+                <div data-testid={row.testId} className="voice-profile-management-row-inner">
                   <div className="voice-profile-person-header">
                     <div className="voice-profile-avatar-wrap">
                       <span className="voice-profile-person-avatar">
@@ -433,6 +479,7 @@ function VoiceProfilesSection({
                       <div className="voice-profile-title-row">
                         <strong data-testid="voice-profile-person-name">{row.name}</strong>
                         <span
+                          data-testid="voice-profile-management-status"
                           className={`voice-profile-status-pill ${
                             row.sampleCount > 0 ? 'ready' : 'empty'
                           }`}
@@ -501,10 +548,15 @@ function VoiceProfilesSection({
                             type="button"
                             className="icon-button profile-delete-sample-btn"
                             onClick={() => deleteProfile(row.primaryProfile!.id)}
-                            title="Usuń profil głosowy"
-                            aria-label={`Usuń profil głosowy ${row.name}`}
+                            title={
+                              canManageVoiceProfiles
+                                ? 'Usun profil glosowy'
+                                : voiceProfileReadonlyReason
+                            }
+                            aria-label={`Usun profil glosowy ${row.name}`}
+                            disabled={!canManageVoiceProfiles}
                           >
-                            🗑
+                            <Trash2 size={16} aria-hidden="true" />
                           </button>
                         </div>
                         <div className="voice-profile-threshold-container">
@@ -521,6 +573,13 @@ function VoiceProfilesSection({
                             max="99"
                             step="1"
                             value={row.thresholdPct}
+                            aria-label={`Prog rozpoznawania ${row.name}`}
+                            disabled={!canManageVoiceProfiles}
+                            title={
+                              canManageVoiceProfiles
+                                ? 'Zmien prog rozpoznawania'
+                                : voiceProfileReadonlyReason
+                            }
                             onChange={(e) => {
                               const threshold = Number(e.target.value) / 100;
                               setProfiles((prev) =>
@@ -1948,7 +2007,11 @@ export default function ProfileTab({
         {activeCategory === 'tools' && (
           <div className="profile-category-view">
             <div className="profile-grid">
-              <VoiceProfilesSection peopleProfiles={peopleProfiles} sessionToken={sessionToken} />
+              <VoiceProfilesSection
+                peopleProfiles={peopleProfiles}
+                sessionToken={sessionToken}
+                workspaceRole={workspaceRole}
+              />
               <VocabularyManagerSection
                 vocabulary={vocabulary}
                 onUpdateVocabulary={onUpdateVocabulary}

--- a/src/ProfileTabStyles.css
+++ b/src/ProfileTabStyles.css
@@ -578,6 +578,41 @@
   margin-top: 20px;
 }
 
+.voice-profile-management {
+  overflow: hidden;
+}
+
+.voice-profile-management-header {
+  display: grid;
+  grid-template-columns: minmax(190px, 1.35fr) 0.7fr 0.9fr 0.85fr 1fr 74px;
+  gap: 12px;
+  align-items: center;
+  padding: 0 8px 4px;
+  color: var(--muted);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.voice-profile-permission-note {
+  margin: 0;
+  padding: 10px 12px;
+  border: 1px solid rgba(245, 158, 11, 0.2);
+  border-radius: 8px;
+  background: rgba(245, 158, 11, 0.08);
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+.voice-profile-management-row {
+  margin: 0;
+}
+
+.voice-profile-management-row-inner {
+  min-width: 0;
+}
+
 .voice-profile-person-group {
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.08);
@@ -809,6 +844,12 @@
 
 .profile-delete-sample-btn:hover {
   background: rgba(239, 68, 68, 0.1);
+}
+
+.profile-delete-sample-btn:disabled,
+.vp-threshold-slider:disabled {
+  cursor: not-allowed;
+  opacity: 0.45;
 }
 
 .voice-profile-threshold-container {
@@ -1065,6 +1106,10 @@
 }
 
 @media (max-width: 720px) {
+  .voice-profile-management-header {
+    display: none;
+  }
+
   .voice-profile-metrics-row {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }


### PR DESCRIPTION
## Issue
Closes #1336

## Changes
- Adds a full-width voice profile management surface in Profile > Narzedzia AI.
- Shows profile rows with person, sample count, threshold, status, last update, and delete action.
- Gates threshold edits and deletes to owner/admin roles on the frontend, matching the backend permission model.
- Updates the Profile UI action contract fingerprint and evidence.

## Tests run
- RED first: `node_modules\\.bin\\vitest.cmd run src\\ProfileTab.test.tsx --coverage.enabled=false` failed on the new management table/threshold/delete/role tests before implementation.
- `node_modules\\.bin\\vitest.cmd run src\\ProfileTab.test.tsx --coverage.enabled=false`
- `node_modules\\.bin\\vitest.cmd run src\\ProfileTab.comprehensive.test.tsx --coverage.enabled=false`
- `node_modules\\.bin\\vitest.cmd run src\\ProfileTab.test.tsx src\\ProfileTab.comprehensive.test.tsx --coverage.enabled=false`
- `node_modules\\.bin\\tsc.cmd --noEmit`
- `node_modules\\.bin\\prettier.cmd --check docs\\testing\\ui-action-contracts.json src\\ProfileTab.tsx src\\ProfileTabStyles.css src\\ProfileTab.test.tsx`
- `node scripts\\audit-mojibake.mjs`
- `node scripts\\audit-ui-action-contracts.mjs --write-report` confirms Profile fingerprint `f2f33d285234a017`; local Windows run still reports the pre-existing Calendar fingerprint mismatch.
- Local Playwright visual smoke: `reports/issue-1336-profile-management-1440x900.png`, `reports/issue-1336-profile-management-900x900.png`, `reports/issue-1336-profile-management-390x844.png`, `reports/issue-1336-profile-management-table-390x844.png`; no console errors or horizontal overflow in the responsive smoke.
- Pre-push release guard passed: `test:server:retry`, focused frontend/hook guard tests, `audit:build-warnings` production build.

## Known risks
- The manual local UI action audit still reports an unrelated Calendar fingerprint mismatch on Windows (`Calendar src/CalendarTab.tsx`); this PR only changes and updates the Profile contract.
- Mobile element screenshot starts within the scrolled profile table because the app shell has its own scroll container; the responsive smoke still found the table and controls and passed overflow/console checks.

## Follow-up tasks
- Consider a dedicated compact row layout for voice profiles if the team wants stricter table alignment beyond the current card-row management view.