### PR TITLE
[#1241] [Production Readiness][P1] Add Playwright audio E2E for record, upload, transcribe, and status states

### DIFF
--- a/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
+++ b/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
@@ -113,6 +113,19 @@ When that PR is merged, the workflow:
 4. Checks the issue line in `#1263`.
 5. Dispatches the next unchecked issue.
 
+## Audio E2E readiness
+
+Issue `#1241` adds a dedicated deterministic browser audio gate:
+
+```powershell
+pnpm run test:e2e:audio
+```
+
+The runner starts Playwright with `PLAYWRIGHT_MEDIA_PROVIDER=remote`, mocks browser
+capture APIs instead of using real microphone hardware, and exercises record,
+pause, resume, stop, upload, processing, retry, transcript attach, and fixture
+audio import paths.
+
 ## Blocked work
 
 If Codex cannot complete an issue:

--- a/package.json
+++ b/package.json
@@ -141,6 +141,7 @@
     "coverage:open:frontend": "start coverage\\frontend\\index.html",
     "coverage:summary": "node scripts/coverage-summary.cjs",
     "test:e2e": "playwright test",
+    "test:e2e:audio": "node scripts/run-audio-playwright.mjs",
     "test:e2e:release": "playwright test tests/e2e/smoke.spec.js tests/e2e/advanced-journeys.spec.js tests/e2e/remote-api.spec.js",
     "test:e2e:remote-api": "node scripts/run-remote-api-playwright.mjs",
     "test:e2e:production-system": "playwright test tests/e2e/production-system-audit.spec.js --project=chromium",

--- a/scripts/run-audio-playwright.mjs
+++ b/scripts/run-audio-playwright.mjs
@@ -1,0 +1,37 @@
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const require = createRequire(import.meta.url);
+const viteBinary = path.join(
+  repoRoot,
+  'node_modules',
+  '.bin',
+  process.platform === 'win32' ? 'vite.cmd' : 'vite'
+);
+const playwrightPackageRoot = path.dirname(require.resolve('@playwright/test'));
+const playwrightCli = path.join(playwrightPackageRoot, 'cli.js');
+const args = [
+  'test',
+  'tests/e2e/audio-pipeline.spec.ts',
+  '--project=chromium',
+  ...process.argv.slice(2),
+];
+
+const result = spawnSync(process.execPath, [playwrightCli, ...args], {
+  stdio: 'inherit',
+  env: {
+    ...process.env,
+    PLAYWRIGHT_MEDIA_PROVIDER: 'remote',
+    PLAYWRIGHT_WEB_COMMAND:
+      process.env.PLAYWRIGHT_WEB_COMMAND || `"${viteBinary}" --host 127.0.0.1 --port 3000`,
+  },
+});
+
+if (result.error) {
+  console.error(result.error);
+}
+
+process.exit(result.status ?? 1);

--- a/tests/e2e/audio-pipeline.spec.ts
+++ b/tests/e2e/audio-pipeline.spec.ts
@@ -1,0 +1,533 @@
+import { expect, test } from '@playwright/test';
+import { fixtureAudioFile, wavToneBuffer } from './fixtures/audioFixture.js';
+import { seedLoggedInUser } from './helpers/seed.js';
+
+test.skip(
+  process.env.PLAYWRIGHT_MEDIA_PROVIDER !== 'remote',
+  'Audio pipeline E2E requires PLAYWRIGHT_MEDIA_PROVIDER=remote; use pnpm run test:e2e:audio.'
+);
+
+type AudioRouteOptions = {
+  holdUpload?: boolean;
+  failUpload?: boolean;
+  failFirstUpload?: boolean;
+  failTranscriptionStart?: boolean;
+};
+
+async function openShellTab(page, label: string) {
+  const hamburger = page.locator('.modern-hamburger-btn');
+  const navItem = page.locator('.modern-nav-item').filter({ hasText: label }).first();
+
+  if (!(await navItem.isVisible().catch(() => false)) && (await hamburger.isVisible())) {
+    await hamburger.click();
+  }
+
+  await expect(navItem).toBeVisible();
+  await navItem.click();
+}
+
+async function acceptRecordingConsent(page) {
+  const dialog = page.getByRole('dialog', { name: /zgod|nagrywanie/i });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await dialog.getByRole('checkbox').check();
+  await dialog.getByRole('button', { name: /Akceptuje i zaczynam nagrywanie/i }).click();
+}
+
+async function readPersistedRecordingQueue(page) {
+  return page.evaluate(() => {
+    const raw = window.localStorage.getItem('voicelog.recordingQueue.v1');
+    return raw ? JSON.parse(raw) : null;
+  });
+}
+
+async function readPersistedMeetings(page) {
+  return page.evaluate(() => {
+    const raw = window.localStorage.getItem('voicelog_meetings_store');
+    return raw ? JSON.parse(raw)?.state?.meetings || [] : [];
+  });
+}
+
+async function installFakeAudioCapture(page, mode: 'ready' | 'permission-denied' | 'unsupported') {
+  await page.addInitScript((captureMode) => {
+    const createFakeStream = () => ({
+      id: `fake_stream_${Date.now()}`,
+      active: true,
+      getTracks: () => [{ kind: 'audio', enabled: true, stop() {} }],
+      getAudioTracks: () => [{ kind: 'audio', enabled: true, stop() {} }],
+    });
+
+    class FakeAudioNode {
+      connect() {
+        return this;
+      }
+      disconnect() {}
+    }
+
+    class FakeAnalyserNode extends FakeAudioNode {
+      fftSize = 256;
+      frequencyBinCount = 32;
+      getByteFrequencyData(target: Uint8Array) {
+        for (let index = 0; index < target.length; index += 1) {
+          target[index] = index % 3 === 0 ? 36 : 12;
+        }
+      }
+    }
+
+    class FakeAudioContext {
+      state = 'running';
+      createMediaStreamSource() {
+        return new FakeAudioNode();
+      }
+      createAnalyser() {
+        return new FakeAnalyserNode();
+      }
+      createMediaStreamDestination() {
+        return { stream: createFakeStream() };
+      }
+      close() {
+        this.state = 'closed';
+        return Promise.resolve();
+      }
+    }
+
+    class FakeMediaRecorder {
+      static isTypeSupported() {
+        return true;
+      }
+      stream: MediaStream;
+      mimeType: string;
+      state = 'inactive';
+      ondataavailable: ((event: { data: Blob }) => void) | null = null;
+      onstop: (() => void) | null = null;
+
+      constructor(stream: MediaStream, options: MediaRecorderOptions = {}) {
+        this.stream = stream;
+        this.mimeType = options.mimeType || 'audio/webm';
+      }
+      start() {
+        this.state = 'recording';
+      }
+      stop() {
+        if (this.state === 'inactive') return;
+        this.state = 'inactive';
+        this.ondataavailable?.({
+          data: new Blob([new Uint8Array(25 * 1024 * 1024)], {
+            type: this.mimeType || 'audio/webm',
+          }),
+        });
+        this.onstop?.();
+      }
+      pause() {
+        this.state = 'paused';
+      }
+      resume() {
+        this.state = 'recording';
+      }
+    }
+
+    Object.defineProperty(navigator, 'permissions', {
+      configurable: true,
+      value: {
+        query: async () => ({
+          state: captureMode === 'permission-denied' ? 'denied' : 'granted',
+          onchange: null,
+        }),
+      },
+    });
+
+    if (captureMode === 'unsupported') {
+      Object.defineProperty(navigator, 'mediaDevices', {
+        configurable: true,
+        value: undefined,
+      });
+      Object.defineProperty(window, 'MediaRecorder', {
+        configurable: true,
+        value: undefined,
+      });
+      return;
+    }
+
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        getUserMedia: async () => {
+          if (captureMode === 'permission-denied') {
+            const error = new Error('Permission denied by E2E test');
+            error.name = 'NotAllowedError';
+            throw error;
+          }
+          return createFakeStream();
+        },
+      },
+    });
+    Object.defineProperty(window, 'AudioContext', {
+      configurable: true,
+      value: FakeAudioContext,
+    });
+    Object.defineProperty(window, 'webkitAudioContext', {
+      configurable: true,
+      value: FakeAudioContext,
+    });
+    Object.defineProperty(window, 'MediaRecorder', {
+      configurable: true,
+      value: FakeMediaRecorder,
+    });
+    delete window.SpeechRecognition;
+    delete window.webkitSpeechRecognition;
+  }, mode);
+}
+
+async function mockRemoteAudioPipeline(page, options: AudioRouteOptions = {}) {
+  const stats = {
+    uploadRequests: 0,
+    transcriptionStartRequests: 0,
+    transcriptionStatusRequests: 0,
+    retryRequests: 0,
+  };
+  let releaseUpload: (() => void) | null = null;
+  let uploadReleased = false;
+  let resolveUploadStarted: () => void = () => {};
+  const uploadStarted = new Promise<void>((resolve) => {
+    resolveUploadStarted = resolve;
+  });
+
+  const completeUpload = async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        storageMode: 'remote',
+        durationMs: 4200,
+        audioQuality: { rmsDb: -18, clipping: false },
+      }),
+    });
+  };
+
+  const maybeHoldOrFailUpload = async (route, isFirstChunkOrSingleUpload: boolean) => {
+    if (isFirstChunkOrSingleUpload) {
+      stats.uploadRequests += 1;
+      resolveUploadStarted();
+    }
+
+    if (options.holdUpload && isFirstChunkOrSingleUpload) {
+      await new Promise<void>((uploadRelease) => {
+        releaseUpload = () => {
+          uploadReleased = true;
+          uploadRelease();
+        };
+        if (uploadReleased) uploadRelease();
+      });
+    }
+
+    if (
+      isFirstChunkOrSingleUpload &&
+      (options.failUpload || (options.failFirstUpload && stats.uploadRequests === 1))
+    ) {
+      await route.fulfill({
+        status: 400,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Upload audio odrzucony przez test E2E.' }),
+      });
+      return true;
+    }
+
+    return false;
+  };
+
+  await page.route('**/media/recordings/*/audio/chunk-status?*', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ nextIndex: 0 }),
+    });
+  });
+
+  await page.route('**/media/recordings/*/audio/chunk?*', async (route, request) => {
+    if (request.method() !== 'PUT') {
+      await route.fallback();
+      return;
+    }
+
+    const index = Number(new URL(request.url()).searchParams.get('index') || 0);
+    if (await maybeHoldOrFailUpload(route, index === 0)) {
+      return;
+    }
+
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true }),
+    });
+  });
+
+  await page.route('**/media/recordings/*/audio/finalize', async (route) => {
+    await completeUpload(route);
+  });
+
+  await page.route('**/media/recordings/*/audio', async (route, request) => {
+    if (request.method() === 'GET') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'audio/wav',
+        body: wavToneBuffer(),
+      });
+      return;
+    }
+
+    if (request.method() !== 'PUT') {
+      await route.fallback();
+      return;
+    }
+
+    if (await maybeHoldOrFailUpload(route, true)) {
+      return;
+    }
+
+    await completeUpload(route);
+  });
+
+  await page.route('**/media/recordings/*/transcribe', async (route, request) => {
+    if (request.method() === 'POST') {
+      stats.transcriptionStartRequests += 1;
+      if (options.failTranscriptionStart) {
+        await route.fulfill({
+          status: 400,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Transkrypcja odrzucona przez test E2E.' }),
+        });
+        return;
+      }
+      await route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          pipelineStatus: 'processing',
+          activeJob: true,
+          queuedPosition: 1,
+          retryAfterMs: 1500,
+        }),
+      });
+      return;
+    }
+
+    stats.transcriptionStatusRequests += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        pipelineStatus: stats.transcriptionStatusRequests === 1 ? 'processing' : 'done',
+        activeJob: stats.transcriptionStatusRequests === 1,
+        retryAfterMs: 1500,
+        segments:
+          stats.transcriptionStatusRequests === 1
+            ? []
+            : [
+                {
+                  id: 'audio-e2e-seg-1',
+                  timestamp: 0,
+                  endTimestamp: 4.2,
+                  speakerId: 0,
+                  text: 'Audio E2E transcript attached.',
+                  verificationStatus: 'verified',
+                },
+              ],
+        speakerNames: { 0: 'Audio E2E' },
+        speakerCount: 1,
+        confidence: 0.98,
+      }),
+    });
+  });
+
+  await page.route('**/media/recordings/*/retry-transcribe', async (route) => {
+    stats.retryRequests += 1;
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        pipelineStatus: 'done',
+        segments: [
+          {
+            id: 'audio-e2e-retry-seg-1',
+            timestamp: 0,
+            endTimestamp: 3,
+            speakerId: 0,
+            text: 'Audio E2E retry transcript attached.',
+            verificationStatus: 'verified',
+          },
+        ],
+        speakerNames: { 0: 'Audio E2E' },
+        speakerCount: 1,
+      }),
+    });
+  });
+
+  await page.route('**/media/analyze', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        summary: 'Audio E2E summary',
+        actionItems: [{ text: 'Confirm audio E2E coverage.' }],
+        decisions: ['Audio pipeline E2E is covered'],
+      }),
+    });
+  });
+
+  await page.route('**/media/upload-policy', async (route) => {
+    await route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        maxRawUploadBytes: 200 * 1024 * 1024,
+        clientChunkBytes: 4 * 1024 * 1024,
+        singleObjectMaxBytes: 24 * 1024 * 1024,
+        segmentPartMaxBytes: 20 * 1024 * 1024,
+        storageContentType: 'audio/webm',
+      }),
+    });
+  });
+
+  return {
+    stats,
+    uploadStarted,
+    releaseUpload: () => {
+      uploadReleased = true;
+      releaseUpload?.();
+    },
+  };
+}
+
+test.describe('Audio recording pipeline E2E', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  test('records, pauses, resumes, uploads, processes, and attaches transcript', async ({
+    page,
+  }) => {
+    const pipeline = await mockRemoteAudioPipeline(page, { holdUpload: true });
+    await installFakeAudioCapture(page, 'ready');
+    await seedLoggedInUser(page);
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Nagraj ad hoc' }).click();
+    await acceptRecordingConsent(page);
+
+    await expect(page.getByText(/Nagrywanie/i).first()).toBeVisible({ timeout: 10_000 });
+    await page.getByRole('button', { name: /Wstrzymaj/i }).click();
+    await expect(page.getByText(/Wstrzymano/i)).toBeVisible();
+    await page.getByRole('button', { name: /Wzn/i }).click();
+    await expect(page.getByText(/Nagrywanie/i).first()).toBeVisible();
+    await page
+      .getByRole('button', { name: /Zako|Stop/i })
+      .first()
+      .click();
+
+    await pipeline.uploadStarted;
+    await expect(page.getByText(/Wgrywanie|Wysy|audio/i).first()).toBeVisible();
+
+    pipeline.releaseUpload();
+    await expect(page.getByText('Audio E2E transcript attached.')).toBeVisible({
+      timeout: 25_000,
+    });
+    await expect(page.getByText('Audio E2E summary')).toBeVisible();
+    expect(pipeline.stats.uploadRequests).toBe(1);
+    expect(pipeline.stats.transcriptionStartRequests).toBe(1);
+    expect(pipeline.stats.transcriptionStatusRequests).toBeGreaterThanOrEqual(2);
+
+    const meetings = await readPersistedMeetings(page);
+    const completedRecording = meetings
+      .flatMap((meeting: { recordings?: unknown[] }) => meeting.recordings || [])
+      .find((recording: { transcript?: Array<{ text?: string }> }) =>
+        recording.transcript?.some((segment) => segment.text === 'Audio E2E transcript attached.')
+      );
+    expect(completedRecording).toBeTruthy();
+  });
+
+  test('shows unsupported microphone state without creating queue item', async ({ page }) => {
+    await installFakeAudioCapture(page, 'unsupported');
+    await seedLoggedInUser(page);
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Nagraj ad hoc' }).click();
+    await acceptRecordingConsent(page);
+
+    await expect(page.getByText(/nie obs.*dost.*mikrofonu/i)).toBeVisible();
+    const queue = await readPersistedRecordingQueue(page);
+    expect(queue?.state?.recordingQueue || []).toHaveLength(0);
+  });
+
+  test('shows permission denied state without creating queue item', async ({ page }) => {
+    await installFakeAudioCapture(page, 'permission-denied');
+    await seedLoggedInUser(page);
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Nagraj ad hoc' }).click();
+    await acceptRecordingConsent(page);
+
+    await expect(page.getByText(/mikrofon.*zablokowany|dostep.*mikrofonu/i)).toBeVisible();
+    const queue = await readPersistedRecordingQueue(page);
+    expect(queue?.state?.recordingQueue || []).toHaveLength(0);
+  });
+
+  test('keeps failed upload retryable and succeeds after retry', async ({ page }) => {
+    const pipeline = await mockRemoteAudioPipeline(page, { failFirstUpload: true });
+    await seedLoggedInUser(page);
+
+    await page.goto('/');
+    await openShellTab(page, 'Nagrania');
+    await page.getByTestId('recordings-file-input').setInputFiles(fixtureAudioFile('retry.webm'));
+    await expect(page.getByText(/Upload audio odrzucony/i).first()).toBeVisible({
+      timeout: 20_000,
+    });
+
+    await page
+      .getByRole('button', { name: /Spr.*ponownie|Ponow przetwarzanie/i })
+      .first()
+      .click();
+    await expect
+      .poll(
+        async () => {
+          const meetings = await readPersistedMeetings(page);
+          return meetings
+            .flatMap((meeting: { recordings?: unknown[] }) => meeting.recordings || [])
+            .some((recording: { transcript?: Array<{ text?: string }> }) =>
+              recording.transcript?.some(
+                (segment) => segment.text === 'Audio E2E transcript attached.'
+              )
+            );
+        },
+        { timeout: 25_000 }
+      )
+      .toBe(true);
+    expect(pipeline.stats.uploadRequests).toBe(2);
+    expect(pipeline.stats.transcriptionStartRequests).toBe(1);
+  });
+
+  test('uploads fixture audio file through deterministic import path', async ({ page }) => {
+    const pipeline = await mockRemoteAudioPipeline(page);
+    await seedLoggedInUser(page);
+
+    await page.goto('/');
+    await openShellTab(page, 'Nagrania');
+    await page.getByTestId('recordings-file-input').setInputFiles(fixtureAudioFile());
+
+    await expect
+      .poll(
+        async () => {
+          const meetings = await readPersistedMeetings(page);
+          return meetings
+            .flatMap((meeting: { recordings?: unknown[] }) => meeting.recordings || [])
+            .some((recording: { transcript?: Array<{ text?: string }> }) =>
+              recording.transcript?.some(
+                (segment) => segment.text === 'Audio E2E transcript attached.'
+              )
+            );
+        },
+        { timeout: 25_000 }
+      )
+      .toBe(true);
+    await page.getByText('Import: audio-e2e-fixture').first().click();
+    await expect(page.getByText('Audio E2E transcript attached.')).toBeVisible();
+    expect(pipeline.stats.uploadRequests).toBe(1);
+    expect(pipeline.stats.transcriptionStartRequests).toBe(1);
+  });
+});

