### PR TITLE
ci(queue): allow PR label synchronization

### DIFF
--- a/.github/workflows/codex-production-readiness-queue.yml
+++ b/.github/workflows/codex-production-readiness-queue.yml
@@ -33,7 +33,7 @@ concurrency:
 permissions:
   contents: read
   issues: write
-  pull-requests: read
+  pull-requests: write
   checks: read
   actions: read
 

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -92,7 +92,7 @@ describe('GitHub workflows validation', () => {
       );
       expect(setupPnpmStep?.uses, `${jobName} pnpm action`).toBe('pnpm/action-setup@v6');
       expect(resolveStoreStep?.run, `${jobName} pnpm store path`).toContain('pnpm store path');
-      expect(cacheStep?.uses, `${jobName} cache action`).toBe('actions/cache@v5');
+      expect(cacheStep?.uses, `${jobName} cache action`).toBe('actions/cache@v6');
       expect(cacheStep?.with?.path, `${jobName} cache path`).toBe('${{ env.PNPM_STORE_PATH }}');
       expect(cacheStep?.with?.key, `${jobName} cache key`).toContain("hashFiles('pnpm-lock.yaml')");
       expect(installStep?.run, `${jobName} install retry loop`).toContain('for attempt in 1 2 3');
@@ -106,7 +106,7 @@ describe('GitHub workflows validation', () => {
     const workflowPath = path.join(workflowDir, 'backend-production-smoke.yml');
     const content = readFileSync(workflowPath, 'utf8');
 
-    expect(content).toContain('uses: actions/cache@v5');
+    expect(content).toContain('uses: actions/cache@v6');
     expect(content).not.toContain('uses: actions/cache@v4');
   });
 
@@ -136,6 +136,7 @@ describe('GitHub workflows validation', () => {
     expect(parsed?.on?.schedule).toBeTruthy();
     expect(parsed?.permissions?.checks).toBe('read');
     expect(parsed?.permissions?.actions).toBe('read');
+    expect(parsed?.permissions?.['pull-requests']).toBe('write');
     expect(content).toContain('codex:checks-failed');
     expect(content).toContain('sync_pr_checks');
     expect(content).toContain('reconcile_open_prs');
@@ -263,7 +264,7 @@ describe('GitHub workflows validation', () => {
 
     expect(content).not.toContain('pnpm install --no-frozen-lockfile');
     expect(resolveStoreStep?.run).toContain('pnpm store path');
-    expect(cacheStep?.uses).toBe('actions/cache@v5');
+    expect(cacheStep?.uses).toBe('actions/cache@v6');
     expect(cacheStep?.with?.path).toBe('${{ env.PNPM_STORE_PATH }}');
     expect(cacheStep?.with?.key).toContain("hashFiles('pnpm-lock.yaml')");
     expect(installStep?.run).toContain('for attempt in 1 2 3');


### PR DESCRIPTION
## Summary
- Grants the production-readiness queue workflow `pull-requests: write` so it can label PRs during `sync_pr_checks` without failing with `Resource not accessible by integration`.
- Updates workflow validation tests to match the merged `actions/cache@v6` Dependabot change from #1366.

## Changed files
- `.github/workflows/codex-production-readiness-queue.yml`
- `scripts/validate-github-workflows.test.ts`

## Tests run
- `node_modules/.bin/vitest.cmd run -c vitest.scripts.config.ts scripts/validate-github-workflows.test.ts --coverage.enabled=false` passed
- `node scripts/validate-github-workflows.mjs` passed
- `npx --yes prettier@3.9.4 --check .github/workflows/codex-production-readiness-queue.yml scripts/validate-github-workflows.test.ts --config .prettierrc` passed before split push; file-level recheck passed after the test commit
- Pre-push release guard passed before local push was blocked by missing local `workflow` OAuth scope

## Risks
- This expands workflow permission from PR read to PR write only for the queue workflow that already mutates issues and labels.

## Rollback
- Revert this PR to return the queue workflow to read-only PR permissions.

Fixes the queue sync failure observed on PR #1406.