### PR TITLE
fix(ci): extend production persistence gate timeout

### DIFF
--- a/scripts/release-readiness.test.ts
+++ b/scripts/release-readiness.test.ts
@@ -94,6 +94,17 @@ describe('release readiness gates', () => {
     );
   });
 
+  it('keeps production persistence retries within the production audit timeout budget', () => {
+    const helper = read('tests/e2e/helpers/productionAudit.js');
+    const spec = read('tests/e2e/production-persistence.spec.js');
+
+    expect(helper).toContain('PRODUCTION_AUDIT_STATE_PATCH_TIMEOUT_MS');
+    expect(helper).toContain('PRODUCTION_AUDIT_TEST_TIMEOUT_MS');
+    expect(helper).toContain('45_000');
+    expect(helper).toContain('180_000');
+    expect(spec).toContain('test.setTimeout(PRODUCTION_AUDIT_TEST_TIMEOUT_MS)');
+  });
+
   it('fails strict production gate config when required production secrets are missing', () => {
     expect(() => validateProductionGateEnv({})).toThrow('release:prod-gate:strict missing');
     expect(() =>

--- a/tests/e2e/helpers/productionAudit.js
+++ b/tests/e2e/helpers/productionAudit.js
@@ -10,7 +10,21 @@ export const AUTH_TOKEN = process.env.PRODUCTION_SMOKE_AUTH_TOKEN || '';
 export const WORKSPACE_ID = process.env.PRODUCTION_SMOKE_WORKSPACE_ID || '';
 export const AUDIT_REQUIRED = process.env.PRODUCTION_SYSTEM_AUDIT_REQUIRED === 'true';
 export const AUDIT_PREFIX = process.env.PRODUCTION_AUDIT_PREFIX || 'audit_20260529_';
-const API_REQUEST_TIMEOUT_MS = Number(process.env.PRODUCTION_AUDIT_REQUEST_TIMEOUT_MS || 35_000);
+
+function readPositiveIntEnv(name, fallback) {
+  const value = Number(process.env[name]);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+const API_REQUEST_TIMEOUT_MS = readPositiveIntEnv('PRODUCTION_AUDIT_REQUEST_TIMEOUT_MS', 45_000);
+const STATE_PATCH_REQUEST_TIMEOUT_MS = readPositiveIntEnv(
+  'PRODUCTION_AUDIT_STATE_PATCH_TIMEOUT_MS',
+  Math.max(API_REQUEST_TIMEOUT_MS, 45_000)
+);
+export const PRODUCTION_AUDIT_TEST_TIMEOUT_MS = readPositiveIntEnv(
+  'PRODUCTION_AUDIT_TEST_TIMEOUT_MS',
+  180_000
+);
 
 async function sleep(ms) {
   await new Promise((resolve) => setTimeout(resolve, ms));
@@ -44,7 +58,7 @@ export function authHeaders() {
 export async function fetchProductionSession(request) {
   const response = await request.get(
     apiUrl(`/auth/session?workspaceId=${encodeURIComponent(WORKSPACE_ID)}`),
-    { headers: authHeaders() }
+    { headers: authHeaders(), timeout: API_REQUEST_TIMEOUT_MS }
   );
 
   expect(response.status(), await response.text()).toBeLessThan(500);
@@ -88,7 +102,7 @@ export async function installProductionSession(page, request) {
 export async function fetchWorkspaceState(request) {
   const response = await request.get(
     apiUrl(`/state/bootstrap?workspaceId=${encodeURIComponent(WORKSPACE_ID)}`),
-    { headers: authHeaders() }
+    { headers: authHeaders(), timeout: API_REQUEST_TIMEOUT_MS }
   );
 
   expect(response.status(), await response.text()).toBeLessThan(500);
@@ -100,7 +114,7 @@ export async function fetchWorkspaceState(request) {
 
 export async function patchWorkspaceState(request, delta, options = {}) {
   const attempts = options.attempts || 3;
-  const timeout = options.timeout || API_REQUEST_TIMEOUT_MS;
+  const timeout = options.timeout || STATE_PATCH_REQUEST_TIMEOUT_MS;
   let lastError = null;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {

--- a/tests/e2e/production-persistence.spec.js
+++ b/tests/e2e/production-persistence.spec.js
@@ -3,6 +3,7 @@ import { expect, test } from '@playwright/test';
 
 import {
   AUDIT_PREFIX,
+  PRODUCTION_AUDIT_TEST_TIMEOUT_MS,
   attachRuntimeGuard,
   createAuditMeeting,
   fetchWorkspaceState,
@@ -32,7 +33,7 @@ test.describe('production persistence gate', () => {
   });
 
   test('audit meeting delete persists after refresh and remote sync', async ({ page, request }) => {
-    test.setTimeout(120_000);
+    test.setTimeout(PRODUCTION_AUDIT_TEST_TIMEOUT_MS);
     const guard = attachRuntimeGuard(page);
     const meetingId = `${AUDIT_PREFIX}delete_${Date.now()}`;
     const title = `${AUDIT_PREFIX}delete recording smoke ${meetingId}`;


### PR DESCRIPTION
## Issue

Follow-up for failed Production System Audit on `main` SHA `9a64ff3` after #1363.

Root cause: `test:e2e:production-persistence` allowed 3 PATCH retries, but the spec timeout was 120s and PATCH request timeout was 35s. A slow production `/state/workspaces/:id` PATCH could consume most of the test budget on the first attempt, so retry never had enough room to prove recovery.

## Changes

- Align `tests/e2e/helpers/productionAudit.js` with the main production system audit timeout model.
- Use 45s default API/PATCH timeouts and 180s default test timeout.
- Add release-readiness regression coverage so the persistence gate keeps enough retry budget.

## Tests run

- `corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/release-readiness.test.ts --coverage.enabled=false`
- `corepack pnpm exec prettier --check scripts/release-readiness.test.ts tests/e2e/helpers/productionAudit.js tests/e2e/production-persistence.spec.js`
- `PLAYWRIGHT_SKIP_WEB_SERVER=true corepack pnpm run test:e2e:production-persistence` (skips locally without production secrets, validates load path)
- Pre-push release guard: `pnpm run test:server:retry`, frontend guard tests, `pnpm run audit:build-warnings`

## Known risks

- This does not optimize the production PATCH endpoint itself; it makes the release gate tolerant of expected transient production latency and lets retries actually run.

## Follow-up tasks

- Merge and verify Production System Audit reruns green on `main`.