### PR TITLE
feat(observability): add Sentry pipeline context

### DIFF
--- a/docs/ops/SENTRY_AUDIO_PIPELINE_ALERTS.md
+++ b/docs/ops/SENTRY_AUDIO_PIPELINE_ALERTS.md
@@ -1,0 +1,88 @@
+# Sentry Audio Pipeline Alerts
+
+## Scope
+
+This runbook covers Sentry alert setup for recording upload, transcription queue,
+STT pipeline, retry, fallback analysis, and stuck-job failures. Events must be
+safe to inspect: use ids and status fields only, never raw audio, transcript,
+segments, prompts, API keys, tokens, or request payloads.
+
+## Required Event Context
+
+Backend events use the `audio_pipeline` context. Frontend queue events use the
+`recording_queue` context.
+
+Required searchable tags:
+
+- `workspaceId`
+- `recordingId`
+- `jobId` when a durable job exists
+- `pipelineStage`
+- `providerId` when the STT or AI provider is known
+- `errorCode`
+
+Expected warning-level events:
+
+- upload validation failures
+- rate limits and retryable provider failures
+- AI analysis fallback after transcript preservation
+- background post-process failures
+
+Error-level events:
+
+- non-retryable STT failure
+- queue failure after retries are exhausted
+- upload storage failures such as `ENOSPC`
+- transcription start/retry failures that return 5xx without a retryable code
+
+## Alert Rules
+
+Create these Sentry issue or metric alerts after deploy.
+
+### High Failed Transcription Rate
+
+- Filter: `errorCode:TRANSCRIPTION_JOB_FAILED OR errorCode:stt_failed OR errorCode:stt_rate_limited`
+- Environment: `production`
+- Threshold: more than 5 events in 10 minutes
+- Grouping: `errorCode`, `providerId`, `pipelineStage`
+- Action: page/on-call if non-retryable, Slack/email if retryable.
+
+### Stuck Jobs
+
+- Filter: `pipelineStage:job_capacity_wait OR errorCode:BACKGROUND_TRANSCRIPTION_PENDING`
+- Environment: `production`
+- Threshold: more than 10 warning events in 30 minutes
+- Action: check Railway memory, queue depth, durable job leases, and `/health`.
+
+### No-Key Or Fallback Analysis Rate
+
+- Filter: `pipelineStage:ai_analysis AND errorCode:AI_ANALYSIS_FAILED`
+- Environment: `production`
+- Threshold: more than 3 warning events in 15 minutes
+- Action: verify AI provider keys, quota, fallback mode, and user-visible status.
+
+### Upload Validation Spike
+
+- Filter: `pipelineStage:upload_validation`
+- Environment: `production`
+- Threshold: more than 20 warning events in 10 minutes
+- Action: inspect content types, max-size failures, browser/client release, and abuse signals.
+
+## Manual Verification Checklist
+
+After deploy:
+
+- Upload one valid short audio file and confirm no error-level Sentry event is created.
+- Trigger one invalid MIME upload in staging or preview and confirm a warning event has `pipelineStage=upload_validation`.
+- Trigger or simulate one transcription failure and confirm the event includes `workspaceId`, `recordingId`, `pipelineStage`, and `errorCode`.
+- Confirm the event payload does not contain transcript text, segment text, audio bytes, tokens, or raw request payloads.
+- Confirm frontend queue failure events use `recording_queue` context and the same `recordingId`.
+
+## Release Evidence
+
+Attach to the PR or release note:
+
+- Sentry issue/event link for the test validation failure.
+- Sentry issue/event link for the simulated pipeline failure.
+- Screenshot or export of alert rules.
+- Test command output for Sentry context redaction and queue failure coverage.

--- a/server/lib/sentryContext.ts
+++ b/server/lib/sentryContext.ts
@@ -1,0 +1,93 @@
+export type SentryContextLevel = 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+
+export interface AudioPipelineSentryContext extends Record<string, unknown> {
+  requestId?: string;
+  workspaceId?: string;
+  recordingId?: string;
+  jobId?: string;
+  pipelineStage?: string;
+  providerId?: string;
+  errorCode?: string;
+  operation?: string;
+  retryable?: boolean;
+}
+
+export interface SentryCaptureOptions {
+  level?: SentryContextLevel;
+  fingerprint?: string[];
+}
+
+const REDACTED = '[redacted]';
+const MAX_DEPTH = 5;
+const SENSITIVE_KEY_PATTERN =
+  /(authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|password|secret|transcript|segments|audio|buffer|raw|payload)/i;
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeError(error: Error) {
+  const enriched = error as Error & {
+    code?: unknown;
+    errorCode?: unknown;
+    status?: unknown;
+    statusCode?: unknown;
+  };
+
+  return {
+    name: error.name,
+    message: error.message,
+    ...(enriched.code ? { code: String(enriched.code) } : {}),
+    ...(enriched.errorCode ? { errorCode: String(enriched.errorCode) } : {}),
+    ...(enriched.status ? { status: Number(enriched.status) } : {}),
+    ...(enriched.statusCode ? { statusCode: Number(enriched.statusCode) } : {}),
+  };
+}
+
+export function sanitizeSentryValue(value: unknown, key = '', depth = 0): unknown {
+  if (SENSITIVE_KEY_PATTERN.test(key)) return REDACTED;
+  if (value instanceof Error) return normalizeError(value);
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (depth >= MAX_DEPTH) return '[truncated]';
+  if (Array.isArray(value)) {
+    return value.map((item) => sanitizeSentryValue(item, key, depth + 1));
+  }
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, entryValue]) => [
+        entryKey,
+        sanitizeSentryValue(entryValue, entryKey, depth + 1),
+      ])
+    );
+  }
+  return String(value);
+}
+
+export function sanitizeSentryContext(
+  context: AudioPipelineSentryContext | undefined
+): Record<string, unknown> {
+  if (!context || !isPlainObject(context)) return {};
+  const sanitized = sanitizeSentryValue(context);
+  return isPlainObject(sanitized) ? sanitized : {};
+}
+
+export function sentryTagsFromContext(context: Record<string, unknown>) {
+  const tags: Record<string, string> = {};
+  for (const key of [
+    'workspaceId',
+    'recordingId',
+    'jobId',
+    'pipelineStage',
+    'providerId',
+    'errorCode',
+  ]) {
+    const value = context[key];
+    if (value !== undefined && value !== null && value !== '') {
+      tags[key] = String(value).slice(0, 200);
+    }
+  }
+  return tags;
+}

--- a/server/logger.ts
+++ b/server/logger.ts
@@ -1,5 +1,11 @@
 // Sentry is initialized in sentry.ts via initSentry() - no duplicate init here.
 // Lazy-load @sentry/node to avoid pulling ~25MB into memory at startup.
+import {
+  sanitizeSentryContext,
+  sentryTagsFromContext,
+  type AudioPipelineSentryContext,
+  type SentryContextLevel,
+} from './lib/sentryContext.ts';
 import { structuredLogger } from './lib/structuredLogger.ts';
 
 let _Sentry: any = null;
