### PR TITLE
feat(observability): add structured pipeline logging

### DIFF
--- a/server/http/app-security.ts
+++ b/server/http/app-security.ts
@@ -222,7 +222,7 @@ export function registerNotFoundHandler(app: Hono<any>, allowedOrigins = 'http:/
 export function registerAppErrorHandler(app: Hono<any>, allowedOrigins = 'http://localhost:3000') {
   app.onError((err: any, c) => {
     setSecurityHeaders(c);
-    console.error('APP ERROR STACK', err.stack);
+    logger.error('APP ERROR STACK', err, { sentry: false });
 
     // Ensure CORS headers are always present on error responses.
     // app.onError creates a new response that may bypass the cors middleware's

--- a/server/lib/structuredLogger.ts
+++ b/server/lib/structuredLogger.ts
@@ -1,85 +1,136 @@
 /**
  * Structured JSON Logger
  *
- * Replaces console.log/warn/error with structured JSON output
- * for better observability in production (log aggregation, filtering, alerting).
- *
- * Usage:
- *   import { logger } from './lib/structuredLogger.ts';
- *   logger.info('Server started', { port: 4000, env: 'production' });
- *   logger.error('Database connection failed', { error: err.message, code: err.code });
- *
- * Output format:
- *   {"level":"info","timestamp":"2026-04-04T12:00:00.000Z","message":"Server started","data":{"port":4000,"env":"production"}}
+ * Production logs are emitted as one JSON object per line so log backends can
+ * filter by requestId, workspaceId, recordingId, jobId, route, status, stage,
+ * durationMs, and errorCode without scraping text.
  */
-
-import { format } from 'node:util';
 
 type LogLevel = 'debug' | 'info' | 'warn' | 'error';
 
 interface LogEntry {
   level: LogLevel;
   timestamp: string;
+  service: string;
   message: string;
   data?: Record<string, unknown>;
-  requestId?: string;
-  service?: string;
 }
 
 const SERVICE_NAME = process.env.SERVICE_NAME || 'voicelog-server';
+const REDACTED = '[redacted]';
+const MAX_REDACTION_DEPTH = 5;
+const SENSITIVE_KEY_PATTERN =
+  /(authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|password|secret|transcript|segments|audio|buffer|raw|payload)/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeError(error: Error) {
+  const enriched = error as Error & {
+    code?: unknown;
+    errorCode?: unknown;
+    status?: unknown;
+    statusCode?: unknown;
+  };
+
+  return {
+    name: error.name,
+    message: error.message,
+    ...(enriched.code ? { code: String(enriched.code) } : {}),
+    ...(enriched.errorCode ? { errorCode: String(enriched.errorCode) } : {}),
+    ...(enriched.status ? { status: Number(enriched.status) } : {}),
+    ...(enriched.statusCode ? { statusCode: Number(enriched.statusCode) } : {}),
+  };
+}
+
+function redactValue(value: unknown, key = '', depth = 0): unknown {
+  if (SENSITIVE_KEY_PATTERN.test(key)) return REDACTED;
+  if (value instanceof Error) return normalizeError(value);
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (depth >= MAX_REDACTION_DEPTH) return '[truncated]';
+  if (Array.isArray(value)) return value.map((item) => redactValue(item, key, depth + 1));
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, entryValue]) => [
+        entryKey,
+        redactValue(entryValue, entryKey, depth + 1),
+      ])
+    );
+  }
+  return String(value);
+}
+
+function normalizeLogData(data?: unknown): Record<string, unknown> | undefined {
+  if (data === null || data === undefined) return undefined;
+  if (data instanceof Error) return { error: normalizeError(data) };
+  if (isPlainObject(data)) {
+    const redacted = redactValue(data);
+    return isPlainObject(redacted) && Object.keys(redacted).length > 0 ? redacted : undefined;
+  }
+  return { value: redactValue(data) };
+}
+
+function developmentData(data?: unknown) {
+  if (data instanceof Error) return data;
+  if (data !== null && data !== undefined && !isPlainObject(data)) return data;
+  const normalized = normalizeLogData(data);
+  return normalized && Object.keys(normalized).length > 0 ? normalized : '';
+}
 
 function formatLogEntry(level: LogLevel, message: string, data?: Record<string, unknown>): string {
   const entry: LogEntry = {
     level,
     timestamp: new Date().toISOString(),
+    service: SERVICE_NAME,
     message,
     ...(data && Object.keys(data).length > 0 ? { data } : {}),
   };
   return JSON.stringify(entry);
 }
 