--- a/tests/e2e/fixtures/audioFixture.js
+++ b/tests/e2e/fixtures/audioFixture.js
@@ -1,0 +1,36 @@
+// @ts-check
+
+export function wavToneBuffer({ sampleRate = 16_000, durationSeconds = 1, frequency = 440 } = {}) {
+  const sampleCount = Math.floor(sampleRate * durationSeconds);
+  const buffer = Buffer.alloc(44 + sampleCount * 2);
+  buffer.write('RIFF', 0);
+  buffer.writeUInt32LE(36 + sampleCount * 2, 4);
+  buffer.write('WAVE', 8);
+  buffer.write('fmt ', 12);
+  buffer.writeUInt32LE(16, 16);
+  buffer.writeUInt16LE(1, 20);
+  buffer.writeUInt16LE(1, 22);
+  buffer.writeUInt32LE(sampleRate, 24);
+  buffer.writeUInt32LE(sampleRate * 2, 28);
+  buffer.writeUInt16LE(2, 32);
+  buffer.writeUInt16LE(16, 34);
+  buffer.write('data', 36);
+  buffer.writeUInt32LE(sampleCount * 2, 40);
+
+  for (let index = 0; index < sampleCount; index += 1) {
+    const sample = Math.round(
+      Math.sin((2 * Math.PI * frequency * index) / sampleRate) * 0.25 * 32767
+    );
+    buffer.writeInt16LE(sample, 44 + index * 2);
+  }
+
+  return buffer;
+}
+
+export function fixtureAudioFile(name = 'audio-e2e-fixture.wav') {
+  return {
+    name,
+    mimeType: 'audio/wav',
+    buffer: Buffer.concat([wavToneBuffer(), Buffer.alloc(25 * 1024 * 1024)]),
+  };
+}


