### PR TITLE
fix(railway): prevent orphan workspace state FK errors

### DIFF
--- a/scripts/monitoring-error-groups.mjs
+++ b/scripts/monitoring-error-groups.mjs
@@ -297,6 +297,13 @@ export function isActionableRailwayLogEntry(entry) {
     return false;
   }
 
+  if (
+    /\bstatuscode"?\s*:?\s*401\b/i.test(message) &&
+    /niepoprawny email lub haslo/i.test(message)
+  ) {
+    return false;
+  }
+
   return /\b(error|fatal|exception|failed|failure|unhandled|crash|timeout)\b/i.test(lowerMessage);
 }
 

--- a/scripts/monitoring-error-groups.test.ts
+++ b/scripts/monitoring-error-groups.test.ts
@@ -200,6 +200,19 @@ describe('monitoring error groups', () => {
     expect(groups).toHaveLength(0);
   });
 
+  it('ignores expected Railway invalid-login auth failures', () => {
+    const groups = extractRailwayLogGroups([
+      {
+        level: 'error',
+        service: 'voicelog-server',
+        message:
+          '2026-07-02T20:03:24.742922037Z [ERRO] APP ERROR STACK data={"error":{"name":"Error","message":"Niepoprawny email lub haslo.","statusCode":401}} timestamp="2026-07-02T20:03:24.733Z" service="voicelog-server"',
+      },
+    ]);
+
+    expect(groups).toHaveLength(0);
+  });
+
   it('keeps real Railway runtime errors actionable after noise filtering', () => {
     const groups = extractRailwayLogGroups([
       { level: 'info', message: '[INFO] [REQ] GET /health - 200 [40ms]' },

--- a/server/database.ts
+++ b/server/database.ts
@@ -1196,7 +1196,13 @@ export class Database {
 
   async workspaceIdsForUser(userId: string): Promise<string[]> {
     const rows = await this._query(
-      'SELECT workspace_id FROM workspace_members WHERE user_id = ? ORDER BY joined_at ASC',
+      `
+        SELECT workspace_members.workspace_id
+        FROM workspace_members
+        JOIN workspaces ON workspaces.id = workspace_members.workspace_id
+        WHERE workspace_members.user_id = ?
+        ORDER BY workspace_members.joined_at ASC
+      `,
       [userId]
     );
     return rows.map((row) => row.workspace_id);
@@ -1584,10 +1590,15 @@ export class Database {
   }
 
   async getMembership(workspaceId: string, userId: string): Promise<any> {
-    return this._get('SELECT * FROM workspace_members WHERE workspace_id = ? AND user_id = ?', [
-      workspaceId,
-      userId,
-    ]);
+    return this._get(
+      `
+        SELECT workspace_members.*
+        FROM workspace_members
+        JOIN workspaces ON workspaces.id = workspace_members.workspace_id
+        WHERE workspace_members.workspace_id = ? AND workspace_members.user_id = ?
+      `,
+      [workspaceId, userId]
+    );
   }
 
   async selectWorkspaceForUser(userId: string, preferredWorkspaceId: string = ''): Promise<string> {

--- a/server/tests/database.test.ts
+++ b/server/tests/database.test.ts
@@ -46,6 +46,44 @@ describe('Database (Async Worker SQLite)', () => {
     expect(result).toBeNull();
   });
 
+  test('Regression: Issue #1403 - ignores orphan workspace memberships during bootstrap', async () => {
+    const timestamp = new Date().toISOString();
+    const userId = `user_orphan_${Date.now()}`;
+    const validWorkspaceId = `workspace_valid_${Date.now()}`;
+    const orphanWorkspaceId = `workspace_orphan_${Date.now()}`;
+
+    await db._execute(
+      `INSERT INTO users (
+        id, email, password_hash, name, provider, google_sub, google_email,
+        recovery_code_hash, recovery_code_expires_at, profile_json, created_at, updated_at
+      ) VALUES (?, ?, '', 'Orphan Test', 'local', '', ?, '', '', '{}', ?, ?)`,
+      [`${userId}`, `${userId}@example.test`, `${userId}@example.test`, timestamp, timestamp]
+    );
+    await db._execute(
+      `INSERT INTO workspaces (id, name, owner_user_id, invite_code, created_at, updated_at)
+       VALUES (?, 'Valid Workspace', ?, ?, ?, ?)`,
+      [validWorkspaceId, userId, `INV${String(Date.now()).slice(-8)}`, timestamp, timestamp]
+    );
+    await db._execute(
+      `INSERT INTO workspace_members (workspace_id, user_id, member_role, joined_at)
+       VALUES (?, ?, 'owner', ?)`,
+      [orphanWorkspaceId, userId, timestamp]
+    );
+    await db._execute(
+      `INSERT INTO workspace_members (workspace_id, user_id, member_role, joined_at)
+       VALUES (?, ?, 'owner', ?)`,
+      [validWorkspaceId, userId, timestamp]
+    );
+
+    await expect(db.getMembership(orphanWorkspaceId, userId)).resolves.toBeNull();
+
+    const payload = await db.buildSessionPayload(userId, orphanWorkspaceId);
+    expect(payload.workspaceId).toBe(validWorkspaceId);
+    await expect(
+      db._get('SELECT * FROM workspace_state WHERE workspace_id = ?', [orphanWorkspaceId])
+    ).resolves.toBeNull();
+  });
+
   test("should persist data across simulated 'deploys' (process restarts)", async () => {
     const dbPath = path.join(testUploadDir, 'data.sqlite');
 

--- a/server/tests/database/database.additional.test.ts
+++ b/server/tests/database/database.additional.test.ts
@@ -1843,6 +1843,11 @@ describe('Database - Additional Coverage Tests', () => {
 
     test('updateWorkspaceMemberRole updates role to valid value', async () => {
       await db._execute(
+        `INSERT OR REPLACE INTO workspaces (id, name, owner_user_id, invite_code, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        ['ws1', 'Workspace 1', 'u1', 'ROLE01', new Date().toISOString(), new Date().toISOString()]
+      );
+      await db._execute(
         'INSERT OR REPLACE INTO workspace_members (workspace_id, user_id, member_role, joined_at) VALUES (?, ?, ?, ?)',
         ['ws1', 'u1', 'member', new Date().toISOString()]
       );
@@ -1854,6 +1859,11 @@ describe('Database - Additional Coverage Tests', () => {
     });
 
     test('updateWorkspaceMemberRole clamps invalid role to member', async () => {
+      await db._execute(
+        `INSERT OR REPLACE INTO workspaces (id, name, owner_user_id, invite_code, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+        ['ws1', 'Workspace 1', 'u1', 'ROLE01', new Date().toISOString(), new Date().toISOString()]
+      );
       await db._execute(
         'INSERT OR REPLACE INTO workspace_members (workspace_id, user_id, member_role, joined_at) VALUES (?, ?, ?, ?)',
         ['ws1', 'u1', 'admin', new Date().toISOString()]


### PR DESCRIPTION
## Summary
- Prevent orphaned workspace memberships from being selected as an active workspace during session bootstrap.
- Require membership checks to join an existing workspace row before granting access.
- Treat the known invalid-login 401 message as expected auth noise in Railway error grouping so it does not create runtime-error groups.

## Root Cause
#1403 was caused by `workspaceIdsForUser()` selecting IDs directly from `workspace_members`. If production data contained an orphan membership, `buildSessionPayload()` could choose that missing workspace and then `getWorkspaceState()` attempted to create `workspace_state`, which violates the Postgres FK `workspace_state_workspace_id_fkey`.

#1404 is a monitoring classification issue: a normal bad-login 401 (`Niepoprawny email lub haslo.`) was logged as `APP ERROR STACK`, so the grouping script treated it as actionable Railway runtime failure.

## Validation
- PASS: `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts server/tests/database.test.ts server/tests/database/database.additional.test.ts --coverage.enabled=false`
- PASS: `node_modules\.bin\vitest.cmd run -c vitest.scripts.config.ts scripts/monitoring-error-groups.test.ts --coverage.enabled=false`
- PASS: `node_modules\.bin\prettier.cmd --check "server/database.ts" "server/tests/database.test.ts" "server/tests/database/database.additional.test.ts" "scripts/monitoring-error-groups.mjs" "scripts/monitoring-error-groups.test.ts"`
- PASS: `node_modules\.bin\tsc.cmd --noEmit`
- PASS: `node_modules\.bin\tsc.cmd --project server/tsconfig.server.json --noEmit`

## Wider Check
- WARN: full `node_modules\.bin\vitest.cmd run -c server/vitest.config.ts --coverage.enabled=false` ran 1472 tests; 1385 passed, 82 skipped, and 5 failed by unrelated hook/test timeouts in `ai`, `digest`, `api-critical`, `regression`, and `TranscriptionService.additional`.

## Monitoring
Refs #1403.
Refs #1404.
Do not close the monitoring issues until this is deployed and a fresh Railway monitor run no longer reports the groups.
