### PR TITLE
fix(ai): tolerate quota reset overflow

### DIFF
--- a/server/lib/aiQuotaStore.ts
+++ b/server/lib/aiQuotaStore.ts
@@ -1,3 +1,5 @@
+import { logger } from '../logger.ts';
+
 export type AiQuotaCheck = {
   key: string;
   limit: number;
@@ -30,6 +32,22 @@ function retryAfterSeconds(resetAt: number, now: number) {
   return Math.max(1, Math.ceil((resetAt - now) / 1000));
 }
 
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isResetAtIntegerOverflow(error: unknown) {
+  const message = errorMessage(error);
+  return /out of range for type integer|integer out of range/i.test(message);
+}
+
+function warnQuotaFallback(message: string, error: unknown) {
+  logger.warn('[AI quota] DB quota store fallback', {
+    message,
+    error: errorMessage(error),
+  });
+}
+
 export class MemoryAiQuotaStore implements AiQuotaStore {
   private readonly counters = new Map<string, AiQuotaEntry>();
 
@@ -60,6 +78,8 @@ export class MemoryAiQuotaStore implements AiQuotaStore {
 
 export class DbAiQuotaStore implements AiQuotaStore {
   private initialized = false;
+  private fallbackMode = false;
+  private readonly fallbackStore = new MemoryAiQuotaStore();
 
   constructor(private readonly db: any) {}
 
@@ -79,6 +99,10 @@ export class DbAiQuotaStore implements AiQuotaStore {
 
   private async ensurePostgresResetAtBigint() {
     if (this.db?.type !== 'postgres') return;
+    await this.repairResetAtColumn();
+  }
+
+  private async repairResetAtColumn() {
     await this.db._execute(`
       ALTER TABLE ai_quota_counters
       ALTER COLUMN reset_at TYPE BIGINT USING reset_at::bigint
@@ -86,6 +110,43 @@ export class DbAiQuotaStore implements AiQuotaStore {
   }
 
   async increment(checks: AiQuotaCheck[]): Promise<AiQuotaExceeded | null> {
+    if (this.fallbackMode) {
+      return this.fallbackStore.increment(checks);
+    }
+
+    try {
+      return await this.incrementWithDb(checks);
+    } catch (error) {
+      if (!isResetAtIntegerOverflow(error)) {
+        throw error;
+      }
+      warnQuotaFallback('reset_at overflow detected; attempting BIGINT repair', error);
+    }
+
+    try {
+      await this.repairResetAtColumn();
+    } catch (error) {
+      warnQuotaFallback('BIGINT repair failed; using in-memory quota fallback', error);
+      this.fallbackMode = true;
+      return this.fallbackStore.increment(checks);
+    }
+
+    try {
+      return await this.incrementWithDb(checks);
+    } catch (error) {
+      if (!isResetAtIntegerOverflow(error)) {
+        throw error;
+      }
+      warnQuotaFallback(
+        'reset_at overflow persisted after repair; using in-memory fallback',
+        error
+      );
+      this.fallbackMode = true;
+      return this.fallbackStore.increment(checks);
+    }
+  }
+
+  private async incrementWithDb(checks: AiQuotaCheck[]): Promise<AiQuotaExceeded | null> {
     await this.ensureSchema();
 
     for (const check of checks) {
@@ -126,6 +187,8 @@ export class DbAiQuotaStore implements AiQuotaStore {
   }
 
   async reset() {
+    this.fallbackMode = false;
+    this.fallbackStore.reset();
     await this.ensureSchema();
     await this.db._execute('DELETE FROM ai_quota_counters');
   }

--- a/server/tests/lib/aiQuotaStore.test.ts
+++ b/server/tests/lib/aiQuotaStore.test.ts
@@ -56,6 +56,62 @@ function createFakeDb(options: { type?: string } = {}) {
   };
 }
 
+function createOverflowDb(
+  options: {
+    repairSucceeds?: boolean;
+    overflowPersists?: boolean;
+    genericInsertError?: boolean;
+  } = {}
+) {
+  const rows = new Map<
+    string,
+    { key: string; count: number; reset_at: number; updated_at: string }
+  >();
+  const statements: string[] = [];
+  let repaired = false;
+  let insertAttempts = 0;
+
+  return {
+    rows,
+    statements,
+    get insertAttempts() {
+      return insertAttempts;
+    },
+    async _execute(sql: string, params: unknown[] = []) {
+      statements.push(sql);
+      if (/CREATE TABLE/i.test(sql)) return;
+      if (/ALTER TABLE ai_quota_counters/i.test(sql)) {
+        if (!options.repairSucceeds) {
+          throw new Error('permission denied for table ai_quota_counters');
+        }
+        repaired = true;
+        return;
+      }
+      if (/INSERT INTO ai_quota_counters/i.test(sql)) {
+        insertAttempts += 1;
+        if (options.genericInsertError) {
+          throw new Error('connection lost');
+        }
+        if (!repaired || options.overflowPersists) {
+          throw new Error('value "1782975650185" is out of range for type integer');
+        }
+        const [key, count, resetAt, updatedAt] = params;
+        rows.set(String(key), {
+          key: String(key),
+          count: Number(count),
+          reset_at: Number(resetAt),
+          updated_at: String(updatedAt),
+        });
+        return;
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+    async _get(_sql: string, params: unknown[] = []) {
+      return rows.get(String(params[0])) || null;
+    },
+  };
+}
+
 describe('AI quota stores', () => {
   test('MemoryAiQuotaStore returns Retry-After when a window limit is exceeded', async () => {
     const store = new MemoryAiQuotaStore();
@@ -131,6 +187,50 @@ describe('AI quota stores', () => {
         /ALTER TABLE ai_quota_counters\s+ALTER COLUMN reset_at TYPE BIGINT USING reset_at::bigint/i
       )
     );
+  });
+
+  test('DbAiQuotaStore repairs reset_at integer overflow and retries the DB write', async () => {
+    const db = createOverflowDb({ repairSucceeds: true });
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+
+    expect(db.insertAttempts).toBe(2);
+    expect(db.statements).toContainEqual(
+      expect.stringMatching(/ALTER TABLE ai_quota_counters\s+ALTER COLUMN reset_at TYPE BIGINT/i)
+    );
+    expect(db.rows.get('ai:user:u1:hour')?.reset_at).toBe(1_782_975_710_185);
+  });
+
+  test('DbAiQuotaStore falls back to memory when overflow repair is denied', async () => {
+    const db = createOverflowDb();
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+    const exceeded = await store.increment([makeCheck({ now: 1_782_975_650_186 })]);
+
+    expect(exceeded).toMatchObject({
+      key: 'ai:user:u1:hour',
+      limit: 1,
+    });
+    expect(db.insertAttempts).toBe(1);
+  });
+
+  test('DbAiQuotaStore falls back to memory when reset_at overflow persists after repair', async () => {
+    const db = createOverflowDb({ repairSucceeds: true, overflowPersists: true });
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+
+    expect(db.insertAttempts).toBe(2);
+    expect(db.rows.size).toBe(0);
+  });
+
+  test('DbAiQuotaStore still propagates non-overflow DB failures', async () => {
+    const db = createOverflowDb({ genericInsertError: true });
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck()])).rejects.toThrow('connection lost');
   });
 
   test('DbAiQuotaStore reset deletes persisted counters', async () => {

--- a/server/tests/routes/ai.test.ts
+++ b/server/tests/routes/ai.test.ts
@@ -30,6 +30,24 @@ function createFakeQuotaDb() {
   };
 }
 
+function createIntegerOverflowQuotaDb() {
+  return {
+    async _execute(sql: string) {
+      if (/CREATE TABLE/i.test(sql)) return;
+      if (/ALTER TABLE ai_quota_counters/i.test(sql)) {
+        throw new Error('permission denied for table ai_quota_counters');
+      }
+      if (/INSERT INTO ai_quota_counters/i.test(sql)) {
+        throw new Error('value "1782975650185" is out of range for type integer');
+      }
+      throw new Error(`Unexpected quota SQL: ${sql}`);
+    },
+    async _get() {
+      return null;
+    },
+  };
+}
+
 describe('AI Routes', () => {
   let app: Awaited<ReturnType<typeof createApp>>;
   let mockAuthService: any;
@@ -391,6 +409,32 @@ describe('AI Routes', () => {
       expect(first.status).toBe(200);
       expect(second.status).toBe(429);
       expect(second.headers.get('Retry-After')).toMatch(/^\d+$/);
+    });
+
+    test('Regression: #1360 - production AI quota integer overflow does not 500 suggest-tasks', async () => {
+      vi.stubEnv('VOICELOG_AI_QUOTA_STORE', 'db');
+      vi.stubEnv('ANTHROPIC_API_KEY', '');
+      vi.resetModules();
+      const { createApp: createQuotaApp } = await import('../../app.ts');
+      const quotaApp = createQuotaApp({
+        authService: mockAuthService,
+        workspaceService: mockWorkspaceService,
+        transcriptionService: mockTranscriptionService,
+        db: createIntegerOverflowQuotaDb(),
+        config: { allowedOrigins: '*', trustProxy: false, uploadDir: '/tmp' },
+      });
+
+      const res = await quotaApp.request('/ai/suggest-tasks', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-session' },
+        body: JSON.stringify({
+          transcript: [],
+          people: [],
+        }),
+      });
+
+      expect(res.status).toBe(200);
+      await expect(res.json()).resolves.toEqual({ tasks: [] });
     });
 
     test('returns empty tasks when ANTHROPIC_API_KEY is not configured', async () => {


### PR DESCRIPTION
## Issue
Closes #1360

## Changes
- Detect PostgreSQL `reset_at` integer overflow in `DbAiQuotaStore` and attempt an online BIGINT repair.
- Fall back to process-local memory quota when repair is denied or the overflow persists, so AI endpoints degrade to quota-local behavior instead of returning 500.
- Log the fallback path with error context for production diagnosis.
- Added regression coverage for the production `/ai/suggest-tasks` audit failure and unit coverage for repair/fallback branches.

## Tests run
- RED: `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\routes\\ai.test.ts --coverage.enabled=false` failed before the fix: `/ai/suggest-tasks` returned 500 for `value 1782975650185 is out of range for type integer`.
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts server\\tests\\lib\\aiQuotaStore.test.ts server\\tests\\routes\\ai.test.ts --coverage.enabled=false` -> 2 files / 44 tests passed.
- `node_modules\\.bin\\tsc.cmd --project server\\tsconfig.server.json --noEmit` -> passed.
- `node_modules\\.bin\\vitest.cmd run -c server\\vitest.config.ts --retry=3` -> 97 files passed / 2 skipped, 1384 tests passed / 82 skipped, branch coverage 90.49% locally before commit and 90.36% in pre-push release guard.
- Pre-push release guard -> backend coverage, frontend release slice, and build warning audit passed.

## Known risks
- If production DB permissions block the BIGINT repair, quota temporarily becomes process-local for the affected server process. That is safer than a 500, but a follow-up schema migration should still verify `ai_quota_counters.reset_at` is BIGINT in production.
- Existing SQLite experimental warnings and test-only Supabase disabled warnings remain unrelated.

## Follow-up tasks
- After merge, rerun/observe Production System Audit for the same endpoint that failed in run 28571600984.
- Verify production `ai_quota_counters.reset_at` column type directly during the next DB maintenance window.