### PR DESCRIPTION
Closes #1241

## Summary
- Added a dedicated deterministic Playwright audio E2E gate for the production recorder pipeline.
- Covers ad-hoc recording, pause/resume/stop, upload status, chunked upload, transcription polling, transcript attachment, retry after upload failure, unsupported microphone, permission denied, and fixture-file import.
- Added a small runner that forces remote media mode and invokes Playwright without relying on Windows `.cmd` shims.
- Documented the new audio E2E readiness command in the production readiness queue.

## Changed files
- `tests/e2e/audio-pipeline.spec.ts`
- `tests/e2e/fixtures/audioFixture.js`
- `scripts/run-audio-playwright.mjs`
- `package.json`
- `docs/CODEX_PRODUCTION_READINESS_QUEUE.md`

## Tests run
- `node_modules\.bin\tsc.cmd --noEmit` - passed
- `node_modules\.bin\eslint.cmd tests\e2e\audio-pipeline.spec.ts --max-warnings=0` - passed
- `node_modules\.bin\stylelint.cmd src/**/*.{css,scss}` - passed
- `npx --yes prettier@3.9.4 --check tests/e2e/audio-pipeline.spec.ts tests/e2e/fixtures/audioFixture.js scripts/run-audio-playwright.mjs docs/CODEX_PRODUCTION_READINESS_QUEUE.md package.json` - passed
- `node scripts\run-audio-playwright.mjs` - passed, 5/5 Chromium tests

## Risks
- The new E2E spec intentionally logs expected console errors for negative microphone/upload scenarios; those are part of the test evidence, not production regressions.
- The browser test uses route mocks for backend audio endpoints, so it validates frontend orchestration and UI states rather than real STT provider availability.

## Rollback
- Revert this PR to remove the dedicated audio E2E gate and package script; no runtime product behavior is changed.