### PR TITLE
[#1237] [Production Readiness][P1] Type recorder store and queue processor critical path

### DIFF
--- a/src/lib/recordingQueue.ts
+++ b/src/lib/recordingQueue.ts
@@ -247,11 +247,17 @@ export interface RecordingQueueItem {
   queuedPosition?: number | null;
   processingAgeMs?: number | null;
   retryAfterMs?: number | null;
+  errorCode?: string;
+  retryable?: boolean;
+  audioValidation?: unknown;
+  sttAttempts?: unknown[];
   recordingConsent?: RecordingConsentMetadata | null;
   /** Timestamp (ISO string) when processing started — used to compute elapsed processing time */
   lastReconciledAt?: number;
   processingStartedAt?: string;
 }
+
+export type RecordingQueueItemUpdate = Partial<RecordingQueueItem>;
 
 export interface RecordingQueueSummary {
   total: number;
@@ -277,7 +283,7 @@ interface CreateRecordingQueueItemInput {
   recordingConsent?: RecordingConsentMetadata | null;
 }
 
-export function normalizeRecordingPipelineStatus(value) {
+export function normalizeRecordingPipelineStatus(value: unknown): RecordingPipelineStatus {
   if (value === 'completed') {
     return 'done';
   }
@@ -375,6 +381,15 @@ export function normalizeRecordingQueue(queue: unknown[] = []): RecordingQueueIt
         pipelineBuildTime: current.pipelineBuildTime || '',
         audioQuality: current.audioQuality || null,
         transcriptionDiagnostics: current.transcriptionDiagnostics || null,
+        activeJob: Boolean(current.activeJob),
+        queuedPosition: typeof current.queuedPosition === 'number' ? current.queuedPosition : null,
+        processingAgeMs:
+          typeof current.processingAgeMs === 'number' ? current.processingAgeMs : null,
+        retryAfterMs: typeof current.retryAfterMs === 'number' ? current.retryAfterMs : null,
+        errorCode: String(current.errorCode || ''),
+        retryable: Boolean(current.retryable),
+        audioValidation: current.audioValidation || null,
+        sttAttempts: Array.isArray(current.sttAttempts) ? current.sttAttempts : [],
         recordingConsent: current.recordingConsent || null,
         lastReconciledAt: Math.max(0, Number(current.lastReconciledAt) || 0),
       };
@@ -439,7 +454,7 @@ export function removeRecordingQueueItemsForMeeting(
 export function updateRecordingQueueItem(
   queue: unknown[],
   recordingId: string,
-  updates: Partial<RecordingQueueItem>
+  updates: RecordingQueueItemUpdate
 ): RecordingQueueItem[] {
   const existing = normalizeRecordingQueue(queue).find((item) => item.recordingId === recordingId);
   if (!existing) {

--- a/src/services/mediaService.ts
+++ b/src/services/mediaService.ts
@@ -9,6 +9,8 @@ import {
   normalizeMediaTranscriptionResponse,
   type MediaTranscriptionResponse,
 } from '../shared/contracts';
+import type { TranscriptSegment } from '../shared/types';
+import type { RecordingConsentMetadata } from '../lib/recordingConsent';
 
 export const REMOTE_TRANSCRIPTION_PROVIDER = {
   id: 'remote-pipeline',
@@ -30,6 +32,53 @@ const DEFAULT_UPLOAD_POLICY = {
 let uploadPolicyPromise: Promise<typeof DEFAULT_UPLOAD_POLICY> | null = null;
 const mediaApiOptions = MEDIA_API_BASE_URL ? { baseUrl: MEDIA_API_BASE_URL } : {};
 type TranscriptionProgressAuthMode = 'session' | 'progress';
+type LiveTranscriptionControllerOptions = Parameters<
+  typeof createBrowserTranscriptionController
+>[0];
+
+export interface MediaServiceMeetingTarget {
+  id?: string;
+  workspaceId?: string;
+  title?: string;
+  attendees?: Array<string | { name?: string; email?: string }>;
+  tags?: unknown[];
+  [key: string]: unknown;
+}
+
+export interface PersistRecordingAudioOptions {
+  workspaceId?: string;
+  meetingId?: string;
+  onProgress?: (percent: number) => void;
+}
+
+export interface PersistRecordingAudioResult {
+  storageMode: 'indexeddb' | 'remote' | string;
+  partCount?: number;
+  durationMs?: number;
+  audioQuality?: unknown;
+}
+
+export interface StartTranscriptionJobInput {
+  recordingId?: string;
+  blob?: Blob | null;
+  meeting?: MediaServiceMeetingTarget | null;
+  rawSegments?: TranscriptSegment[];
+  recordingConsent?: RecordingConsentMetadata | null;
+}
+
+export interface TranscriptionProgressPayload {
+  status?: string;
+  progress?: number;
+  message?: string;
+  [key: string]: unknown;
+}
+
+export interface RagAnswerResponse {
+  answer?: string;
+  [key: string]: unknown;
+}
+
+export type RagAnswerResult = RagAnswerResponse | string;
 
 export function buildTranscriptionProgressRequest(
   recordingId: string,
@@ -59,7 +108,7 @@ async function getUploadPolicy() {
       method: 'GET',
       retries: 0,
     })
-      .then((policy: any) => ({
+      .then((policy: unknown) => ({
         ...DEFAULT_UPLOAD_POLICY,
         ...(policy && typeof policy === 'object' ? policy : {}),
       }))
@@ -68,18 +117,19 @@ async function getUploadPolicy() {
   return uploadPolicyPromise;
 }
 
-function isRetryableChunkUploadError(error: any) {
+function isRetryableChunkUploadError(error: unknown) {
   // Never retry when browser is clearly offline
   if (typeof navigator !== 'undefined' && navigator.onLine === false) {
     return false;
   }
 
-  const status = Number(error?.status || 0);
+  const errorDetails = error as { status?: unknown; message?: unknown } | null | undefined;
+  const status = Number(errorDetails?.status || 0);
   if ([429, 502, 503, 504].includes(status)) {
     return true;
   }
 
-  const message = String(error?.message || '').toLowerCase();
+  const message = String(errorDetails?.message || '').toLowerCase();
   return (
     message.includes('backend jest chwilowo niedostepny') ||
     message.includes('failed to fetch') ||
@@ -126,7 +176,7 @@ async function uploadChunkWithRetry({
         }
       );
       return;
-    } catch (error: any) {
+    } catch (error: unknown) {
       attempt += 1;
       const canRetry = isRetryableChunkUploadError(error) && attempt < maxAttempts;
       if (!canRetry) {
@@ -138,7 +188,9 @@ async function uploadChunkWithRetry({
           Math.min(attempt - 1, CHUNK_UPLOAD_RETRY_DELAYS_MS.length - 1)
         ];
       console.warn(
-        `[upload] Chunk ${index + 1}/${total} retry ${attempt}/${maxAttempts - 1} after error: ${error?.message || 'unknown error'}`
+        `[upload] Chunk ${index + 1}/${total} retry ${attempt}/${maxAttempts - 1} after error: ${
+          (error as { message?: unknown } | null)?.message || 'unknown error'
+        }`
       );
       await sleep(delayMs);
     }
@@ -177,26 +229,75 @@ export function mapRemoteTranscriptionResult(response: MediaTranscriptionRespons
   };
 }
 
-function createLocalMediaService() {
+type RemoteTranscriptionResultBase = ReturnType<typeof mapRemoteTranscriptionResult>;
+
+export type MediaTranscriptionJobResult = Partial<
+  Omit<RemoteTranscriptionResultBase, 'diarization' | 'pipelineStatus' | 'reviewSummary'>
+> & {
+  diarization?: unknown;
+  verifiedSegments?: TranscriptSegment[];
+  providerId?: string;
+  providerLabel?: string;
+  pipelineStatus?: string;
+  reviewSummary?: unknown;
+};
+
+export interface MediaService {
+  mode: 'local' | 'remote';
+  supportsLiveTranscription: () => boolean;
+  createLiveController: (options: LiveTranscriptionControllerOptions) => unknown;
+  persistRecordingAudio: (
+    recordingId: string,
+    blob: Blob,
+    options?: PersistRecordingAudioOptions
+  ) => Promise<PersistRecordingAudioResult>;
+  getRecordingAudioBlob: (recordingId: string) => Promise<Blob | null | undefined>;
+  startTranscriptionJob: (
+    input: StartTranscriptionJobInput
+  ) => Promise<MediaTranscriptionJobResult>;
+  getTranscriptionJobStatus: (recordingId: string) => Promise<MediaTranscriptionJobResult | null>;
+  retryTranscriptionJob?: (recordingId: string) => Promise<MediaTranscriptionJobResult | null>;
+  normalizeRecordingAudio: (recordingId: string) => Promise<void>;
+  transcribeLiveChunk?: (blob: Blob) => Promise<string>;
+  getVoiceCoaching: (
+    recordingId: string,
+    speakerId: string,
+    segments: TranscriptSegment[]
+  ) => Promise<string>;
+  rediarize: (recordingId: string) => Promise<unknown>;
+  subscribeToTranscriptionProgress: (
+    recordingId: string,
+    onProgress: (payload: TranscriptionProgressPayload) => void
+  ) => (() => void) | undefined;
+  extractVoiceProfileFromSpeaker: (
+    recordingId: string,
+    speakerId: string,
+    speakerName?: string
+  ) => Promise<unknown>;
+  askRAG: (workspaceId: string, question: string) => Promise<RagAnswerResult>;
+  deleteRecording: (recordingId: string) => Promise<void>;
+}
+
+function createLocalMediaService(): MediaService {
   return {
     mode: 'local',
     supportsLiveTranscription() {
       return Boolean(getSpeechRecognitionClass());
     },
-    createLiveController(options) {
+    createLiveController(options: LiveTranscriptionControllerOptions) {
       return createBrowserTranscriptionController(options);
     },
-    async persistRecordingAudio(recordingId, blob) {
+    async persistRecordingAudio(recordingId: string, blob: Blob) {
       await saveAudioBlob(recordingId, blob);
       return {
         storageMode: 'indexeddb',
         audioQuality: null,
       };
     },
-    getRecordingAudioBlob(recordingId) {
+    getRecordingAudioBlob(recordingId: string) {
       return getAudioBlob(recordingId);
     },
-    async startTranscriptionJob({ rawSegments }) {
+    async startTranscriptionJob({ rawSegments }: StartTranscriptionJobInput) {
       const diarization = diarizeSegments(rawSegments || []);
       const verifiedSegments = verifyRecognizedSegments(diarization.segments);
 
@@ -229,12 +330,16 @@ function createLocalMediaService() {
     async normalizeRecordingAudio() {
       throw new Error('Normalizacja głośności niedostępna w trybie lokalnym.');
     },
-    async getVoiceCoaching(recordingId, speakerId, segments) {
+    async getVoiceCoaching(
+      _recordingId: string,
+      _speakerId: string,
+      _segments: TranscriptSegment[]
+    ) {
       throw new Error(
         'Trener Wymowy AI korzystający z analizy akustycznej dostępny jest tylko przy użyciu pełnego trybu serwerowego. Skonfiguruj bazę by odblokować supermoce OpenAI.'
       );
     },
-    async rediarize(recordingId) {
+    async rediarize(_recordingId: string) {
       throw new Error('Diarizacja zaawansowana dostępna tylko w trybie serwerowym.');
     },
     subscribeToTranscriptionProgress() {
@@ -245,7 +350,7 @@ function createLocalMediaService() {
         'Generowanie profili głosowych bazujących na nagraniach z transkrypcji dostępne tylko w trybie serwerowym.'
       );
     },
-    async askRAG(workspaceId, question) {
+    async askRAG(_workspaceId: string, question: string) {
       if (!question) return 'Zadaj konkretne pytanie.';
       return 'Funkcja przeszukiwania baz danych dostępna tylko przez zdalne API.';
     },
@@ -255,19 +360,23 @@ function createLocalMediaService() {
   };
 }
 
-function createRemoteMediaService() {
+function createRemoteMediaService(): MediaService {
   return {
     mode: 'remote',
     supportsLiveTranscription() {
       // Browser SpeechRecognition works independently of where audio is stored
       return Boolean(getSpeechRecognitionClass());
     },
-    createLiveController(options) {
+    createLiveController(options: LiveTranscriptionControllerOptions) {
       // Use browser SpeechRecognition for immediate live captioning;
       // the server does high-quality Whisper transcription post-recording.
       return createBrowserTranscriptionController(options);
     },
-    async persistRecordingAudio(recordingId, blob, options: any = {}) {
+    async persistRecordingAudio(
+      recordingId: string,
+      blob: Blob,
+      options: PersistRecordingAudioOptions = {}
+    ) {
       const { workspaceId = '', meetingId = '', onProgress } = options;
       const resolvedWorkspaceId = String(workspaceId || '').trim();
       if (!resolvedWorkspaceId) {
@@ -309,8 +418,8 @@ function createRemoteMediaService() {
             if (Number.isFinite(nextIndex)) {
               startIndex = Math.max(0, Math.min(total, Math.floor(nextIndex)));
             }
-          } catch (error: any) {
-            if (Number(error?.status) === 404) {
+          } catch (error: unknown) {
+            if (Number((error as { status?: unknown } | null)?.status) === 404) {
               chunkStatusEndpointSupported = 'no';
             }
             // If status lookup fails, fallback to uploading from the beginning.
@@ -399,14 +508,19 @@ function createRemoteMediaService() {
             : null,
       };
     },
-    async getRecordingAudioBlob(recordingId) {
+    async getRecordingAudioBlob(recordingId: string) {
       const response = await apiRequest(`/media/recordings/${recordingId}/audio`, {
         method: 'GET',
         parseAs: 'raw',
       });
       return response.blob();
     },
-    async startTranscriptionJob({ recordingId, blob, meeting, recordingConsent }) {
+    async startTranscriptionJob({
+      recordingId,
+      blob,
+      meeting,
+      recordingConsent,
+    }: StartTranscriptionJobInput) {
       const participants = (meeting?.attendees || [])
         .map((a) => (typeof a === 'string' ? a : a.name || a.email || ''))
         .filter(Boolean);
@@ -425,7 +539,7 @@ function createRemoteMediaService() {
 
       return mapRemoteTranscriptionResult(response);
     },
-    async getTranscriptionJobStatus(recordingId) {
+    async getTranscriptionJobStatus(recordingId: string) {
       const response = await apiRequest(`/media/recordings/${recordingId}/transcribe`, {
         method: 'GET',
         retries: TRANSCRIPTION_STATUS_RETRIES,
@@ -433,17 +547,17 @@ function createRemoteMediaService() {
 
       return mapRemoteTranscriptionResult(response);
     },
-    async retryTranscriptionJob(recordingId) {
+    async retryTranscriptionJob(recordingId: string) {
       const response = await apiRequest(`/media/recordings/${recordingId}/retry-transcribe`, {
         method: 'POST',
       });
 
       return mapRemoteTranscriptionResult(response);
     },
-    async normalizeRecordingAudio(recordingId) {
+    async normalizeRecordingAudio(recordingId: string) {
       await apiRequest(`/media/recordings/${recordingId}/normalize`, { method: 'POST' });
     },
-    async transcribeLiveChunk(blob) {
+    async transcribeLiveChunk(blob: Blob) {
       const response = await apiRequest('/transcribe/live', {
         method: 'POST',
         body: blob,
@@ -451,17 +565,20 @@ function createRemoteMediaService() {
       });
       return typeof response === 'object' ? response?.text || '' : '';
     },
-    async getVoiceCoaching(recordingId, speakerId, segments) {
+    async getVoiceCoaching(recordingId: string, speakerId: string, segments: TranscriptSegment[]) {
       const response = await apiRequest(`/media/recordings/${recordingId}/voice-coaching`, {
         method: 'POST',
         body: { speakerId, segments },
       });
       return typeof response === 'object' ? response?.coaching || '' : '';
     },
-    async rediarize(recordingId) {
+    async rediarize(recordingId: string) {
       return apiRequest(`/media/recordings/${recordingId}/rediarize`, { method: 'POST' });
     },
-    subscribeToTranscriptionProgress(recordingId, onProgress) {
+    subscribeToTranscriptionProgress(
+      recordingId: string,
+      onProgress: (payload: TranscriptionProgressPayload) => void
+    ) {
       const token = resolvePersistedSession()?.token || '';
       const request = buildTranscriptionProgressRequest(recordingId, token);
       let closed = false;
@@ -522,8 +639,8 @@ function createRemoteMediaService() {
               boundary = buffer.search(/\r?\n\r?\n/);
             }
           }
-        } catch (error: any) {
-          if (closed || error?.name === 'AbortError') return;
+        } catch (error: unknown) {
+          if (closed || (error as { name?: unknown } | null)?.name === 'AbortError') return;
           errorCount += 1;
           if (errorCount > PROGRESS_MAX_RECONNECT_ERRORS) return;
           setTimeout(
@@ -543,13 +660,17 @@ function createRemoteMediaService() {
         abortController?.abort();
       };
     },
-    async extractVoiceProfileFromSpeaker(recordingId, speakerId, speakerName) {
+    async extractVoiceProfileFromSpeaker(
+      recordingId: string,
+      speakerId: string,
+      speakerName?: string
+    ) {
       return apiRequest(`/media/recordings/${recordingId}/voice-profiles/from-speaker`, {
         method: 'POST',
         body: { speakerId, speakerName },
       });
     },
-    async askRAG(workspaceId, question) {
+    async askRAG(workspaceId: string, question: string) {
       return apiRequest(`/workspaces/${workspaceId}/rag/ask`, {
         method: 'POST',
         body: { question },
@@ -561,7 +682,7 @@ function createRemoteMediaService() {
   };
 }
 
-export function createMediaService() {
+export function createMediaService(): MediaService {
   return MEDIA_PIPELINE_PROVIDER === 'remote'
     ? createRemoteMediaService()
     : createLocalMediaService();

--- a/src/shared/AskAIPopover.tsx
+++ b/src/shared/AskAIPopover.tsx
@@ -39,7 +39,7 @@ export default function AskAIPopover({ currentWorkspace, onClose }) {
     try {
       const ms = await createMediaService();
       const res = await ms.askRAG(currentWorkspace.id, query);
-      setAnswer(res?.answer || 'Brak odpowiedzi');
+      setAnswer(typeof res === 'string' ? res : res?.answer || 'Brak odpowiedzi');
     } catch (err) {
       setAnswer('Wystąpił błąd podczas przeszukiwania archiwalnych nagrań.');
     } finally {

--- a/src/store/recorderQueueProcessor.ts
+++ b/src/store/recorderQueueProcessor.ts
@@ -2,12 +2,20 @@ import {
   RECORDING_WORKSPACE_REQUIRED_MESSAGE,
   isWorkspaceMissingErrorMessage,
   normalizeRecordingPipelineStatus,
+  type RecordingQueueItemUpdate,
+  type RecordingQueueMeetingLike,
   type RecordingPipelineStatus,
   type RecordingQueueItem,
 } from '../lib/recordingQueue';
 import { addQueueBreadcrumb, captureQueueException, type QueueSentryContext } from '../sentry';
 import type { TranscriptionStatusPayload } from '../shared/types';
 import type { MeetingAnalysis, TranscriptSegment } from '../shared/types';
+import type {
+  MediaService,
+  MediaServiceMeetingTarget,
+  MediaTranscriptionJobResult,
+  PersistRecordingAudioResult,
+} from '../services/mediaService';
 
 type QueueSnapshot = {
   progressPercent: number;
@@ -15,6 +23,24 @@ type QueueSnapshot = {
 };
 
 type QueueStatePatch = Record<string, unknown>;
+
+export type QueueMeetingTarget = MediaServiceMeetingTarget & RecordingQueueMeetingLike;
+
+export type QueueAttachedRecording = {
+  id: string;
+  createdAt: string;
+  duration: number;
+  transcript: TranscriptionStatusPayload['segments'];
+  pipelineStatus: 'done';
+  processingStartedAt?: string | null;
+  processingEndedAt?: string;
+  [key: string]: unknown;
+};
+
+export type AttachCompletedRecording = (
+  meetingId: QueueMeetingTarget | string,
+  recording: QueueAttachedRecording
+) => boolean | void;
 
 export const BACKGROUND_TRANSCRIPTION_PENDING_MESSAGE =
   'Transkrypcja nadal trwa w tle. Odswiezymy status automatycznie.';
@@ -30,15 +56,15 @@ const TRANSCRIPTION_MAX_HARD_TIMEOUT_MS = 90 * 60 * 1000;
 
 export interface QueueProcessorContext {
   nextItem: RecordingQueueItem;
-  resolveMeetingForQueueItem: (item: RecordingQueueItem) => any;
-  attachCompletedRecording: (meetingId: any, recording: any) => boolean | void;
+  resolveMeetingForQueueItem: (item: RecordingQueueItem) => QueueMeetingTarget | null | undefined;
+  attachCompletedRecording: AttachCompletedRecording;
   setCurrentSegments?: (segments: TranscriptionStatusPayload['segments']) => void;
-  updateQueueItem: (recordingId: string, updates: Record<string, unknown>) => void;
+  updateQueueItem: (recordingId: string, updates: RecordingQueueItemUpdate) => void;
   removeQueueItem: (recordingId: string) => void;
   setState: (patch: QueueStatePatch) => void;
   getState: () => { lastQueueErrorKey?: string };
   getAudioBlob: (recordingId: string) => Promise<Blob | null | undefined>;
-  createMediaService: () => any;
+  createMediaService: () => MediaService;
   filterSilence: (blob: Blob) => Promise<{
     blob: Blob;
     originalDurationS: number;
@@ -47,22 +73,22 @@ export interface QueueProcessorContext {
   }>;
   enhanceAndReencode: (blob: Blob, options: Record<string, unknown>) => Promise<Blob>;
   analyzeMeeting: (input: {
-    meeting: any;
+    meeting: QueueMeetingTarget;
     segments: TranscriptSegment[];
     speakerNames: Record<string, string>;
-    diarization: any;
+    diarization: unknown;
   }) => Promise<MeetingAnalysis>;
   getPipelineSnapshot: (
     status: RecordingPipelineStatus | string | null | undefined,
     upstreamProgress?: number | null,
     upstreamMessage?: string
   ) => QueueSnapshot;
-  normalizeTranscriptionResponse: (response: any) => any;
-  buildFallbackAnalysis: (message: string, diarization: any) => any;
+  normalizeTranscriptionResponse: (response: unknown) => StartedTranscription;
+  buildFallbackAnalysis: (message: string, diarization: unknown) => MeetingAnalysis;
   emptyTranscriptMessage: string;
-  toUserFacingQueueError: (error: any) => string;
-  isExpectedDomainFailure: (error: any) => boolean;
-  isTransientNetworkError: (error: any) => boolean;
+  toUserFacingQueueError: (error: unknown) => string;
+  isExpectedDomainFailure: (error: unknown) => boolean;
+  isTransientNetworkError: (error: unknown) => boolean;
   maxAutoRetries: number;
   retryDelaysMs: number[];
   sleep?: (ms: number) => Promise<void>;
@@ -78,7 +104,7 @@ type StartedTranscription = TranscriptionStatusPayload & {
   pipelineVersion?: string;
   pipelineBuildTime?: string;
   audioQuality?: unknown;
-  transcriptionDiagnostics?: Record<string, any> | null;
+  transcriptionDiagnostics?: TranscriptionStatusPayload['transcriptionDiagnostics'] | null;
   transcriptOutcome?: string;
   emptyReason?: string;
   userMessage?: string;
@@ -147,7 +173,7 @@ function maxTranscriptEndSeconds(segments: unknown) {
 function resolveRecordingDurationSeconds(
   nextItem: RecordingQueueItem,
   transcription: Partial<StartedTranscription> | null | undefined,
-  uploadResult: { durationMs?: unknown } | null
+  uploadResult: PersistRecordingAudioResult | null
 ) {
   const candidates = [
     positiveNumber(uploadResult?.durationMs) / 1000,
@@ -165,8 +191,8 @@ function getPollingSleepMs(value: unknown) {
   return Math.max(1500, Math.min(10_000, retryAfterMs));
 }
 
-function getTransientRetryDelayMs(error: any, fallbackDelayMs: number) {
-  const retryAfterMs = Number(error?.retryAfterMs);
+function getTransientRetryDelayMs(error: unknown, fallbackDelayMs: number) {
+  const retryAfterMs = Number((error as { retryAfterMs?: unknown } | null)?.retryAfterMs);
   if (Number.isFinite(retryAfterMs) && retryAfterMs > 0) {
     return Math.max(5_000, Math.min(5 * 60_000, Math.round(retryAfterMs)));
   }
@@ -231,8 +257,15 @@ export function isRemoteRecordingMissingError(
   );
 }
 
+function getRuntimeEnv(): Record<string, unknown> {
+  return ((import.meta as ImportMeta & { env?: Record<string, unknown> }).env || {}) as Record<
+    string,
+    unknown
+  >;
+}
+
 export function shouldReportBackgroundTranscriptionPendingToConsole(
-  env: Record<string, unknown> = ((import.meta as any).env || {}) as Record<string, unknown>
+  env: Record<string, unknown> = getRuntimeEnv()
 ) {
   return env.VITE_VOICELOG_DEBUG_QUEUE === 'true' || env.PROD !== true;
 }
@@ -331,9 +364,9 @@ export async function attachRecordingWithRetry({
   retries = 7,
   retryDelayMs = 2000,
 }: {
-  attachCompletedRecording: (meetingId: any, recording: any) => boolean | void;
-  meetingId: any;
-  recording: any;
+  attachCompletedRecording: AttachCompletedRecording;
+  meetingId: QueueMeetingTarget | string;
+  recording: QueueAttachedRecording;
   sleep?: (ms: number) => Promise<void>;
   retries?: number;
   retryDelayMs?: number;
@@ -349,7 +382,10 @@ export async function attachRecordingWithRetry({
   return attached !== false;
 }
 
-function getAttachTarget(target: any, nextItem?: RecordingQueueItem) {
+function getAttachTarget(
+  target: QueueMeetingTarget | string | null | undefined,
+  nextItem?: RecordingQueueItem
+): QueueMeetingTarget | string | null | undefined {
   if (target && typeof target === 'object' && target.id) {
     return {
       ...target,
@@ -370,11 +406,17 @@ function getAttachTarget(target: any, nextItem?: RecordingQueueItem) {
   return target;
 }
 
-function resolveWorkspaceId(target: any, nextItem: RecordingQueueItem) {
+function resolveWorkspaceId(
+  target: QueueMeetingTarget | null | undefined,
+  nextItem: RecordingQueueItem
+) {
   return String(target?.workspaceId || nextItem.workspaceId || '').trim();
 }
 
-function hasRecoverableAttachContext(target: any, nextItem: RecordingQueueItem) {
+function hasRecoverableAttachContext(
+  target: QueueMeetingTarget | null | undefined,
+  nextItem: RecordingQueueItem
+) {
   const attachTarget = getAttachTarget(target, nextItem);
   if (!attachTarget || typeof attachTarget !== 'object' || !attachTarget.id) {
     return false;
@@ -435,7 +477,7 @@ export async function waitForCompletedTranscription({
   softPollingMs = TRANSCRIPTION_SOFT_POLLING_MS,
 }: {
   nextItem: RecordingQueueItem;
-  mediaService: any;
+  mediaService: MediaService;
   started: StartedTranscription;
   startStatus: RecordingPipelineStatus;
   updateQueueItem: QueueProcessorContext['updateQueueItem'];
@@ -479,8 +521,8 @@ export async function waitForCompletedTranscription({
       ) as StartedTranscription;
       lastStatus = result;
       consecutiveErrors = 0;
-    } catch (pollError: any) {
-      if (Number(pollError?.status) === 404) {
+    } catch (pollError: unknown) {
+      if (Number((pollError as { status?: unknown } | null)?.status) === 404) {
         throw new RemoteRecordingMissingError(pollError);
       }
 
@@ -494,7 +536,7 @@ export async function waitForCompletedTranscription({
       ) {
         console.warn(
           `[Pipeline] Status poll error (${consecutiveErrors}/${maxConsecutiveErrors}, total ${totalPollErrors}/${maxTotalPollErrors}):`,
-          pollError?.message
+          (pollError as { message?: string } | null)?.message
         );
       }
 
@@ -528,9 +570,18 @@ export async function waitForCompletedTranscription({
         audioQuality: result?.audioQuality || nextItem.audioQuality || null,
         transcriptionDiagnostics: result?.transcriptionDiagnostics || null,
       });
-      const failedError: any = new Error(
+      const failedError = new Error(
         result?.errorMessage || 'Serwer nie zakonczyl transkrypcji.'
-      );
+      ) as Error & {
+        audioQuality?: unknown;
+        transcriptionDiagnostics?: TranscriptionStatusPayload['transcriptionDiagnostics'] | null;
+        errorCode?: string;
+        code?: string;
+        retryable?: boolean;
+        retryAfterMs?: unknown;
+        audioValidation?: unknown;
+        sttAttempts?: unknown[];
+      };
       failedError.audioQuality = result?.audioQuality || null;
       failedError.transcriptionDiagnostics = result?.transcriptionDiagnostics || null;
       failedError.errorCode =
@@ -682,7 +733,7 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
       return;
     }
 
-    let uploadResult: { durationMs?: unknown; audioQuality?: unknown } | null = null;
+    let uploadResult: PersistRecordingAudioResult | null = null;
     if (!nextItem.uploaded) {
       let uploadBlob: Blob | null = localBlob as Blob;
       let vadRemovedS = 0;
@@ -791,13 +842,13 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
       pipelineStage: canReuseRemoteUpload ? 'retry' : 'job_start',
     });
 
-    let startedRaw: unknown;
+    let startedRaw: MediaTranscriptionJobResult | null;
     if (canReuseRemoteUpload) {
-      let currentRaw: unknown;
+      let currentRaw: MediaTranscriptionJobResult | null;
       try {
         currentRaw = await mediaService.getTranscriptionJobStatus(nextItem.recordingId);
-      } catch (statusError: any) {
-        if (Number(statusError?.status) === 404) {
+      } catch (statusError: unknown) {
+        if (Number((statusError as { status?: unknown } | null)?.status) === 404) {
           throw new RemoteRecordingMissingError(statusError);
         }
         throw statusError;
@@ -827,7 +878,11 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
       workspaceId,
       pipelineStage: normalizeRecordingPipelineStatus(started?.pipelineStatus),
       providerId: transcriptionProviderId,
-      jobId: String((started as any)?.jobId || (started as any)?.durableJobId || ''),
+      jobId: String(
+        (started as { jobId?: unknown; durableJobId?: unknown })?.jobId ||
+          (started as { durableJobId?: unknown })?.durableJobId ||
+          ''
+      ),
     });
 
     updateQueueItem(nextItem.recordingId, {
@@ -847,7 +902,7 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
 
     const unsubscribeProgress = mediaService.subscribeToTranscriptionProgress?.(
       nextItem.recordingId,
-      (payload: any) => {
+      (payload) => {
         if (!payload || !payload.message) return;
         const progressSnapshot = getPipelineSnapshot(
           payload?.status || 'processing',
@@ -912,7 +967,7 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
         id: nextItem.recordingId,
         createdAt: nextItem.createdAt || new Date().toISOString(),
         duration: resolvedDurationSeconds,
-        transcript: [],
+        transcript: [] as TranscriptionStatusPayload['segments'],
         transcriptOutcome: 'empty',
         emptyReason:
           transcription.emptyReason ||
@@ -939,7 +994,7 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
         },
         transcriptionProvider: transcriptionProviderId,
         transcriptionProviderLabel: transcriptionProviderLabel,
-        pipelineStatus: 'done',
+        pipelineStatus: 'done' as const,
         storageMode: mediaService.mode === 'remote' ? 'remote' : 'indexeddb',
         analysis: buildFallbackAnalysis('Nie wykryto wypowiedzi w nagraniu.', {
           speakerNames: transcription.speakerNames || {},
@@ -951,7 +1006,7 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
 
       const attached = await attachRecordingWithRetry({
         attachCompletedRecording,
-        meetingId: getAttachTarget(targetWithWorkspace, nextItem),
+        meetingId: getAttachTarget(targetWithWorkspace, nextItem) ?? targetWithWorkspace,
         recording,
         sleep,
       });
@@ -1025,7 +1080,10 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
         {
           workspaceId,
           pipelineStage: 'ai_analysis',
-          errorCode: (error as any)?.errorCode || (error as any)?.code || 'AI_ANALYSIS_FAILED',
+          errorCode:
+            String((error as { errorCode?: unknown; code?: unknown })?.errorCode || '') ||
+            String((error as { code?: unknown })?.code || '') ||
+            'AI_ANALYSIS_FAILED',
           retryable: true,
         },
         { level: 'warning' }
@@ -1054,7 +1112,7 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
       },
       transcriptionProvider: transcriptionProviderId,
       transcriptionProviderLabel: transcriptionProviderLabel,
-      pipelineStatus: 'done',
+      pipelineStatus: 'done' as const,
       pipelineGitSha: transcription.pipelineGitSha || '',
       pipelineVersion: transcription.pipelineVersion || '',
       pipelineBuildTime: transcription.pipelineBuildTime || '',
@@ -1068,7 +1126,7 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
 
     const attached = await attachRecordingWithRetry({
       attachCompletedRecording,
-      meetingId: getAttachTarget(targetWithWorkspace, nextItem),
+      meetingId: getAttachTarget(targetWithWorkspace, nextItem) ?? targetWithWorkspace,
       recording,
       sleep,
     });
@@ -1114,7 +1172,18 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
           ? 'Nagranie czeka czesciowo na review.'
           : 'Nagranie zostalo przetworzone.',
     });
-  } catch (error: any) {
+  } catch (error: unknown) {
+    const errorDetails = error as
+      | {
+          message?: unknown;
+          errorCode?: unknown;
+          code?: unknown;
+          status?: unknown;
+          statusCode?: unknown;
+          retryAfterMs?: unknown;
+        }
+      | null
+      | undefined;
     if (isBackgroundTranscriptionPendingError(error)) {
       const retryAfterMs = normalizeRetryAfterMs(error.retryAfterMs);
       const status = normalizeRecordingPipelineStatus(error.pipelineStatus || nextItem.status);
@@ -1160,14 +1229,14 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
       const delay = getTransientRetryDelayMs(error, fallbackDelay);
       console.warn(
         `[queue] Transient network error (retry ${retryCount + 1}/${maxAutoRetries}), backoff ${delay}ms`,
-        error?.message
+        errorDetails?.message
       );
       updateQueueItem(nextItem.recordingId, {
         status: 'queued',
         retryCount: retryCount + 1,
         backoffUntil: now() + delay,
         lastErrorMessage: toUserFacingQueueError(error),
-        errorCode: error?.errorCode || error?.code || '',
+        errorCode: String(errorDetails?.errorCode || errorDetails?.code || ''),
         retryAfterMs: delay,
         errorMessage: '',
       });
@@ -1176,7 +1245,10 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
         'Queue item scheduled for retry.',
         {
           pipelineStage: 'retry',
-          errorCode: error?.errorCode || error?.code || 'TRANSIENT_QUEUE_ERROR',
+          errorCode:
+            String(errorDetails?.errorCode || '') ||
+            String(errorDetails?.code || '') ||
+            'TRANSIENT_QUEUE_ERROR',
           retryable: true,
           retryCount: retryCount + 1,
           retryAfterMs: delay,
@@ -1196,13 +1268,19 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
           error,
           buildQueueSentryContext(nextItem, {
             pipelineStage: 'queue_failure',
-            errorCode: error?.errorCode || error?.code || 'RECORDING_QUEUE_FAILED',
+            errorCode:
+              String(errorDetails?.errorCode || '') ||
+              String(errorDetails?.code || '') ||
+              'RECORDING_QUEUE_FAILED',
             retryable: false,
-            status: error?.status || error?.statusCode || undefined,
+            status: errorDetails?.status || errorDetails?.statusCode || undefined,
           }),
           {
             level: 'error',
-            fingerprint: ['recording-queue', String(error?.errorCode || error?.code || 'failed')],
+            fingerprint: [
+              'recording-queue',
+              String(errorDetails?.errorCode || errorDetails?.code || 'failed'),
+            ],
           }
         );
       } else {
@@ -1211,7 +1289,10 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
           'Expected recording queue failure handled.',
           {
             pipelineStage: 'queue_failure_expected',
-            errorCode: error?.errorCode || error?.code || 'EXPECTED_QUEUE_FAILURE',
+            errorCode:
+              String(errorDetails?.errorCode || '') ||
+              String(errorDetails?.code || '') ||
+              'EXPECTED_QUEUE_FAILURE',
             retryable: false,
           },
           { level: 'warning' }
@@ -1221,10 +1302,10 @@ export async function processRecordingQueueItem(context: QueueProcessorContext) 
     }
 
     const isPermanent =
-      error?.status === 409 ||
+      Number(errorDetails?.status) === 409 ||
       isRemoteRecordingMissingError(error) ||
       isWorkspaceMissingErrorMessage(userFacingMessage) ||
-      isWorkspaceMissingErrorMessage(error?.message) ||
+      isWorkspaceMissingErrorMessage(errorDetails?.message) ||
       (!isTransientNetworkError(error) && retryCount >= maxAutoRetries);
 
     updateQueueItem(nextItem.recordingId, {

--- a/src/store/recorderStore.ts
+++ b/src/store/recorderStore.ts
@@ -10,6 +10,8 @@ import {
   removeRecordingQueueItemsForMeeting,
   updateRecordingQueueItem,
   isWorkspaceMissingErrorMessage,
+  type RecordingQueueItem,
+  type RecordingQueueItemUpdate,
 } from '../lib/recordingQueue';
 import { getAudioBlob } from '../lib/audioStore';
 import { analyzeMeeting } from '../lib/analysis';
@@ -21,10 +23,72 @@ import {
   normalizeMediaTranscriptionResponse,
   type MediaTranscriptionResponse,
 } from '../shared/contracts';
-import type { TranscriptionStatusPayload } from '../shared/types';
-import type { RecordingPipelineStatus } from '../lib/recordingQueue';
+import type { MeetingAnalysis, TranscriptionStatusPayload } from '../shared/types';
+import type { RecordingPipelineStatus, RecordingQueueMeetingLike } from '../lib/recordingQueue';
 import { isTransportErrorMessage } from '../lib/transportErrors';
-import { isRemoteRecordingMissingError, processRecordingQueueItem } from './recorderQueueProcessor';
+import {
+  isRemoteRecordingMissingError,
+  processRecordingQueueItem,
+  type AttachCompletedRecording,
+  type QueueMeetingTarget,
+} from './recorderQueueProcessor';
+
+type RecorderAnalysisStatus = string;
+type RecordingQueueUpdater =
+  RecordingQueueItem[] | ((queue: RecordingQueueItem[]) => RecordingQueueItem[]);
+type QueueMeetingResolver = (item: RecordingQueueItem) => QueueMeetingTarget | null | undefined;
+type PersistedRecorderStore = Partial<RecorderStoreState> & {
+  recordingQueue?: unknown[];
+};
+
+interface StoredRecordingLike {
+  id?: string;
+  createdAt?: string;
+  duration?: number;
+  contentType?: string;
+  mimeType?: string;
+  transcript?: TranscriptionStatusPayload['segments'];
+  pipelineStatus?: string;
+  transcriptionStatus?: string;
+  status?: string;
+  transcriptOutcome?: string;
+  audioQuality?: unknown;
+  [key: string]: unknown;
+}
+
+export interface RecorderStoreState {
+  recordingQueue: RecordingQueueItem[];
+  analysisStatus: RecorderAnalysisStatus;
+  recordingMessage: string;
+  pipelineProgressPercent: number;
+  pipelineStageLabel: string;
+  isProcessingQueue: boolean;
+  lastQueueErrorKey: string;
+  __recordingQueueNeedsPersistence?: boolean;
+}
+
+export interface RecorderStoreActions {
+  setRecordingQueue: (updater: RecordingQueueUpdater) => void;
+  updateQueueItem: (recordingId: string, updates: RecordingQueueItemUpdate) => void;
+  removeQueueItem: (recordingId: string) => void;
+  removeQueueItemsForMeeting: (meetingId: string, recordingIds?: string[]) => void;
+  setAnalysisStatus: (status: RecorderAnalysisStatus) => void;
+  setRecordingMessage: (message: string) => void;
+  setPipelineProgress: (progressPercent: number | null | undefined, stageLabel?: string) => void;
+  retryRecordingQueueItem: (recordingId: string) => void;
+  retryStoredRecording: (
+    meeting: RecordingQueueMeetingLike | null | undefined,
+    recording: StoredRecordingLike | null | undefined,
+    options?: { force?: boolean }
+  ) => string | null;
+  processQueue: (
+    resolveMeetingForQueueItem: QueueMeetingResolver,
+    attachCompletedRecording: AttachCompletedRecording,
+    setCurrentSegments?: (segments: TranscriptionStatusPayload['segments']) => void
+  ) => Promise<void>;
+}
+
+export type RecorderStore = RecorderStoreState & RecorderStoreActions;
 
 function sleep(ms: number) {
   return new Promise<void>((resolve) => {
@@ -103,19 +167,36 @@ function getPipelineSnapshot(
   };
 }
 
-function buildFallbackAnalysis(message, diarization) {
+function buildFallbackAnalysis(
+  message: string,
+  diarization: { speakerNames?: Record<string, string>; speakerCount?: number } | unknown
+): MeetingAnalysis {
+  const diarizationSnapshot =
+    diarization && typeof diarization === 'object'
+      ? (diarization as { speakerNames?: Record<string, string>; speakerCount?: number })
+      : {};
   return {
     summary: message,
     decisions: [],
     actionItems: [],
+    tasks: [],
     followUps: [],
-    needsCoverage: [],
-    speakerLabels: diarization.speakerNames,
-    speakerCount: diarization.speakerCount,
+    answersToNeeds: [],
+    suggestedTags: [],
+    meetingType: '',
+    energyLevel: '',
+    risks: [],
+    blockers: [],
+    participantInsights: [],
+    tensions: [],
+    keyQuotes: [],
+    suggestedAgenda: [],
+    speakerLabels: diarizationSnapshot.speakerNames,
+    speakerCount: diarizationSnapshot.speakerCount,
   };
 }
 
-function hasCompletedTranscript(recording) {
+function hasCompletedTranscript(recording: StoredRecordingLike | null | undefined) {
   const transcript = Array.isArray(recording?.transcript) ? recording.transcript : [];
   if (transcript.length === 0) {
     return false;
@@ -138,22 +219,21 @@ type ExtendedMediaTranscriptionResponse = MediaTranscriptionResponse & {
   reviewSummary?: unknown;
 };
 
-function normalizeTranscriptionResponse(
-  response: ExtendedMediaTranscriptionResponse | null | undefined
-): TranscriptionStatusPayload & {
+function normalizeTranscriptionResponse(response: unknown): TranscriptionStatusPayload & {
   providerId?: string;
   providerLabel?: string;
   reviewSummary?: unknown;
 } {
-  const normalized = normalizeMediaTranscriptionResponse(response);
+  const typedResponse = response as ExtendedMediaTranscriptionResponse | null | undefined;
+  const normalized = normalizeMediaTranscriptionResponse(typedResponse);
   return {
     ...normalized,
-    segments: Array.isArray(response?.verifiedSegments)
-      ? response.verifiedSegments
+    segments: Array.isArray(typedResponse?.verifiedSegments)
+      ? typedResponse.verifiedSegments
       : normalized.segments,
-    providerId: response?.providerId,
-    providerLabel: response?.providerLabel,
-    reviewSummary: response?.reviewSummary ?? normalized.reviewSummary,
+    providerId: typedResponse?.providerId,
+    providerLabel: typedResponse?.providerLabel,
+    reviewSummary: typedResponse?.reviewSummary ?? normalized.reviewSummary,
   };
 }
 
@@ -167,11 +247,24 @@ function normalizeErrorForMatching(value: unknown) {
     .toLowerCase();
 }
 
-function toUserFacingQueueError(error: any) {
-  const errorMessage = String(error?.message || 'Blad przetwarzania.');
+function toUserFacingQueueError(error: unknown) {
+  const errorDetails = error as
+    | {
+        message?: unknown;
+        errorCode?: unknown;
+        code?: unknown;
+        status?: unknown;
+        transcriptionDiagnostics?: { errorCode?: unknown };
+      }
+    | null
+    | undefined;
+  const errorMessage = String(errorDetails?.message || 'Blad przetwarzania.');
   const normalizedMessage = normalizeErrorForMatching(errorMessage);
   const errorCode = String(
-    error?.errorCode || error?.code || error?.transcriptionDiagnostics?.errorCode || ''
+    errorDetails?.errorCode ||
+      errorDetails?.code ||
+      errorDetails?.transcriptionDiagnostics?.errorCode ||
+      ''
   );
 
   if (isRemoteRecordingMissingError(error)) {
@@ -247,7 +340,7 @@ function toUserFacingQueueError(error: any) {
   }
 
   if (
-    error?.status === 507 ||
+    Number(errorDetails?.status) === 507 ||
     errorMessage.includes('Brak miejsca na dysku') ||
     errorMessage.includes('ENOSPC')
   ) {
@@ -257,10 +350,23 @@ function toUserFacingQueueError(error: any) {
   return errorMessage;
 }
 
-function isExpectedDomainFailure(error: any) {
-  const errorMessage = String(error?.message || '');
+function isExpectedDomainFailure(error: unknown) {
+  const errorDetails = error as
+    | {
+        message?: unknown;
+        errorCode?: unknown;
+        code?: unknown;
+        status?: unknown;
+        transcriptionDiagnostics?: { errorCode?: unknown };
+      }
+    | null
+    | undefined;
+  const errorMessage = String(errorDetails?.message || '');
   const errorCode = String(
-    error?.errorCode || error?.code || error?.transcriptionDiagnostics?.errorCode || ''
+    errorDetails?.errorCode ||
+      errorDetails?.code ||
+      errorDetails?.transcriptionDiagnostics?.errorCode ||
+      ''
   );
   return (
     [
@@ -279,14 +385,27 @@ function isExpectedDomainFailure(error: any) {
     isRemoteRecordingMissingError(error) ||
     isWorkspaceMissingErrorMessage(errorMessage) ||
     errorMessage.includes(RECORDING_WORKSPACE_REQUIRED_MESSAGE) ||
-    error?.status === 409
+    Number(errorDetails?.status) === 409
   );
 }
 
-function isTransientNetworkError(error: any) {
-  const msg = String(error?.message || '');
+function isTransientNetworkError(error: unknown) {
+  const errorDetails = error as
+    | {
+        message?: unknown;
+        errorCode?: unknown;
+        code?: unknown;
+        status?: unknown;
+        transcriptionDiagnostics?: { errorCode?: unknown };
+      }
+    | null
+    | undefined;
+  const msg = String(errorDetails?.message || '');
   const errorCode = String(
-    error?.errorCode || error?.code || error?.transcriptionDiagnostics?.errorCode || ''
+    errorDetails?.errorCode ||
+      errorDetails?.code ||
+      errorDetails?.transcriptionDiagnostics?.errorCode ||
+      ''
   );
   if (errorCode === 'stt_rate_limited' || errorCode === 'stt_provider_rate_limited') return true;
   if (errorCode === 'stt_quota_exceeded') return false;
@@ -299,7 +418,7 @@ function isTransientNetworkError(error: any) {
     return false;
   }
   return (
-    Number(error?.status) === 429 ||
+    Number(errorDetails?.status) === 429 ||
     isTransportErrorMessage(msg) ||
     normalizeErrorForMatching(msg).includes('http 502') ||
     normalizeErrorForMatching(msg).includes('serwer chwilowo przeciazony pamieciowo') ||
@@ -311,11 +430,11 @@ const MAX_AUTO_RETRIES = 5;
 // Exponential backoff delays for retries: 1s, 4s, 16s, 32s, 64s (~2 min total - enough for Railway restart)
 const RETRY_DELAYS_MS = [1000, 4000, 16000, 32000, 64000];
 
-function hasQueueNormalizationDrift(queue: unknown[], normalizedQueue: unknown[]) {
+function hasQueueNormalizationDrift(queue: unknown[], normalizedQueue: RecordingQueueItem[]) {
   const current = Array.isArray(queue) ? queue : [];
   if (current.length !== normalizedQueue.length) return true;
-  return normalizedQueue.some((item: any, index) => {
-    const previous = current[index] as any;
+  return normalizedQueue.some((item, index) => {
+    const previous = current[index] as Partial<RecordingQueueItem> | null | undefined;
     const hadWorkspaceMissingError = isWorkspaceMissingErrorMessage(previous?.errorMessage);
     return Boolean(
       previous?.recordingId &&
@@ -325,9 +444,9 @@ function hasQueueNormalizationDrift(queue: unknown[], normalizedQueue: unknown[]
   });
 }
 
-export const useRecorderStore = create<any>()(
+export const useRecorderStore = create<RecorderStore>()(
   persist(
-    (set, get: any) => ({
+    (set, get) => ({
       recordingQueue: [],
       analysisStatus: 'idle',
       recordingMessage: '',
@@ -412,6 +531,7 @@ export const useRecorderStore = create<any>()(
 
       retryStoredRecording: (meeting, recording, options: { force?: boolean } = {}) => {
         if (!meeting?.id || !recording?.id) return null;
+        const recordingId = recording.id;
         if (hasCompletedTranscript(recording) && !options?.force) {
           set({
             lastQueueErrorKey: '',
@@ -425,14 +545,14 @@ export const useRecorderStore = create<any>()(
         }
         const createdAt = recording.createdAt || new Date().toISOString();
         const queueItem = {
-          id: recording.id,
-          recordingId: recording.id,
+          id: recordingId,
+          recordingId,
           meetingId: meeting.id,
           workspaceId: meeting.workspaceId || '',
           meetingTitle: meeting.title || 'Spotkanie',
           meetingSnapshot: meeting,
           mimeType: recording.contentType || recording.mimeType || 'audio/mpeg',
-          rawSegments: [] as any[],
+          rawSegments: [] as TranscriptionStatusPayload['segments'],
           duration: Number(recording.duration) || 0,
           status: 'queued' as const,
           uploaded: true,
@@ -449,7 +569,7 @@ export const useRecorderStore = create<any>()(
         set((state) => ({
           recordingQueue: updateRecordingQueueItem(
             [...state.recordingQueue, queueItem],
-            recording.id,
+            recordingId,
             queueItem
           ),
           lastQueueErrorKey: '',
@@ -458,7 +578,7 @@ export const useRecorderStore = create<any>()(
           pipelineProgressPercent: 8,
           pipelineStageLabel: 'Ponawiamy transkrypcje z pliku zapisanego na serwerze',
         }));
-        return recording.id;
+        return recordingId;
       },
 
       processQueue: async (
@@ -659,19 +779,19 @@ export const useRecorderStore = create<any>()(
       storage: createJSONStorage(() => idbJSONStorage),
       onRehydrateStorage: () => (state) => {
         if (!state) return;
-        if ((state as any).__recordingQueueNeedsPersistence) {
+        if (state.__recordingQueueNeedsPersistence) {
           state.setRecordingQueue(state.recordingQueue);
         }
       },
       merge: (persistedState, currentState) => {
-        const persisted = (persistedState || {}) as any;
-        const recordingQueue = normalizeRecordingQueue(persisted.recordingQueue);
+        const persisted = (persistedState || {}) as PersistedRecorderStore;
+        const recordingQueue = normalizeRecordingQueue(persisted.recordingQueue || []);
         return {
           ...currentState,
           ...persisted,
           recordingQueue,
           __recordingQueueNeedsPersistence: hasQueueNormalizationDrift(
-            persisted.recordingQueue,
+            persisted.recordingQueue || [],
             recordingQueue
           ),
         };


### PR DESCRIPTION
Closes #1237

## Summary

- Added explicit `RecorderStoreState` / `RecorderStoreActions` contracts and removed `create<any>()` from the recorder queue store.
- Typed queue processor boundaries for meeting resolution, completed-recording attach, queue updates, media service calls, upload results, and transcription progress.
- Added typed media service contracts for local/remote upload, transcription job status/retry, progress SSE, and RAG responses.
- Preserved recorder queue runtime behavior while keeping completed job metadata and queue update fields typed.

## Changed files

- `src/store/recorderStore.ts`
- `src/store/recorderQueueProcessor.ts`
- `src/lib/recordingQueue.ts`
- `src/services/mediaService.ts`
- `src/shared/AskAIPopover.tsx`

## Tests run

- [x] `node_modules\\.bin\\tsc.cmd --noEmit`
- [x] `node scripts\\validate-eslint-lint-gate.mjs; node_modules\\.bin\\eslint.cmd src --max-warnings=0`
- [x] `node_modules\\.bin\\prettier.cmd --check src/lib/recordingQueue.ts src/services/mediaService.ts src/shared/AskAIPopover.tsx src/store/recorderQueueProcessor.ts src/store/recorderStore.ts`
- [x] `node_modules\\.bin\\vitest.cmd run src/hooks/useAudioHardware.test.ts src/hooks/useRecorder.test.tsx src/lib/recordingQueue.test.ts src/store/recorderStore.test.ts src/store/recorderQueueProcessor.test.ts --coverage.enabled=false`
- [x] Vite runtime smoke: `node_modules\\.bin\\vite.cmd --host 127.0.0.1 --port 5177 --strictPort`, verified HTTP 200, then stopped the process.

Note: `pnpm run lint:all` did not reach lint execution locally because pnpm 11 attempted a non-TTY module purge/install (`ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`). The equivalent underlying lint commands above passed.

## Risks

- This is a type-focused refactor across the recorder critical path. Runtime behavior is intended to be unchanged, but CI should still exercise the full frontend suite.
- Existing mojibake copy in touched files was not corrected to keep this PR scoped to #1237.

## Rollback notes

- Revert this PR to restore the prior loose recorder queue typing. No database migrations or external API changes are included.