### PR TITLE
fix(rate-limit): tolerate reset overflow

### DIFF
--- a/server/lib/routeRateLimitStore.ts
+++ b/server/lib/routeRateLimitStore.ts
@@ -1,3 +1,5 @@
+import { logger } from '../logger.ts';
+
 export type RouteRateLimitCheck = {
   key: string;
   limit: number;
@@ -28,6 +30,22 @@ function normalizeNow(value: unknown) {
 
 function retryAfterSeconds(resetAt: number, now: number) {
   return Math.max(1, Math.ceil((resetAt - now) / 1000));
+}
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isResetAtIntegerOverflow(error: unknown) {
+  const message = errorMessage(error);
+  return /out of range for type integer|integer out of range/i.test(message);
+}
+
+function warnRateLimitFallback(message: string, error: unknown) {
+  logger.warn('[Rate limit] DB store fallback', {
+    message,
+    error: errorMessage(error),
+  });
 }
 
 function normalizeStoreName(value: unknown) {
@@ -68,6 +86,8 @@ export class MemoryRouteRateLimitStore implements RouteRateLimitStore {
 
 export class DbRouteRateLimitStore implements RouteRateLimitStore {
   private initialized = false;
+  private fallbackMode = false;
+  private readonly fallbackStore = new MemoryRouteRateLimitStore();
 
   constructor(private readonly db: any) {}
 
@@ -77,14 +97,66 @@ export class DbRouteRateLimitStore implements RouteRateLimitStore {
       CREATE TABLE IF NOT EXISTS route_rate_limit_counters (
         key TEXT PRIMARY KEY,
         count INTEGER NOT NULL,
-        reset_at INTEGER NOT NULL,
+        reset_at BIGINT NOT NULL,
         updated_at TEXT NOT NULL
       )
     `);
+    await this.ensurePostgresResetAtBigint();
     this.initialized = true;
   }
 
+  private async ensurePostgresResetAtBigint() {
+    if (this.db?.type !== 'postgres') return;
+    await this.repairResetAtColumn();
+  }
+
+  private async repairResetAtColumn() {
+    await this.db._execute(`
+      ALTER TABLE route_rate_limit_counters
+      ALTER COLUMN reset_at TYPE BIGINT USING reset_at::bigint
+    `);
+  }
+
   async increment(checks: RouteRateLimitCheck[]): Promise<RouteRateLimitExceeded | null> {
+    if (this.fallbackMode) {
+      return this.fallbackStore.increment(checks);
+    }
+
+    try {
+      return await this.incrementWithDb(checks);
+    } catch (error) {
+      if (!isResetAtIntegerOverflow(error)) {
+        throw error;
+      }
+      warnRateLimitFallback('reset_at overflow detected; attempting BIGINT repair', error);
+    }
+
+    try {
+      await this.repairResetAtColumn();
+    } catch (error) {
+      warnRateLimitFallback('BIGINT repair failed; using in-memory rate-limit fallback', error);
+      this.fallbackMode = true;
+      return this.fallbackStore.increment(checks);
+    }
+
+    try {
+      return await this.incrementWithDb(checks);
+    } catch (error) {
+      if (!isResetAtIntegerOverflow(error)) {
+        throw error;
+      }
+      warnRateLimitFallback(
+        'reset_at overflow persisted after repair; using in-memory fallback',
+        error
+      );
+      this.fallbackMode = true;
+      return this.fallbackStore.increment(checks);
+    }
+  }
+
+  private async incrementWithDb(
+    checks: RouteRateLimitCheck[]
+  ): Promise<RouteRateLimitExceeded | null> {
     await this.ensureSchema();
 
     for (const check of checks) {
@@ -129,6 +201,8 @@ export class DbRouteRateLimitStore implements RouteRateLimitStore {
   }
 
   async reset() {
+    this.fallbackMode = false;
+    this.fallbackStore.reset();
     await this.ensureSchema();
     await this.db._execute('DELETE FROM route_rate_limit_counters');
   }

--- a/server/tests/lib/routeRateLimitStore.test.ts
+++ b/server/tests/lib/routeRateLimitStore.test.ts
@@ -51,6 +51,66 @@ function createFakeDb() {
   };
 }
 
+function createOverflowDb(
+  options: {
+    repairSucceeds?: boolean;
+    overflowPersists?: boolean;
+    genericInsertError?: boolean;
+  } = {}
+) {
+  const rows = new Map<
+    string,
+    { key: string; count: number; reset_at: number; updated_at: string }
+  >();
+  const statements: string[] = [];
+  let repaired = false;
+  let insertAttempts = 0;
+
+  return {
+    rows,
+    statements,
+    get insertAttempts() {
+      return insertAttempts;
+    },
+    async _execute(sql: string, params: unknown[] = []) {
+      statements.push(sql);
+      if (/CREATE TABLE/i.test(sql)) return;
+      if (/ALTER TABLE route_rate_limit_counters/i.test(sql)) {
+        if (!options.repairSucceeds) {
+          throw new Error('permission denied for table route_rate_limit_counters');
+        }
+        repaired = true;
+        return;
+      }
+      if (/INSERT INTO route_rate_limit_counters/i.test(sql)) {
+        insertAttempts += 1;
+        if (options.genericInsertError) {
+          throw new Error('connection lost');
+        }
+        if (!repaired || options.overflowPersists) {
+          throw new Error('value "1782975650185" is out of range for type integer');
+        }
+        const [key, resetAt, updatedAt] = params;
+        rows.set(String(key), {
+          key: String(key),
+          count: 1,
+          reset_at: Number(resetAt),
+          updated_at: String(updatedAt),
+        });
+        return;
+      }
+      if (/DELETE FROM route_rate_limit_counters/i.test(sql)) {
+        rows.clear();
+        return;
+      }
+      throw new Error(`Unexpected SQL: ${sql}`);
+    },
+    async _get(_sql: string, params: unknown[] = []) {
+      return rows.get(String(params[0])) || null;
+    },
+  };
+}
+
 describe('route rate limit stores', () => {
   test('MemoryRouteRateLimitStore returns Retry-After when a route limit is exceeded', async () => {
     const store = new MemoryRouteRateLimitStore();
@@ -99,6 +159,52 @@ describe('route rate limit stores', () => {
 
     expect(db.rows.get('route:rag-ask:user:u1')?.count).toBe(1);
     expect(db.rows.get('route:rag-ask:user:u1')?.reset_at).toBe(122_000);
+  });
+
+  test('DbRouteRateLimitStore repairs reset_at integer overflow and retries the DB write', async () => {
+    const db = createOverflowDb({ repairSucceeds: true });
+    const store = new DbRouteRateLimitStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+
+    expect(db.insertAttempts).toBe(2);
+    expect(db.statements).toContainEqual(
+      expect.stringMatching(
+        /ALTER TABLE route_rate_limit_counters\s+ALTER COLUMN reset_at TYPE BIGINT/i
+      )
+    );
+    expect(db.rows.get('route:rag-ask:user:u1')?.reset_at).toBe(1_782_975_710_185);
+  });
+
+  test('DbRouteRateLimitStore falls back to memory when overflow repair is denied', async () => {
+    const db = createOverflowDb();
+    const store = new DbRouteRateLimitStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+    const exceeded = await store.increment([makeCheck({ now: 1_782_975_650_186 })]);
+
+    expect(exceeded).toMatchObject({
+      key: 'route:rag-ask:user:u1',
+      limit: 1,
+    });
+    expect(db.insertAttempts).toBe(1);
+  });
+
+  test('DbRouteRateLimitStore falls back to memory when overflow persists after repair', async () => {
+    const db = createOverflowDb({ repairSucceeds: true, overflowPersists: true });
+    const store = new DbRouteRateLimitStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+
+    expect(db.insertAttempts).toBe(2);
+    expect(db.rows.size).toBe(0);
+  });
+
+  test('DbRouteRateLimitStore still propagates non-overflow DB failures', async () => {
+    const db = createOverflowDb({ genericInsertError: true });
+    const store = new DbRouteRateLimitStore(db);
+
+    await expect(store.increment([makeCheck()])).rejects.toThrow('connection lost');
   });
 
   test('createRouteRateLimitStore selects DB store outside tests when a DB adapter is available', () => {


### PR DESCRIPTION
## Issue
Closes #1360

## Changes
- Store route rate-limit `reset_at` values as `BIGINT` instead of `INTEGER`.
- Repair existing Postgres `route_rate_limit_counters.reset_at` columns on startup before retrying writes.
- Fall back to an in-memory route rate-limit store when production cannot repair the schema or overflow persists, preserving endpoint availability.
- Add regression coverage for repair, denied repair fallback, persistent overflow fallback, and non-overflow DB failures.

## Tests run
- RED: `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\lib\routeRateLimitStore.test.ts --coverage.enabled=false` failed before implementation.
- GREEN: `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\lib\routeRateLimitStore.test.ts --coverage.enabled=false` passed.
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\lib\routeRateLimitStore.test.ts server\tests\lib\aiQuotaStore.test.ts server\tests\routes\ai.test.ts --coverage.enabled=false` passed.
- `node_modules\.bin\tsc.cmd --project server\tsconfig.server.json --noEmit` passed.
- Full backend coverage passed locally: 97 files passed / 2 skipped, 1388 tests passed / 82 skipped.
- Pre-push release guard passed on push, including backend coverage, frontend release slice, and build warning audit.

## Known risks
- If production DB schema repair is denied, route rate limiting becomes process-local until the DB column is migrated to BIGINT.
- Production DB should still be verified for `route_rate_limit_counters.reset_at` and `ai_quota_counters.reset_at` BIGINT after deployment.

## Follow-up tasks
- Rerun/verify Production System Audit after merge and deployment.
- Confirm the production audit no longer reports the integer overflow from `/ai/suggest-tasks`.