-/**
- * Structured logger that outputs JSON logs in production
- * and human-readable logs in development.
- */
 export const structuredLogger = {
-  debug(message: string, data?: Record<string, unknown>): void {
+  debug(message: string, data?: unknown): void {
+    const normalized = normalizeLogData(data);
     if (process.env.LOG_LEVEL === 'debug') {
       if (process.env.NODE_ENV === 'production') {
-        process.stdout.write(formatLogEntry('debug', message, data) + '\n');
+        process.stdout.write(formatLogEntry('debug', message, normalized) + '\n');
       } else {
-        console.debug(`[DEBUG] ${message}`, data ? format(data) : '');
+        console.debug(`[DEBUG] ${message}`, developmentData(data));
       }
     }
   },
 
-  info(message: string, data?: Record<string, unknown>): void {
+  info(message: string, data?: unknown): void {
+    const normalized = normalizeLogData(data);
     if (process.env.NODE_ENV === 'production') {
-      process.stdout.write(formatLogEntry('info', message, data) + '\n');
+      process.stdout.write(formatLogEntry('info', message, normalized) + '\n');
     } else {
-      console.log(`[INFO] ${message}`, data ? format(data) : '');
+      console.log(`[INFO] ${message}`, developmentData(data));
     }
   },
 
-  warn(message: string, data?: Record<string, unknown>): void {
+  warn(message: string, data?: unknown): void {
+    const normalized = normalizeLogData(data);
     if (process.env.NODE_ENV === 'production') {
-      process.stderr.write(formatLogEntry('warn', message, data) + '\n');
+      process.stderr.write(formatLogEntry('warn', message, normalized) + '\n');
     } else {
-      console.warn(`[WARN] ${message}`, data ? format(data) : '');
+      console.warn(`[WARN] ${message}`, developmentData(data));
     }
   },
 
-  error(message: string, data?: Record<string, unknown>): void {
+  error(message: string, data?: unknown): void {
+    const normalized = normalizeLogData(data);
     if (process.env.NODE_ENV === 'production') {
-      process.stderr.write(formatLogEntry('error', message, data) + '\n');
+      process.stderr.write(formatLogEntry('error', message, normalized) + '\n');
     } else {
-      console.error(`[ERROR] ${message}`, data ? format(data) : '');
+      console.error(`[ERROR] ${message}`, developmentData(data));
     }
   },
 
-  /**
-   * Create a child logger with default context (e.g., requestId).
-   */
   child(context: Record<string, unknown>) {
     return {
       debug: (msg: string, data?: Record<string, unknown>) =>

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,5 +1,7 @@
-// Sentry is initialized in sentry.ts via initSentry() — no duplicate init here.
+// Sentry is initialized in sentry.ts via initSentry() - no duplicate init here.
 // Lazy-load @sentry/node to avoid pulling ~25MB into memory at startup.
+import { structuredLogger } from './lib/structuredLogger.ts';
+
 let _Sentry: any = null;
 let _sentryLoading: Promise<any> | null = null;
 
@@ -7,7 +9,6 @@ interface LoggerOptions {
   sentry?: boolean;
 }
 
-// Async version for when we need guaranteed Sentry access
 async function getSentryAsync(): Promise<any> {
   if (_Sentry) return _Sentry;
   if (!process.env.SENTRY_DSN) return null;
@@ -24,16 +25,16 @@ async function getSentryAsync(): Promise<any> {
 
 export const logger = {
   info: (msg: string, meta: any = {}) => {
-    console.log(`[INFO] ${msg}`, Object.keys(meta).length ? meta : '');
+    structuredLogger.info(msg, meta);
   },
   warn: (msg: string, meta: any = {}, options: LoggerOptions = {}) => {
-    console.warn(`[WARN] ${msg}`, Object.keys(meta).length ? meta : '');
+    structuredLogger.warn(msg, meta);
     if (process.env.SENTRY_DSN && options.sentry !== false) {
       getSentryAsync().then((s) => s?.captureMessage(msg, 'warning'));
     }
   },
   error: (msg: string, err: any = null, options: LoggerOptions = {}) => {
-    console.error(`[ERROR] ${msg}`, err || '');
+    structuredLogger.error(msg, err);
     if (process.env.SENTRY_DSN && options.sentry !== false) {
       getSentryAsync().then((s) => {
         if (err instanceof Error) {

--- a/server/pipeline.ts
+++ b/server/pipeline.ts
@@ -353,6 +353,8 @@ async function runTranscriptionAttempt(
         MetricsService.observeStageDuration(name, pipelineMetrics.stages[name]);
         logger.info(`[Metrics] Pipeline Stage Complete`, {
           requestId: reqId,
+          workspaceId: asset.workspace_id,
+          recordingId: asset.id,
           stage: name,
           durationMs: pipelineMetrics.stages[name],
         });
@@ -890,6 +892,7 @@ async function runTranscriptionAttempt(
       if (pipelineMetrics && pipelineMetrics.total > 0) {
         logger.info(`[Metrics] Pipeline Total Duration`, {
           requestId: pipelineMetrics.requestId,
+          workspaceId: asset.workspace_id,
           recordingId: asset.id,
           totalDurationMs: parseFloat(pipelineMetrics.total.toFixed(2)),
           stages: pipelineMetrics.stages,

--- a/server/services/TranscriptionService.ts
+++ b/server/services/TranscriptionService.ts
@@ -750,7 +750,9 @@ export default class TranscriptionService extends EventEmitter {
 
         logger.info('[Pipeline] Starting transcription job.', {
           requestId: reqId,
+          workspaceId: asset.workspace_id,
           recordingId,
+          jobId: activeJob?.id || '',
           processingMode,
         });
 
@@ -839,7 +841,9 @@ export default class TranscriptionService extends EventEmitter {
 
         logger.info('[Metrics] Pipeline completed successfully.', {
           requestId: reqId,
+          workspaceId: asset.workspace_id,
           recordingId,
+          jobId: activeJob?.id || '',
           durationMs: (performance.now() - startSTT).toFixed(2),
           confidence: result.diarization?.confidence || 0,
         });
@@ -856,12 +860,25 @@ export default class TranscriptionService extends EventEmitter {
       })
       .catch(async (error: any) => {
         try {
+          const { logger } = await import('../logger.ts');
           const failureDiagnostics = buildFailureDiagnostics(error);
           const currentJob =
             activeJob ||
             (typeof this.db.getTranscriptionJobByRecordingId === 'function'
               ? await this.db.getTranscriptionJobByRecordingId(recordingId)
               : null);
+          logger.error('[Pipeline] Transcription job failed.', {
+            requestId: options.requestId || 'internal-stt',
+            workspaceId: asset.workspace_id,
+            recordingId,
+            jobId: currentJob?.id || activeJob?.id || '',
+            errorCode:
+              error?.errorCode ||
+              error?.code ||
+              failureDiagnostics?.errorCode ||
+              'TRANSCRIPTION_JOB_FAILED',
+            message: error?.message || String(error || 'Unknown pipeline error'),
+          });
           if (currentJob && typeof this.db.failTranscriptionJob === 'function') {
             await this.db.failTranscriptionJob(currentJob.id, this.workerId, error);
           }
@@ -964,6 +981,7 @@ export default class TranscriptionService extends EventEmitter {
 
       logger.info('[Pipeline] Background post-process completed.', {
         requestId: reqId,
+        workspaceId: asset.workspace_id,
         recordingId,
       });
     } catch (error: any) {
@@ -973,6 +991,7 @@ export default class TranscriptionService extends EventEmitter {
       });
       logger.warn('[Pipeline] Background post-process failed.', {
         requestId: reqId,
+        workspaceId: asset.workspace_id,
         recordingId,
         message: error?.message || String(error),
       });

--- a/server/tests/logger.test.ts
+++ b/server/tests/logger.test.ts
@@ -10,10 +10,13 @@ vi.mock('@sentry/node', () => ({
 
 describe('logger.ts', () => {
   let originalSentryDsn: string | undefined;
+  let originalNodeEnv: string | undefined;
 
   beforeEach(() => {
     vi.resetModules();
     originalSentryDsn = process.env.SENTRY_DSN;
+    originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'development';
     delete process.env.SENTRY_DSN;
   });
 
@@ -25,6 +28,11 @@ describe('logger.ts', () => {
       process.env.SENTRY_DSN = originalSentryDsn;
     } else {
       delete process.env.SENTRY_DSN;
+    }
+    if (originalNodeEnv !== undefined) {
+      process.env.NODE_ENV = originalNodeEnv;
+    } else {
+      delete process.env.NODE_ENV;
     }
   });
 
@@ -110,5 +118,54 @@ describe('logger.ts', () => {
     await Promise.resolve();
     expect(mockCaptureMessage).not.toHaveBeenCalled();
     expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  test('emits production info logs as structured JSON through the public logger', async () => {
+    process.env.NODE_ENV = 'production';
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const { logger } = await import('../logger.ts');
+
+    logger.info('request completed', {
+      requestId: 'req-1',
+      workspaceId: 'ws-1',
+      route: '/health',
+      status: 200,
+      durationMs: '12.30',
+    });
+
+    const parsed = JSON.parse((writeSpy.mock.calls[0][0] as string).trim());
+    expect(parsed).toMatchObject({
+      level: 'info',
+      service: 'voicelog-server',
+      message: 'request completed',
+      data: {
+        requestId: 'req-1',
+        workspaceId: 'ws-1',
+        route: '/health',
+        status: 200,
+        durationMs: '12.30',
+      },
+    });
+  });
+
+  test('production logger redacts token and transcript fields before writing JSON', async () => {
+    process.env.NODE_ENV = 'production';
+    const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+    const { logger } = await import('../logger.ts');
+
+    logger.info('pipeline data', {
+      requestId: 'req-2',
+      accessToken: 'secret-token',
+      transcriptJson: 'private transcript',
+    });
+
+    const parsed = JSON.parse((writeSpy.mock.calls[0][0] as string).trim());
+    expect(parsed.data).toMatchObject({
+      requestId: 'req-2',
+      accessToken: '[redacted]',
+      transcriptJson: '[redacted]',
+    });
+    expect(JSON.stringify(parsed)).not.toContain('secret-token');
+    expect(JSON.stringify(parsed)).not.toContain('private transcript');
   });
 });

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -1988,8 +1988,11 @@ describe('Media Routes', () => {
       expect(res.status).toBe(403);
       expect(mockTranscriptionService.deleteMediaAsset).not.toHaveBeenCalled();
       expect(consoleErrorSpy).toHaveBeenCalledWith(
-        'APP ERROR STACK',
-        expect.stringContaining('Nie masz dostepu do tego workspace.')
+        '[ERROR] APP ERROR STACK',
+        expect.objectContaining({
+          message: 'Nie masz dostepu do tego workspace.',
+          statusCode: 403,
+        })
       );
     });
   });

--- a/server/tests/structuredLogger.test.ts
+++ b/server/tests/structuredLogger.test.ts
@@ -32,8 +32,43 @@ describe('structuredLogger.ts', () => {
       const parsed = JSON.parse(output);
       expect(parsed.level).toBe('info');
       expect(parsed.message).toBe('Server started');
+      expect(parsed.service).toBe('voicelog-server');
       expect(parsed.data).toEqual({ port: 4000 });
       expect(parsed).toHaveProperty('timestamp');
+    });
+
+    test('redacts secrets and transcript-like payloads in production JSON', async () => {
+      process.env.NODE_ENV = 'production';
+      const writeSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+      const { structuredLogger } = await import('../lib/structuredLogger.js');
+
+      structuredLogger.info('Pipeline payload received', {
+        requestId: 'req-1',
+        workspaceId: 'ws-1',
+        recordingId: 'rec-1',
+        accessToken: 'secret-token',
+        transcript: 'private transcript',
+        nested: {
+          api_key: 'sk-secret',
+          safe: 'kept',
+        },
+      });
+
+      const parsed = JSON.parse((writeSpy.mock.calls[0][0] as string).trim());
+      expect(parsed.data).toEqual({
+        requestId: 'req-1',
+        workspaceId: 'ws-1',
+        recordingId: 'rec-1',
+        accessToken: '[redacted]',
+        transcript: '[redacted]',
+        nested: {
+          api_key: '[redacted]',
+          safe: 'kept',
+        },
+      });
+      expect(JSON.stringify(parsed)).not.toContain('secret-token');
+      expect(JSON.stringify(parsed)).not.toContain('private transcript');
+      expect(JSON.stringify(parsed)).not.toContain('sk-secret');
     });
   });
 

--- a/server/tests/transcription.test.ts
+++ b/server/tests/transcription.test.ts
@@ -117,6 +117,7 @@ describe('TranscriptionService', () => {
   });
 
   it('deduplicates in-flight transcription jobs and persists successful results', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
     const service = new TranscriptionService(
       mockDb,
       mockWorkspaceService,
@@ -140,11 +141,13 @@ describe('TranscriptionService', () => {
     const asset = { id: 'asset_1', file_path: 'test.wav', workspace_id: 'ws_1' };
 
     service.ensureTranscriptionJob('rec_1', asset, {
+      requestId: 'req-rec-1',
       participants: ['Kasia'],
       vocabulary: 'lead',
       processingMode: 'fast',
     });
     service.ensureTranscriptionJob('rec_1', asset, {
+      requestId: 'req-rec-1',
       participants: ['Kasia'],
       vocabulary: 'lead',
       processingMode: 'fast',
@@ -166,6 +169,24 @@ describe('TranscriptionService', () => {
     expect(mockDb.saveTranscriptionResult).toHaveBeenCalledWith(
       'rec_1',
       expect.objectContaining({ pipelineStatus: 'completed' })
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      '[INFO] [Pipeline] Starting transcription job.',
+      expect.objectContaining({
+        requestId: 'req-rec-1',
+        workspaceId: 'ws_1',
+        recordingId: 'rec_1',
+        jobId: '',
+      })
+    );
+    expect(logSpy).toHaveBeenCalledWith(
+      '[INFO] [Metrics] Pipeline completed successfully.',
+      expect.objectContaining({
+        requestId: 'req-rec-1',
+        workspaceId: 'ws_1',
+        recordingId: 'rec_1',
+        jobId: '',
+      })
     );
     expect(mockDb.queueTranscription).not.toHaveBeenCalled();
     expect(service.transcriptionJobs.has('rec_1')).toBe(false);
@@ -324,6 +345,7 @@ describe('TranscriptionService', () => {
   }, 10000);
 
   it('Regression: #0 - persists retryable STT rate-limit diagnostics on failure', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
     const service = new TranscriptionService(
       mockDb,
       mockWorkspaceService,
@@ -348,9 +370,19 @@ describe('TranscriptionService', () => {
     mockAudioPipeline.transcribeRecording.mockRejectedValue(failure);
     const asset = { id: 'asset_429', file_path: 'test.wav', workspace_id: 'ws_1' };
 
-    service.ensureTranscriptionJob('rec_429', asset, {});
+    service.ensureTranscriptionJob('rec_429', asset, { requestId: 'req-429' });
     await service.transcriptionJobs.get('rec_429');
 
+    expect(errorSpy).toHaveBeenCalledWith(
+      '[ERROR] [Pipeline] Transcription job failed.',
+      expect.objectContaining({
+        requestId: 'req-429',
+        workspaceId: 'ws_1',
+        recordingId: 'rec_429',
+        jobId: '',
+        errorCode: 'stt_rate_limited',
+      })
+    );
     expect(mockDb.markTranscriptionFailure).toHaveBeenCalledWith(
       'rec_429',
       'Rate limit reached for audio transcriptions.',


### PR DESCRIPTION
## Issue
Closes #1238

## Changes
- Routed the public backend logger through structured production JSON logging while preserving readable development output and Sentry forwarding.
- Added redaction for token/API key/secret/transcript/audio-like fields before production JSON logs are written.
- Added request/workspace/recording/job correlation fields to transcription job lifecycle and pipeline metric logs.
- Moved app error stack logging through the public logger and updated route regression expectations.

## Tests run
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\structuredLogger.test.ts server\\tests\\logger.test.ts server\\tests\\http\\app-security.test.ts server\\tests\\transcription.test.ts server\\tests\\services\\TranscriptionService.additional.test.ts --coverage.enabled=false` (76 passed)
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\audio-pipeline.unit.test.ts server\\tests\\pipeline-coverage.test.ts --coverage.enabled=false` (43 passed)
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\routes\\media.test.ts --coverage.enabled=false` (49 passed)
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts --retry=3` (95 files passed, 1366 tests passed, 82 skipped)
- `node_modules\\.bin\\tsc.cmd --project server\\tsconfig.server.json --noEmit`
- `node_modules\\.bin\\tsc.cmd --noEmit`
- `node scripts\\audit-mojibake.mjs`
- `git diff --check`
- Pre-push release guard: backend retry suite, frontend guard tests, build warning audit, production build

## Known risks
- Production logs now emit JSON lines for public logger calls; any manual log scraping that expects `[INFO]` text in production should switch to JSON fields.
- Some direct `console.*` calls remain outside the touched media/transcription critical path and can be migrated in follow-up work.

## Follow-up tasks
- Extend structured logging to non-critical backend modules that still write directly to console.
- Add log sampling or level controls if production volume becomes too high.