### PR TITLE
fix(ci): ignore Railway info log noise

### DIFF
--- a/scripts/monitoring-error-groups.mjs
+++ b/scripts/monitoring-error-groups.mjs
@@ -282,7 +282,7 @@ export function isActionableRailwayLogEntry(entry) {
     return false;
   }
 
-  if (/^\[info\]\s+/i.test(message)) {
+  if (/^(?:\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\s+)?\[info\]\s+/i.test(message)) {
     return false;
   }
 

--- a/scripts/monitoring-error-groups.test.ts
+++ b/scripts/monitoring-error-groups.test.ts
@@ -189,6 +189,17 @@ describe('monitoring error groups', () => {
     expect(groups).toHaveLength(0);
   });
 
+  it('ignores timestamp-prefixed Railway info logs from error reports', () => {
+    const groups = extractRailwayLogGroups([
+      {
+        message:
+          '2026-07-01T18:14:00.128470915Z [INFO] [Bootstrap] Startup transcription recovery: recovered=0, skipped=0, failed=0, alreadyActive=0. timestamp="2026-07-01T18:14:00.116Z" service="voicelog-server"',
+      },
+    ]);
+
+    expect(groups).toHaveLength(0);
+  });
+
   it('keeps real Railway runtime errors actionable after noise filtering', () => {
     const groups = extractRailwayLogGroups([
       { level: 'info', message: '[INFO] [REQ] GET /health - 200 [40ms]' },


### PR DESCRIPTION
## Issue

Fixes #1354.

Also supports #1356/#1355 triage: the real PostgreSQL integer overflow from `/ai/suggest-tasks` is already fixed on `main` by `6a4d66a` and `93259b5`; this PR prevents the separate false-positive Railway INFO group from being recreated.

## Changes

- Ignore timestamp-prefixed Railway `[INFO]` log lines in monitoring grouping.
- Add a regression test for the exact `Startup transcription recovery` log shape from the Railway report.

## Tests run

- `corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/monitoring-error-groups.test.ts --coverage.enabled=false`
- `corepack pnpm exec prettier --check scripts/monitoring-error-groups.mjs scripts/monitoring-error-groups.test.ts`
- `corepack pnpm exec vitest run -c server/vitest.config.ts server/tests/lib/aiQuotaStore.test.ts server/tests/routes/ai.test.ts server/tests/lib/routeRateLimitStore.test.ts --coverage.enabled=false`
- Pre-push release guard: `pnpm run test:server:retry`, frontend guard tests, `pnpm run audit:build-warnings`

## Known risks

- This change intentionally only filters non-actionable Railway INFO noise; real `error`/`fatal` entries continue to be grouped.

## Follow-up tasks

- After merge, close #1354 and update/close #1356/#1355 with CI and production evidence.