@@ -7,6 +13,9 @@ let _sentryLoading: Promise<any> | null = null;
 
 interface LoggerOptions {
   sentry?: boolean;
+  sentryContext?: AudioPipelineSentryContext;
+  sentryLevel?: SentryContextLevel;
+  fingerprint?: string[];
 }
 
 async function getSentryAsync(): Promise<any> {
@@ -23,6 +32,39 @@ async function getSentryAsync(): Promise<any> {
   return _sentryLoading;
 }
 
+function resolveSentryContext(data: unknown, options: LoggerOptions) {
+  if (options.sentryContext) return sanitizeSentryContext(options.sentryContext);
+  if (data && typeof data === 'object' && !(data instanceof Error) && !Array.isArray(data)) {
+    return sanitizeSentryContext(data as AudioPipelineSentryContext);
+  }
+  return {};
+}
+
+function captureWithContext(
+  sentry: any,
+  action: (scope: any) => void,
+  context: Record<string, unknown>,
+  options: LoggerOptions
+) {
+  if (!sentry?.withScope) {
+    action(null);
+    return;
+  }
+  sentry.withScope((scope: any) => {
+    if (options.sentryLevel) scope.setLevel(options.sentryLevel);
+    if (Object.keys(context).length > 0) {
+      scope.setContext('audio_pipeline', context);
+      for (const [key, value] of Object.entries(sentryTagsFromContext(context))) {
+        scope.setTag(key, value);
+      }
+    }
+    if (options.fingerprint?.length) {
+      scope.setFingerprint(options.fingerprint);
+    }
+    action(scope);
+  });
+}
+
 export const logger = {
   info: (msg: string, meta: any = {}) => {
     structuredLogger.info(msg, meta);
@@ -30,18 +72,36 @@ export const logger = {
   warn: (msg: string, meta: any = {}, options: LoggerOptions = {}) => {
     structuredLogger.warn(msg, meta);
     if (process.env.SENTRY_DSN && options.sentry !== false) {
-      getSentryAsync().then((s) => s?.captureMessage(msg, 'warning'));
+      const context = resolveSentryContext(meta, options);
+      getSentryAsync().then((s) => {
+        if (!s) return;
+        captureWithContext(
+          s,
+          () => s.captureMessage(msg, options.sentryLevel || 'warning'),
+          context,
+          options
+        );
+      });
     }
   },
   error: (msg: string, err: any = null, options: LoggerOptions = {}) => {
     structuredLogger.error(msg, err);
     if (process.env.SENTRY_DSN && options.sentry !== false) {
+      const context = resolveSentryContext(err, options);
       getSentryAsync().then((s) => {
-        if (err instanceof Error) {
-          s?.captureException(err);
-        } else {
-          s?.captureMessage(msg, 'error');
-        }
+        if (!s) return;
+        captureWithContext(
+          s,
+          () => {
+            if (err instanceof Error) {
+              s.captureException(err);
+            } else {
+              s.captureMessage(msg, options.sentryLevel || 'error');
+            }
+          },
+          context,
+          options
+        );
       });
     }
   },

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -35,6 +35,7 @@ import {
   splitNormalizedAudioIntoParts,
   validateAudioForTranscription,
 } from '../lib/mediaStoragePipeline.ts';
+import { addPipelineBreadcrumb, capturePipelineException } from '../sentry.ts';
 
 const AUDIO_CONTENT_TYPE_EXTENSIONS: Record<string, string[]> = {
   'audio/webm': ['.webm'],
@@ -853,6 +854,27 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
     const contentLength = parseInt(c.req.header('content-length') || '0', 10);
     if (contentLength > MAX_RAW_UPLOAD_BYTES) {
       const sizeValidation = validateRawUploadSize(contentLength);
+      capturePipelineException(
+        Object.assign(
+          new Error(
+            sizeValidation.ok === false ? sizeValidation.message : 'Audio upload too large.'
+          ),
+          {
+            code: sizeValidation.ok === false ? sizeValidation.code : 'audio_too_large',
+            statusCode: 413,
+          }
+        ),
+        {
+          requestId: reqId,
+          workspaceId,
+          recordingId,
+          pipelineStage: 'upload_validation',
+          operation: 'media.upload',
+          errorCode: sizeValidation.ok === false ? sizeValidation.code : 'audio_too_large',
+          contentLength,
+        },
+        { level: 'warning', fingerprint: ['audio-upload-validation', 'size'] }
+      );
       if (sizeValidation.ok !== false) {
         return c.json({ code: 'audio_too_large', message: 'Plik audio przekracza limit.' }, 413);
       }
@@ -867,6 +889,22 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
 
     const mimeValidation = validateAudioMimeType(c.req.header('content-type') || '');
     if (!mimeValidation.ok) {
+      capturePipelineException(
+        Object.assign(new Error(mimeValidation.message), {
+          code: mimeValidation.code,
+          statusCode: mimeValidation.status,
+        }),
+        {
+          requestId: reqId,
+          workspaceId,
+          recordingId,
+          pipelineStage: 'upload_validation',
+          operation: 'media.upload',
+          errorCode: mimeValidation.code,
+          contentType: c.req.header('content-type') || '',
+        },
+        { level: 'warning', fingerprint: ['audio-upload-validation', mimeValidation.code] }
+      );
       return c.json(
         { code: mimeValidation.code, message: mimeValidation.message },
         mimeValidation.status
@@ -914,12 +952,37 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       });
     } catch (uploadErr: any) {
       if (uploadErr instanceof MediaStoragePipelineError) {
+        capturePipelineException(
+          uploadErr,
+          {
+            requestId: reqId,
+            workspaceId,
+            recordingId,
+            pipelineStage: 'upload_validation',
+            operation: 'media.upload',
+            errorCode: uploadErr.code || 'audio_validation_failed',
+            retryable: false,
+          },
+          { level: 'warning', fingerprint: ['audio-upload-validation', uploadErr.code] }
+        );
         return c.json(audioValidationErrorBody(uploadErr), audioValidationErrorStatus(uploadErr));
       }
       if (
         (uploadErr as any).code === 'ENOSPC' ||
         String(uploadErr.message).includes('Brak miejsca na dysku')
       ) {
+        capturePipelineException(
+          uploadErr,
+          {
+            requestId: reqId,
+            workspaceId,
+            recordingId,
+            pipelineStage: 'upload_storage',
+            operation: 'media.upload',
+            errorCode: 'ENOSPC',
+          },
+          { level: 'error', fingerprint: ['audio-upload-storage', 'ENOSPC'] }
+        );
         return c.json(
           { message: 'Brak miejsca na dysku serwera. Skontaktuj sie z administratorem.' },
           507
@@ -938,6 +1001,16 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
     logger.info(`[Metrics] Uploaded audio chunk`, {
       requestId: reqId,
       recordingId,
+      workspaceId,
+      sizeBytes: asset.size_bytes,
+      durationMs: (performance.now() - uploadStart).toFixed(2),
+    });
+    addPipelineBreadcrumb('Audio upload completed.', {
+      requestId: reqId,
+      workspaceId,
+      recordingId,
+      pipelineStage: 'upload',
+      operation: 'media.upload',
       sizeBytes: asset.size_bytes,
       durationMs: (performance.now() - uploadStart).toFixed(2),
     });
@@ -1232,6 +1305,13 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       }
 
       try {
+        addPipelineBreadcrumb('Transcription start requested.', {
+          requestId: c.get('reqId'),
+          workspaceId: body.workspaceId || asset.workspace_id,
+          recordingId,
+          pipelineStage: 'job_start_request',
+          operation: 'transcription.start',
+        });
         const result = await startTranscriptionPipeline(recordingId, asset, {
           ...body,
           processingMode: resolveProcessingMode(body.processingMode),
@@ -1250,6 +1330,22 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       } catch (err: any) {
         console.error(`[transcribe] Pipeline error for ${recordingId}:`, err?.message);
         const status = err?.statusCode || err?.status || 500;
+        capturePipelineException(
+          err,
+          {
+            requestId: c.get('reqId'),
+            workspaceId: body.workspaceId || asset.workspace_id,
+            recordingId,
+            pipelineStage: 'job_start_request',
+            operation: 'transcription.start',
+            errorCode: err?.errorCode || err?.code || 'TRANSCRIPTION_START_FAILED',
+            retryable: status === 429 || status === 503,
+          },
+          {
+            level: status === 429 || status === 503 ? 'warning' : 'error',
+            fingerprint: ['audio-pipeline', 'transcription-start'],
+          }
+        );
         return c.json(
           { message: err?.message || 'Błąd przetwarzania transkrypcji.', recordingId },
           status
@@ -1355,6 +1451,14 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       }
 
       try {
+        addPipelineBreadcrumb('Transcription retry requested.', {
+          requestId: c.get('reqId'),
+          workspaceId: asset.workspace_id,
+          recordingId,
+          pipelineStage: 'retry',
+          operation: 'transcription.retry',
+          previousStatus: status || 'unknown',
+        });
         const result = await startTranscriptionPipeline(recordingId, asset, {
           workspaceId: asset.workspace_id,
           meetingId: asset.meeting_id,
@@ -1385,6 +1489,22 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       } catch (err: any) {
         console.error(`[retry-transcribe] Pipeline error for ${recordingId}:`, err?.message);
         const status = err?.statusCode || err?.status || 500;
+        capturePipelineException(
+          err,
+          {
+            requestId: c.get('reqId'),
+            workspaceId: asset.workspace_id,
+            recordingId,
+            pipelineStage: 'retry',
+            operation: 'transcription.retry',
+            errorCode: err?.errorCode || err?.code || 'TRANSCRIPTION_RETRY_FAILED',
+            retryable: status === 429 || status === 503,
+          },
+          {
+            level: status === 429 || status === 503 ? 'warning' : 'error',
+            fingerprint: ['audio-pipeline', 'transcription-retry'],
+          }
+        );
         return c.json(
           { message: err?.message || 'Błąd przetwarzania transkrypcji.', recordingId },
           status

--- a/server/sentry.ts
+++ b/server/sentry.ts
@@ -1,5 +1,12 @@
 import * as Sentry from '@sentry/node';
 import { logger } from './logger.js';
+import {
+  sanitizeSentryContext,
+  sentryTagsFromContext,
+  type AudioPipelineSentryContext,
+  type SentryCaptureOptions,
+  type SentryContextLevel,
+} from './lib/sentryContext.ts';
 import { resolveBuildMetadata } from './runtime.js';
 
 export function initSentry() {
@@ -29,9 +36,9 @@ export function initSentry() {
   }
 }
 
-export function captureException(error: Error) {
+export function captureException(error: Error, context?: AudioPipelineSentryContext) {
   try {
-    Sentry.captureException(error);
+    capturePipelineException(error, context);
   } catch (err) {
     // Fail silently if Sentry is not initialized
   }
@@ -44,3 +51,45 @@ export function addBreadcrumb(breadcrumb: Parameters<typeof Sentry.addBreadcrumb
     // Fail silently if Sentry is not initialized
   }
 }
+
+export function addPipelineBreadcrumb(
+  message: string,
+  context: AudioPipelineSentryContext = {},
+  options: {
+    category?: string;
+    level?: SentryContextLevel;
+  } = {}
+) {
+  addBreadcrumb({
+    category: options.category || 'audio.pipeline',
+    level: options.level || 'info',
+    message,
+    data: sanitizeSentryContext(context),
+  });
+}
+
+export function capturePipelineException(
+  error: unknown,
+  context: AudioPipelineSentryContext = {},
+  options: SentryCaptureOptions = {}
+) {
+  try {
+    const normalizedError = error instanceof Error ? error : new Error(String(error));
+    const sanitizedContext = sanitizeSentryContext(context);
+    Sentry.withScope((scope) => {
+      scope.setLevel(options.level || (sanitizedContext.retryable ? 'warning' : 'error'));
+      scope.setContext('audio_pipeline', sanitizedContext);
+      for (const [key, value] of Object.entries(sentryTagsFromContext(sanitizedContext))) {
+        scope.setTag(key, value);
+      }
+      if (options.fingerprint?.length) {
+        scope.setFingerprint(options.fingerprint);
+      }
+      Sentry.captureException(normalizedError);
+    });
+  } catch (err) {
+    // Fail silently if Sentry is not initialized
+  }
+}
+
+export { sanitizeSentryContext };

--- a/server/services/TranscriptionService.ts
+++ b/server/services/TranscriptionService.ts
@@ -6,6 +6,7 @@ import {
   parseMediaManifest,
 } from '../lib/mediaStoragePolicy.ts';
 import { requireVoiceProfileEmbedding } from '../lib/voiceProfileEmbedding.ts';
+import { addPipelineBreadcrumb, capturePipelineException } from '../sentry.ts';
 
 const VOICE_PROFILE_EMBEDDING_MODEL = 'voice-profile-embedding';
 const VOICE_PROFILE_EMBEDDING_VERSION = '1';
@@ -612,6 +613,14 @@ export default class TranscriptionService extends EventEmitter {
     if (durableJob) {
       this._durableJobContext.set(recordingId, { asset, options });
     }
+    addPipelineBreadcrumb('Transcription job enqueued.', {
+      requestId: options?.requestId || 'internal-stt',
+      workspaceId: asset?.workspace_id,
+      recordingId,
+      jobId: durableJob?.id || '',
+      pipelineStage: 'job_enqueue',
+      operation: 'transcription.enqueue',
+    });
 
     const rss = process.memoryUsage().rss;
     const atCapacity = this.transcriptionJobs.size >= TranscriptionService.MAX_CONCURRENT_JOBS;
@@ -623,6 +632,19 @@ export default class TranscriptionService extends EventEmitter {
         : `${this.transcriptionJobs.size} concurrent jobs (max ${TranscriptionService.MAX_CONCURRENT_JOBS})`;
       if (durableJob) {
         console.log(`[Pipeline] Durable job ${recordingId} remains queued (${reason}).`);
+        addPipelineBreadcrumb(
+          'Transcription job waiting for capacity.',
+          {
+            requestId: options?.requestId || 'internal-stt',
+            workspaceId: asset?.workspace_id,
+            recordingId,
+            jobId: durableJob?.id || '',
+            pipelineStage: 'job_capacity_wait',
+            operation: 'transcription.enqueue',
+            reason,
+          },
+          { level: 'warning' }
+        );
         if (memoryPressure && typeof global.gc === 'function') global.gc();
         return;
       }
@@ -631,6 +653,19 @@ export default class TranscriptionService extends EventEmitter {
         this._pendingQueue.push({ recordingId, asset, options });
         console.log(
           `[Pipeline] Queued job ${recordingId} (${reason}). Queue size: ${this._pendingQueue.length}`
+        );
+        addPipelineBreadcrumb(
+          'Legacy transcription job queued locally.',
+          {
+            requestId: options?.requestId || 'internal-stt',
+            workspaceId: asset?.workspace_id,
+            recordingId,
+            pipelineStage: 'job_capacity_wait',
+            operation: 'transcription.enqueue',
+            queueSize: this._pendingQueue.length,
+            reason,
+          },
+          { level: 'warning' }
         );
       }
       await this.queueTranscription(recordingId, options);
@@ -755,6 +790,15 @@ export default class TranscriptionService extends EventEmitter {
           jobId: activeJob?.id || '',
           processingMode,
         });
+        addPipelineBreadcrumb('Transcription job started.', {
+          requestId: reqId,
+          workspaceId: asset.workspace_id,
+          recordingId,
+          jobId: activeJob?.id || '',
+          pipelineStage: 'job_start',
+          operation: 'transcription.process',
+          processingMode,
+        });
 
         const markProcessingPromise = this.markTranscriptionProcessing(recordingId);
         const [wsState, memberNames, voiceProfiles] = await Promise.all([
@@ -804,6 +848,18 @@ export default class TranscriptionService extends EventEmitter {
               skipChunkVAD: processingMode !== 'full' || !config.VOICELOG_ENABLE_CHUNK_VAD,
               skipVoiceProfileMatch: processingMode !== 'full',
             });
+        addPipelineBreadcrumb('STT pipeline completed.', {
+          requestId: reqId,
+          workspaceId: asset.workspace_id,
+          recordingId,
+          jobId: activeJob?.id || '',
+          pipelineStage: 'stt',
+          operation: 'transcription.process',
+          providerId:
+            result?.transcriptionDiagnostics?.sttProviderInfo?.providerId ||
+            result?.transcriptionDiagnostics?.sttProviderInfo?.provider ||
+            '',
+        });
 
         const isEmptyTranscript = result?.transcriptOutcome === 'empty';
         this.emit(`progress-${recordingId}`, {
@@ -847,6 +903,15 @@ export default class TranscriptionService extends EventEmitter {
           durationMs: (performance.now() - startSTT).toFixed(2),
           confidence: result.diarization?.confidence || 0,
         });
+        addPipelineBreadcrumb('Recording result attached.', {
+          requestId: reqId,
+          workspaceId: asset.workspace_id,
+          recordingId,
+          jobId: activeJob?.id || '',
+          pipelineStage: 'attach_completion',
+          operation: 'transcription.complete',
+          durationMs: (performance.now() - startSTT).toFixed(2),
+        });
 
         if (!isEmptyTranscript && result.segments && result.segments.length > 0) {
           this.vectorizeTranscriptionResultToRAG(
@@ -867,17 +932,37 @@ export default class TranscriptionService extends EventEmitter {
             (typeof this.db.getTranscriptionJobByRecordingId === 'function'
               ? await this.db.getTranscriptionJobByRecordingId(recordingId)
               : null);
-          logger.error('[Pipeline] Transcription job failed.', {
+          const errorCode =
+            error?.errorCode ||
+            error?.code ||
+            failureDiagnostics?.errorCode ||
+            'TRANSCRIPTION_JOB_FAILED';
+          const sentryContext = {
             requestId: options.requestId || 'internal-stt',
             workspaceId: asset.workspace_id,
             recordingId,
             jobId: currentJob?.id || activeJob?.id || '',
-            errorCode:
-              error?.errorCode ||
-              error?.code ||
-              failureDiagnostics?.errorCode ||
-              'TRANSCRIPTION_JOB_FAILED',
-            message: error?.message || String(error || 'Unknown pipeline error'),
+            pipelineStage: 'failure',
+            operation: 'transcription.process',
+            errorCode,
+            retryable: Boolean(error?.retryable || failureDiagnostics?.retryable),
+            providerId:
+              error?.providerId ||
+              failureDiagnostics?.sttProviderInfo?.providerId ||
+              failureDiagnostics?.sttProviderInfo?.provider ||
+              '',
+          };
+          logger.error(
+            '[Pipeline] Transcription job failed.',
+            {
+              ...sentryContext,
+              message: error?.message || String(error || 'Unknown pipeline error'),
+            },
+            { sentry: false }
+          );
+          capturePipelineException(error, sentryContext, {
+            level: sentryContext.retryable ? 'warning' : 'error',
+            fingerprint: ['audio-pipeline', String(errorCode)],
           });
           if (currentJob && typeof this.db.failTranscriptionJob === 'function') {
             await this.db.failTranscriptionJob(currentJob.id, this.workerId, error);
@@ -950,6 +1035,13 @@ export default class TranscriptionService extends EventEmitter {
         enhancementsPending: true,
         postprocessStage: 'running',
       });
+      addPipelineBreadcrumb('Background post-process started.', {
+        requestId: reqId,
+        workspaceId: asset.workspace_id,
+        recordingId,
+        pipelineStage: 'postprocess',
+        operation: 'transcription.postprocess',
+      });
       this.emit(`progress-${recordingId}`, {
         progress: 100,
         enhancementsPending: true,
@@ -984,6 +1076,13 @@ export default class TranscriptionService extends EventEmitter {
         workspaceId: asset.workspace_id,
         recordingId,
       });
+      addPipelineBreadcrumb('Background post-process completed.', {
+        requestId: reqId,
+        workspaceId: asset.workspace_id,
+        recordingId,
+        pipelineStage: 'postprocess_complete',
+        operation: 'transcription.postprocess',
+      });
     } catch (error: any) {
       await this.updateTranscriptionMetadata(recordingId, {
         enhancementsPending: false,
@@ -995,6 +1094,19 @@ export default class TranscriptionService extends EventEmitter {
         recordingId,
         message: error?.message || String(error),
       });
+      capturePipelineException(
+        error,
+        {
+          requestId: reqId,
+          workspaceId: asset.workspace_id,
+          recordingId,
+          pipelineStage: 'postprocess_failure',
+          operation: 'transcription.postprocess',
+          errorCode: error?.errorCode || error?.code || 'POSTPROCESS_FAILED',
+          retryable: true,
+        },
+        { level: 'warning', fingerprint: ['audio-pipeline', 'postprocess'] }
+      );
     } finally {
       await cleanupLocalSource();
     }

--- a/server/tests/lib/sentryContext.test.ts
+++ b/server/tests/lib/sentryContext.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it } from 'vitest';
+import {
+  sanitizeSentryContext,
+  sanitizeSentryValue,
+  sentryTagsFromContext,
+} from '../../lib/sentryContext.ts';
+
+describe('sentryContext', () => {
+  it('returns empty context for missing or non-object input', () => {
+    expect(sanitizeSentryContext(undefined)).toEqual({});
+    expect(sanitizeSentryContext(null as never)).toEqual({});
+    expect(sanitizeSentryContext('not-context' as never)).toEqual({});
+  });
+
+  it('redacts sensitive fields recursively while preserving safe ids', () => {
+    const sanitized = sanitizeSentryContext({
+      requestId: 'req_1',
+      workspaceId: 'ws_1',
+      recordingId: 'rec_1',
+      accessToken: 'secret-token',
+      transcriptJson: 'private transcript',
+      nested: {
+        audioBuffer: Buffer.from('audio'),
+        safeValue: true,
+      },
+      attempts: [
+        {
+          providerId: 'openai',
+          rawPayload: { text: 'secret payload' },
+        },
+      ],
+    });
+
+    expect(sanitized).toMatchObject({
+      requestId: 'req_1',
+      workspaceId: 'ws_1',
+      recordingId: 'rec_1',
+      accessToken: '[redacted]',
+      transcriptJson: '[redacted]',
+      nested: {
+        audioBuffer: '[redacted]',
+        safeValue: true,
+      },
+      attempts: [
+        {
+          providerId: 'openai',
+          rawPayload: '[redacted]',
+        },
+      ],
+    });
+    expect(JSON.stringify(sanitized)).not.toContain('secret-token');
+    expect(JSON.stringify(sanitized)).not.toContain('private transcript');
+  });
+
+  it('normalizes Error values without stack traces', () => {
+    const error = Object.assign(new Error('STT failed'), {
+      code: 'stt_failed',
+      statusCode: 502,
+    });
+
+    expect(sanitizeSentryValue(error)).toEqual({
+      name: 'Error',
+      message: 'STT failed',
+      code: 'stt_failed',
+      statusCode: 502,
+    });
+  });
+
+  it('stringifies non-plain values and truncates very deep objects', () => {
+    const deep = { a: { b: { c: { d: { e: { f: 'too deep' } } } } } };
+
+    expect(sanitizeSentryValue(Symbol('provider'))).toBe('Symbol(provider)');
+    expect(sanitizeSentryValue(deep)).toEqual({
+      a: {
+        b: {
+          c: {
+            d: {
+              e: '[truncated]',
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it('builds searchable tags from populated context keys only', () => {
+    const longProvider = 'p'.repeat(240);
+
+    expect(
+      sentryTagsFromContext({
+        workspaceId: 'ws_1',
+        recordingId: 'rec_1',
+        jobId: '',
+        pipelineStage: 'stt',
+        providerId: longProvider,
+        errorCode: null,
+      })
+    ).toEqual({
+      workspaceId: 'ws_1',
+      recordingId: 'rec_1',
+      pipelineStage: 'stt',
+      providerId: 'p'.repeat(200),
+    });
+  });
+});

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -2,6 +2,17 @@ import { afterAll, afterEach, beforeAll, beforeEach, describe, it, expect, vi } 
 import fs from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
+
+const sentryMocks = vi.hoisted(() => ({
+  addPipelineBreadcrumb: vi.fn(),
+  capturePipelineException: vi.fn(),
+}));
+
+vi.mock('../../sentry.ts', () => ({
+  addPipelineBreadcrumb: sentryMocks.addPipelineBreadcrumb,
+  capturePipelineException: sentryMocks.capturePipelineException,
+}));
+
 import { createApp } from '../../app.ts';
 import { MAX_RAW_UPLOAD_BYTES, buildSegmentedMediaManifest } from '../../lib/mediaStoragePolicy.ts';
 import { createProgressToken, resetProgressTokensForTests } from '../../lib/progressTokens.ts';
@@ -86,6 +97,8 @@ describe('Media Routes', () => {
   afterEach(() => {
     vi.restoreAllMocks();
     vi.clearAllMocks();
+    sentryMocks.addPipelineBreadcrumb.mockClear();
+    sentryMocks.capturePipelineException.mockClear();
     // Reset fs state to default after each test
     setFsState();
   });
@@ -1605,6 +1618,21 @@ describe('Media Routes', () => {
       const data = await res.json();
       expect(data.message).toContain('STT provider unreachable');
       expect(data.recordingId).toBe('rec_err');
+      expect(sentryMocks.capturePipelineException).toHaveBeenCalledWith(
+        expect.any(Error),
+        expect.objectContaining({
+          workspaceId: 'ws_1',
+          recordingId: 'rec_err',
+          pipelineStage: 'job_start_request',
+          operation: 'transcription.start',
+          errorCode: 'TRANSCRIPTION_START_FAILED',
+          retryable: false,
+        }),
+        expect.objectContaining({
+          level: 'error',
+          fingerprint: ['audio-pipeline', 'transcription-start'],
+        })
+      );
     });
 
     it('POST /retry-transcribe returns error JSON when pipeline throws', async () => {

--- a/server/tests/sentry.test.ts
+++ b/server/tests/sentry.test.ts
@@ -2,10 +2,20 @@ import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const mockSentryInit = vi.fn();
 const mockCaptureException = vi.fn();
+const mockAddBreadcrumb = vi.fn();
+const mockScope = {
+  setLevel: vi.fn(),
+  setContext: vi.fn(),
+  setTag: vi.fn(),
+  setFingerprint: vi.fn(),
+};
+const mockWithScope = vi.fn((callback: (scope: typeof mockScope) => void) => callback(mockScope));
 
 vi.mock('@sentry/node', () => ({
   init: mockSentryInit,
   captureException: mockCaptureException,
+  addBreadcrumb: mockAddBreadcrumb,
+  withScope: mockWithScope,
 }));
 
 // Mock logger to avoid side effects
@@ -16,6 +26,7 @@ vi.mock('./logger.js', () => ({
 describe('sentry.ts', () => {
   beforeEach(() => {
     vi.resetModules();
+    vi.clearAllMocks();
     delete process.env.SENTRY_DSN;
     delete process.env.RAILWAY_GIT_COMMIT_SHA;
   });
@@ -62,10 +73,77 @@ describe('sentry.ts', () => {
     const err = new Error('test error');
     captureException(err);
     expect(mockCaptureException).toHaveBeenCalledWith(err);
+    expect(mockScope.setContext).toHaveBeenCalledWith('audio_pipeline', {});
   });
 
   test('fails silently when Sentry is not initialized', async () => {
     const { captureException } = await import('../sentry.js');
     expect(() => captureException(new Error('no sentry'))).not.toThrow();
+  });
+
+  test('redacts sensitive pipeline context before adding breadcrumbs', async () => {
+    const { addPipelineBreadcrumb } = await import('../sentry.js');
+
+    addPipelineBreadcrumb('Pipeline failed', {
+      requestId: 'req_1',
+      workspaceId: 'ws_1',
+      recordingId: 'rec_1',
+      accessToken: 'secret-token',
+      transcriptJson: 'private transcript',
+      audioBuffer: 'binary audio',
+    });
+
+    expect(mockAddBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'audio.pipeline',
+        data: expect.objectContaining({
+          requestId: 'req_1',
+          workspaceId: 'ws_1',
+          recordingId: 'rec_1',
+          accessToken: '[redacted]',
+          transcriptJson: '[redacted]',
+          audioBuffer: '[redacted]',
+        }),
+      })
+    );
+    expect(JSON.stringify(mockAddBreadcrumb.mock.calls[0][0])).not.toContain('private transcript');
+  });
+
+  test('captures pipeline exceptions with safe context and searchable tags', async () => {
+    const { capturePipelineException } = await import('../sentry.js');
+    const err = new Error('STT crashed');
+
+    capturePipelineException(
+      err,
+      {
+        requestId: 'req_2',
+        workspaceId: 'ws_1',
+        recordingId: 'rec_1',
+        jobId: 'job_1',
+        pipelineStage: 'stt',
+        providerId: 'openai',
+        errorCode: 'stt_failed',
+        segments: [{ text: 'private segment' }],
+      },
+      { level: 'warning', fingerprint: ['audio-pipeline', 'stt_failed'] }
+    );
+
+    expect(mockScope.setLevel).toHaveBeenCalledWith('warning');
+    expect(mockScope.setContext).toHaveBeenCalledWith(
+      'audio_pipeline',
+      expect.objectContaining({
+        requestId: 'req_2',
+        workspaceId: 'ws_1',
+        recordingId: 'rec_1',
+        jobId: 'job_1',
+        pipelineStage: 'stt',
+        providerId: 'openai',
+        errorCode: 'stt_failed',
+        segments: '[redacted]',
+      })
+    );
+    expect(mockScope.setTag).toHaveBeenCalledWith('recordingId', 'rec_1');
+    expect(mockScope.setFingerprint).toHaveBeenCalledWith(['audio-pipeline', 'stt_failed']);
+    expect(mockCaptureException).toHaveBeenCalledWith(err);
   });
 });

--- a/server/tests/transcription.test.ts
+++ b/server/tests/transcription.test.ts
@@ -1,4 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sentryMocks = vi.hoisted(() => ({
+  addPipelineBreadcrumb: vi.fn(),
+  capturePipelineException: vi.fn(),
+}));
+
+vi.mock('../sentry.ts', () => ({
+  addPipelineBreadcrumb: sentryMocks.addPipelineBreadcrumb,
+  capturePipelineException: sentryMocks.capturePipelineException,
+}));
+
 import TranscriptionService from '../services/TranscriptionService.ts';
 import { buildSegmentedMediaManifest } from '../lib/mediaStoragePolicy.ts';
 
@@ -59,6 +70,8 @@ describe('TranscriptionService', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    sentryMocks.addPipelineBreadcrumb.mockClear();
+    sentryMocks.capturePipelineException.mockClear();
   });
 
   it('falls back to injected audioPipeline and calls transcribeRecording', async () => {
@@ -381,6 +394,22 @@ describe('TranscriptionService', () => {
         recordingId: 'rec_429',
         jobId: '',
         errorCode: 'stt_rate_limited',
+      })
+    );
+    expect(sentryMocks.capturePipelineException).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        requestId: 'req-429',
+        workspaceId: 'ws_1',
+        recordingId: 'rec_429',
+        pipelineStage: 'failure',
+        operation: 'transcription.process',
+        errorCode: 'stt_rate_limited',
+        retryable: true,
+      }),
+      expect.objectContaining({
+        level: 'warning',
+        fingerprint: ['audio-pipeline', 'stt_rate_limited'],
       })
     );
     expect(mockDb.markTranscriptionFailure).toHaveBeenCalledWith(

--- a/src/sentry.test.ts
+++ b/src/sentry.test.ts
@@ -1,10 +1,25 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const sentryMocks = vi.hoisted(() => ({
-  init: vi.fn(),
-  browserTracingIntegration: vi.fn(() => ({ name: 'browser-tracing' })),
-  replayIntegration: vi.fn(() => ({ name: 'replay' })),
-}));
+const sentryMocks = vi.hoisted(() => {
+  const scope = {
+    setLevel: vi.fn(),
+    setContext: vi.fn(),
+    setTag: vi.fn(),
+    setFingerprint: vi.fn(),
+  };
+
+  return {
+    init: vi.fn(),
+    browserTracingIntegration: vi.fn(() => ({ name: 'browser-tracing' })),
+    replayIntegration: vi.fn(() => ({ name: 'replay' })),
+    addBreadcrumb: vi.fn(),
+    captureException: vi.fn(),
+    scope,
+    withScope: vi.fn((callback: (scope: unknown) => void) => {
+      callback(scope);
+    }),
+  };
+});
 
 vi.mock('@sentry/react', () => sentryMocks);
 
@@ -83,5 +98,68 @@ describe('initSentry', () => {
         integrations: [{ name: 'browser-tracing' }, { name: 'replay' }],
       })
     );
+  });
+
+  it('redacts sensitive queue context before sending breadcrumbs', async () => {
+    const { addQueueBreadcrumb } = await import('./sentry');
+
+    addQueueBreadcrumb('Queue failed', {
+      workspaceId: 'ws_1',
+      recordingId: 'rec_1',
+      accessToken: 'secret-token',
+      transcript: 'private transcript',
+      audioBuffer: 'binary audio',
+    });
+
+    expect(sentryMocks.addBreadcrumb).toHaveBeenCalledWith(
+      expect.objectContaining({
+        category: 'recording.queue',
+        data: expect.objectContaining({
+          workspaceId: 'ws_1',
+          recordingId: 'rec_1',
+          accessToken: '[redacted]',
+          transcript: '[redacted]',
+          audioBuffer: '[redacted]',
+        }),
+      })
+    );
+    expect(JSON.stringify(sentryMocks.addBreadcrumb.mock.calls[0][0])).not.toContain(
+      'private transcript'
+    );
+  });
+
+  it('captures queue exceptions with safe context and searchable tags', async () => {
+    const { captureQueueException } = await import('./sentry');
+    const error = new Error('Upload crashed');
+
+    captureQueueException(
+      error,
+      {
+        workspaceId: 'ws_1',
+        recordingId: 'rec_1',
+        pipelineStage: 'upload',
+        errorCode: 'upload_failed',
+        segments: [{ text: 'private segment' }],
+      },
+      { level: 'warning', fingerprint: ['recording-queue', 'upload_failed'] }
+    );
+
+    expect(sentryMocks.scope.setLevel).toHaveBeenCalledWith('warning');
+    expect(sentryMocks.scope.setContext).toHaveBeenCalledWith(
+      'recording_queue',
+      expect.objectContaining({
+        workspaceId: 'ws_1',
+        recordingId: 'rec_1',
+        pipelineStage: 'upload',
+        errorCode: 'upload_failed',
+        segments: '[redacted]',
+      })
+    );
+    expect(sentryMocks.scope.setTag).toHaveBeenCalledWith('recordingId', 'rec_1');
+    expect(sentryMocks.scope.setFingerprint).toHaveBeenCalledWith([
+      'recording-queue',
+      'upload_failed',
+    ]);
+    expect(sentryMocks.captureException).toHaveBeenCalledWith(error);
   });
 });

--- a/src/sentry.ts
+++ b/src/sentry.ts
@@ -1,6 +1,22 @@
 import * as Sentry from '@sentry/react';
 
 const dsn = import.meta.env.VITE_SENTRY_DSN;
+const REDACTED = '[redacted]';
+const MAX_DEPTH = 5;
+const SENSITIVE_KEY_PATTERN =
+  /(authorization|api[-_]?key|access[-_]?token|refresh[-_]?token|id[-_]?token|password|secret|transcript|segments|audio|buffer|raw|payload)/i;
+
+type QueueSentryLevel = 'fatal' | 'error' | 'warning' | 'info' | 'debug';
+
+export interface QueueSentryContext extends Record<string, unknown> {
+  workspaceId?: string;
+  recordingId?: string;
+  jobId?: string;
+  pipelineStage?: string;
+  providerId?: string;
+  errorCode?: string;
+  retryable?: boolean;
+}
 
 function getSentryRelease() {
   return String(import.meta.env.VITE_BUILD_ID || import.meta.env.VITE_VERCEL_GIT_COMMIT_SHA || '')
@@ -21,6 +37,104 @@ export function initSentry() {
     replaysSessionSampleRate: 0,
     replaysOnErrorSampleRate: 1.0,
     integrations: [Sentry.browserTracingIntegration(), Sentry.replayIntegration()],
+  });
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+function normalizeError(error: Error) {
+  const enriched = error as Error & {
+    code?: unknown;
+    errorCode?: unknown;
+    status?: unknown;
+    statusCode?: unknown;
+  };
+
+  return {
+    name: error.name,
+    message: error.message,
+    ...(enriched.code ? { code: String(enriched.code) } : {}),
+    ...(enriched.errorCode ? { errorCode: String(enriched.errorCode) } : {}),
+    ...(enriched.status ? { status: Number(enriched.status) } : {}),
+    ...(enriched.statusCode ? { statusCode: Number(enriched.statusCode) } : {}),
+  };
+}
+
+export function sanitizeSentryContext(value: unknown, key = '', depth = 0): unknown {
+  if (SENSITIVE_KEY_PATTERN.test(key)) return REDACTED;
+  if (value instanceof Error) return normalizeError(value);
+  if (value === null || value === undefined) return value;
+  if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
+    return value;
+  }
+  if (depth >= MAX_DEPTH) return '[truncated]';
+  if (Array.isArray(value)) return value.map((item) => sanitizeSentryContext(item, key, depth + 1));
+  if (isPlainObject(value)) {
+    return Object.fromEntries(
+      Object.entries(value).map(([entryKey, entryValue]) => [
+        entryKey,
+        sanitizeSentryContext(entryValue, entryKey, depth + 1),
+      ])
+    );
+  }
+  return String(value);
+}
+
+function normalizeContext(context?: QueueSentryContext) {
+  const sanitized = sanitizeSentryContext(context || {});
+  return isPlainObject(sanitized) ? sanitized : {};
+}
+
+function applyQueueScope(scope: any, context: Record<string, unknown>, level: QueueSentryLevel) {
+  scope.setLevel?.(level);
+  scope.setContext?.('recording_queue', context);
+  for (const key of [
+    'workspaceId',
+    'recordingId',
+    'jobId',
+    'pipelineStage',
+    'providerId',
+    'errorCode',
+  ]) {
+    const value = context[key];
+    if (value !== undefined && value !== null && value !== '') {
+      scope.setTag?.(key, String(value).slice(0, 200));
+    }
+  }
+}
+
+export function addQueueBreadcrumb(
+  message: string,
+  context: QueueSentryContext = {},
+  options: { level?: QueueSentryLevel; category?: string } = {}
+) {
+  Sentry.addBreadcrumb?.({
+    category: options.category || 'recording.queue',
+    level: options.level || 'info',
+    message,
+    data: normalizeContext(context),
+  });
+}
+
+export function captureQueueException(
+  error: unknown,
+  context: QueueSentryContext = {},
+  options: { level?: QueueSentryLevel; fingerprint?: string[] } = {}
+) {
+  const normalizedError = error instanceof Error ? error : new Error(String(error));
+  const sanitizedContext = normalizeContext(context);
+  Sentry.withScope?.((scope) => {
+    applyQueueScope(
+      scope,
+      sanitizedContext,
+      options.level || (sanitizedContext.retryable ? 'warning' : 'error')
+    );
+    if (options.fingerprint?.length) {
+      scope.setFingerprint?.(options.fingerprint);
+    }
+    Sentry.captureException?.(normalizedError);
   });
 }
 

--- a/src/store/recorderQueueProcessor.test.ts
+++ b/src/store/recorderQueueProcessor.test.ts
@@ -1,4 +1,15 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
+
+const sentryMocks = vi.hoisted(() => ({
+  addQueueBreadcrumb: vi.fn(),
+  captureQueueException: vi.fn(),
+}));
+
+vi.mock('../sentry', () => ({
+  addQueueBreadcrumb: sentryMocks.addQueueBreadcrumb,
+  captureQueueException: sentryMocks.captureQueueException,
+}));
+
 import {
   RECORDING_WORKSPACE_REQUIRED_MESSAGE,
   createRecordingQueueItem,
@@ -184,6 +195,8 @@ function buildContext(overrides: Partial<QueueProcessorContext> = {}) {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  sentryMocks.addQueueBreadcrumb.mockClear();
+  sentryMocks.captureQueueException.mockClear();
 });
 
 describe('buildAudioPreprocessingPlan', () => {
@@ -1047,6 +1060,41 @@ describe('processRecordingQueueItem', () => {
     );
     expect(context.scheduleBackoffReset).toHaveBeenCalledWith('recording-1', 1000);
     expect(context.removeQueueItem).not.toHaveBeenCalled();
+  });
+
+  it('reports unexpected queue failures to Sentry with recording context', async () => {
+    const uploadError = Object.assign(new Error('Remote upload crashed'), {
+      code: 'upload_failed',
+      status: 502,
+      transcript: 'raw transcript must not be sent',
+    });
+    const context = buildContext();
+    context.mediaService.persistRecordingAudio.mockRejectedValueOnce(uploadError);
+
+    await processRecordingQueueItem(context);
+
+    expect(sentryMocks.captureQueueException).toHaveBeenCalledWith(
+      uploadError,
+      expect.objectContaining({
+        workspaceId: 'workspace-1',
+        recordingId: 'recording-1',
+        pipelineStage: 'queue_failure',
+        errorCode: 'upload_failed',
+        retryable: false,
+        status: 502,
+      }),
+      expect.objectContaining({
+        level: 'error',
+        fingerprint: ['recording-queue', 'upload_failed'],
+      })
+    );
+    expect(context.updateQueueItem).toHaveBeenCalledWith(
+      'recording-1',
+      expect.objectContaining({
+        status: 'failed',
+        errorMessage: 'UI: Remote upload crashed',
+      })
+    );
   });
 
   it('advances transient retry delay when previous backoff count exists', async () => {

--- a/src/store/recorderQueueProcessor.ts
+++ b/src/store/recorderQueueProcessor.ts
@@ -5,7 +5,7 @@ import {
   type RecordingPipelineStatus,
   type RecordingQueueItem,
 } from '../lib/recordingQueue';
-import { Sentry } from '../sentry';
+import { addQueueBreadcrumb, captureQueueException, type QueueSentryContext } from '../sentry';
 import type { TranscriptionStatusPayload } from '../shared/types';
 import type { MeetingAnalysis, TranscriptSegment } from '../shared/types';
 
@@ -242,11 +242,31 @@ function reportBackgroundTranscriptionPending(data: Record<string, unknown>) {
     console.info('[queue] Transcription still processing in background.', data);
   }
   if (typeof window === 'undefined') return;
-  Sentry?.addBreadcrumb?.({
-    category: 'recording.queue',
-    level: 'warning',
-    message: BACKGROUND_TRANSCRIPTION_PENDING_MESSAGE,
-    data,
+  addQueueBreadcrumb(BACKGROUND_TRANSCRIPTION_PENDING_MESSAGE, data, { level: 'warning' });
+}
+
+function buildQueueSentryContext(
+  nextItem: RecordingQueueItem,
+  extra: QueueSentryContext = {}
+): QueueSentryContext {
+  return {
+    workspaceId: nextItem.workspaceId || '',
+    recordingId: nextItem.recordingId,
+    pipelineStage: String(nextItem.status || 'queued'),
+    retryable: false,
+    ...extra,
+  };
+}
+
+function addRecordingQueueBreadcrumb(
+  nextItem: RecordingQueueItem,
+  message: string,
+  extra: QueueSentryContext = {},
+  options: { level?: 'fatal' | 'error' | 'warning' | 'info' | 'debug' } = {}
+) {
+  if (typeof window === 'undefined') return;
+  addQueueBreadcrumb(message, buildQueueSentryContext(nextItem, extra), {
+    level: options.level || 'info',
   });
 }
 
@@ -604,8 +624,23 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
     const workspaceId = resolveWorkspaceId(target, nextItem);
     const targetWithWorkspace =
       workspaceId && target.workspaceId !== workspaceId ? { ...target, workspaceId } : target;
+    addRecordingQueueBreadcrumb(nextItem, 'Recording queue item selected.', {
+      workspaceId,
+      pipelineStage: 'queue_selected',
+      storageMode: mediaService.mode,
+    });
 
     if (mediaService.mode === 'remote' && !workspaceId) {
+      addRecordingQueueBreadcrumb(
+        nextItem,
+        'Remote queue item missing workspace id.',
+        {
+          pipelineStage: 'workspace_validation',
+          errorCode: 'missing_workspace_id',
+          retryable: false,
+        },
+        { level: 'warning' }
+      );
       updateQueueItem(nextItem.recordingId, {
         status: 'failed_permanent',
         errorMessage: RECORDING_WORKSPACE_REQUIRED_MESSAGE,
@@ -624,6 +659,17 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
     const localBlob = canReuseRemoteUpload ? null : await getAudioBlob(nextItem.recordingId);
 
     if (!localBlob && !canReuseRemoteUpload) {
+      addRecordingQueueBreadcrumb(
+        nextItem,
+        'Local queue audio blob missing.',
+        {
+          workspaceId,
+          pipelineStage: 'local_audio_lookup',
+          errorCode: 'local_audio_missing',
+          retryable: false,
+        },
+        { level: 'warning' }
+      );
       updateQueueItem(nextItem.recordingId, {
         status: 'failed',
         errorMessage: 'Brakuje lokalnego audio.',
@@ -695,6 +741,11 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
         attempts: (nextItem.attempts || 0) + 1,
         errorMessage: '',
       });
+      addRecordingQueueBreadcrumb(nextItem, 'Audio upload started.', {
+        workspaceId,
+        pipelineStage: 'upload',
+        attempt: (nextItem.attempts || 0) + 1,
+      });
 
       uploadResult = await mediaService.persistRecordingAudio(nextItem.recordingId, uploadBlob, {
         workspaceId,
@@ -710,6 +761,10 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
 
       updateQueueItem(nextItem.recordingId, {
         audioQuality: uploadResult?.audioQuality || nextItem.audioQuality || null,
+      });
+      addRecordingQueueBreadcrumb(nextItem, 'Audio upload stored.', {
+        workspaceId,
+        pipelineStage: 'upload_complete',
       });
     }
 
@@ -730,6 +785,10 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
       pipelineProgressPercent: processingSnapshot.progressPercent,
       pipelineStageLabel: processingSnapshot.stageLabel,
       recordingMessage: 'Audio przeslane. Oczekiwanie na przetwarzanie...',
+    });
+    addRecordingQueueBreadcrumb(nextItem, 'Transcription job start requested.', {
+      workspaceId,
+      pipelineStage: canReuseRemoteUpload ? 'retry' : 'job_start',
     });
 
     let startedRaw: unknown;
@@ -764,6 +823,12 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
     const started = normalizeTranscriptionResponse(startedRaw) as StartedTranscription;
     const transcriptionProviderId = started.providerId || '';
     const transcriptionProviderLabel = started.providerLabel || transcriptionProviderId;
+    addRecordingQueueBreadcrumb(nextItem, 'Transcription job accepted.', {
+      workspaceId,
+      pipelineStage: normalizeRecordingPipelineStatus(started?.pipelineStatus),
+      providerId: transcriptionProviderId,
+      jobId: String((started as any)?.jobId || (started as any)?.durableJobId || ''),
+    });
 
     updateQueueItem(nextItem.recordingId, {
       pipelineGitSha: started?.pipelineGitSha || '',
@@ -954,6 +1019,17 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
       });
     } catch (error) {
       console.error('Meeting analysis failed.', error);
+      addRecordingQueueBreadcrumb(
+        nextItem,
+        'AI analysis fallback used.',
+        {
+          workspaceId,
+          pipelineStage: 'ai_analysis',
+          errorCode: (error as any)?.errorCode || (error as any)?.code || 'AI_ANALYSIS_FAILED',
+          retryable: true,
+        },
+        { level: 'warning' }
+      );
       analysis = buildFallbackAnalysis(
         'Analiza AI nie powiodla sie. Zachowalismy transkrypcje i segmenty.',
         {
@@ -1095,6 +1171,18 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
         retryAfterMs: delay,
         errorMessage: '',
       });
+      addRecordingQueueBreadcrumb(
+        nextItem,
+        'Queue item scheduled for retry.',
+        {
+          pipelineStage: 'retry',
+          errorCode: error?.errorCode || error?.code || 'TRANSIENT_QUEUE_ERROR',
+          retryable: true,
+          retryCount: retryCount + 1,
+          retryAfterMs: delay,
+        },
+        { level: 'warning' }
+      );
       scheduleBackoffReset?.(nextItem.recordingId, delay);
       return;
     }
@@ -1104,6 +1192,30 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
     if (getState().lastQueueErrorKey !== errorKey) {
       if (!isExpectedDomainFailure(error)) {
         console.error('Recording queue item failed.', error);
+        captureQueueException(
+          error,
+          buildQueueSentryContext(nextItem, {
+            pipelineStage: 'queue_failure',
+            errorCode: error?.errorCode || error?.code || 'RECORDING_QUEUE_FAILED',
+            retryable: false,
+            status: error?.status || error?.statusCode || undefined,
+          }),
+          {
+            level: 'error',
+            fingerprint: ['recording-queue', String(error?.errorCode || error?.code || 'failed')],
+          }
+        );
+      } else {
+        addRecordingQueueBreadcrumb(
+          nextItem,
+          'Expected recording queue failure handled.',
+          {
+            pipelineStage: 'queue_failure_expected',
+            errorCode: error?.errorCode || error?.code || 'EXPECTED_QUEUE_FAILURE',
+            retryable: false,
+          },
+          { level: 'warning' }
+        );
       }
       setState({ lastQueueErrorKey: errorKey });
     }


### PR DESCRIPTION
﻿## Issue
Closes #1239

## Changes
- Add sanitized Sentry context helpers for backend audio pipeline and frontend recording queue events.
- Attach request/workspace/recording/job/stage/provider/errorCode context to pipeline breadcrumbs and failures.
- Capture warning-level upload validation, retryable STT, queue retry/fallback, and postprocess failures without raw transcript/audio/payload data.
- Document Sentry alert rules and manual verification in `docs/ops/SENTRY_AUDIO_PIPELINE_ALERTS.md`.

## Tests run
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\sentry.test.ts server\\tests\\logger.test.ts server\\tests\\transcription.test.ts server\\tests\\routes\\media.test.ts --coverage.enabled=false`
- `node_modules\\.bin\\vitest.cmd run src\\sentry.test.ts src\\store\\recorderQueueProcessor.test.ts --coverage.enabled=false`
- `node_modules\\.bin\\tsc.cmd --project server\\tsconfig.server.json --noEmit`
- `node_modules\\.bin\\tsc.cmd --noEmit`
- `node_modules\\.bin\\prettier.cmd --check ...changed files...`
- `node scripts\\audit-mojibake.mjs`
- `git diff --check`
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts --retry=3 --coverage.enabled=false`
- Local backend runtime smoke: `GET /health` returned 200 on `127.0.0.1:4012` and `localhost:4012`.
- Pre-push release guard: `test:server:retry` with coverage, frontend guard tests, production build, and build warning audit passed.

## Known risks
- Sentry alert rules still need to be created in the Sentry project UI/API after merge; the PR adds instrumentation and the runbook, not remote Sentry configuration.
- Warning-level upload validation events may need threshold tuning after production traffic is observed.

## Follow-up tasks
- After deploy, attach real Sentry event links and alert-rule screenshots to the release evidence.
