### PR TITLE
[#1244] Add Zod request validation contracts for media and AI routes

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,6 +37,8 @@ tags:
     description: Frontend error reporting
   - name: Digest
     description: Email digest notifications
+  - name: AI
+    description: AI proxy endpoints with validated request contracts
 
 security:
   - BearerAuth: []
@@ -409,10 +411,11 @@ paths:
                 meetingId:
                   type: string
                 contentType:
-                  type: string
+                  $ref: '#/components/schemas/AudioContentType'
                 total:
                   type: integer
                   minimum: 1
+                  maximum: 600
       responses:
         '200':
           description: Recording finalized or existing asset returned idempotently
@@ -453,6 +456,12 @@ paths:
                     example: recordingId
         '400':
           description: Missing workspace ID
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
 
   /media/recordings/{recordingId}/transcribe:
     post:
@@ -484,7 +493,7 @@ paths:
                 workspaceId:
                   type: string
                 processingMode:
-                  type: string
+                  $ref: '#/components/schemas/ProcessingMode'
       responses:
         '202':
           description: Transcription queued or active job returned idempotently
@@ -506,6 +515,12 @@ paths:
                   idempotencyScope:
                     type: string
                     example: recordingId
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
     get:
       tags: [Media]
       summary: Get transcription status/result
@@ -551,7 +566,7 @@ paths:
                   type: boolean
                   description: Required to retry an already completed non-empty transcription.
                 processingMode:
-                  type: string
+                  $ref: '#/components/schemas/ProcessingMode'
       responses:
         '202':
           description: Retry queued or active job returned idempotently
@@ -575,6 +590,12 @@ paths:
                     example: recordingId
         '409':
           description: Transcription is already completed and force=true is required.
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
 
   /media/recordings/{recordingId}/sketchnote:
     post:
@@ -618,9 +639,21 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoiceCoachingRequest'
       responses:
         '200':
           description: Voice coaching text
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
 
   /media/recordings/{recordingId}/acoustic-features:
     post:
@@ -646,9 +679,21 @@ paths:
           required: true
           schema:
             type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/VoiceProfileFromSpeakerRequest'
       responses:
         '201':
           description: Voice profile created
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
 
   /media/recordings/{recordingId}/rediarize:
     post:
@@ -670,9 +715,21 @@ paths:
     post:
       tags: [Media]
       summary: Analyze meeting transcript
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiAnalyzeRequest'
       responses:
         '200':
           description: Analysis result
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
 
   /media/recordings/{recordingId}:
     delete:
@@ -713,6 +770,12 @@ paths:
           description: Unauthorized
         '413':
           description: Payload too large
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Voice Profiles
@@ -931,6 +994,66 @@ paths:
         '200':
           description: Digest sent
 
+  /ai/person-profile:
+    post:
+      tags: [AI]
+      summary: Generate AI person profile
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiPersonProfileRequest'
+      responses:
+        '200':
+          description: Profile analysis or no-key fallback
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+
+  /ai/suggest-tasks:
+    post:
+      tags: [AI]
+      summary: Suggest tasks from transcript
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiSuggestTasksRequest'
+      responses:
+        '200':
+          description: Suggested tasks or empty fallback
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+
+  /ai/search:
+    post:
+      tags: [AI]
+      summary: Semantic command search
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AiSearchRequest'
+      responses:
+        '200':
+          description: Search matches or no-key fallback
+        '422':
+          description: Validation failed
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Components
 # ─────────────────────────────────────────────────────────────────────────────
@@ -942,6 +1065,206 @@ components:
       bearerFormat: JWT
 
   schemas:
+    ValidationError:
+      type: object
+      required: [code, message, stage, details]
+      properties:
+        code:
+          type: string
+          enum: [validation_failed]
+        message:
+          type: string
+        stage:
+          type: string
+          enum: [validation]
+        details:
+          type: array
+          items:
+            type: object
+            required: [path, code, message]
+            properties:
+              path:
+                type: string
+              code:
+                type: string
+              message:
+                type: string
+
+    ProcessingMode:
+      type: string
+      enum: [fast, full]
+
+    AudioContentType:
+      type: string
+      description: Supported audio content type.
+      pattern: '^(audio/|multipart/form-data|video/webm$|application/octet-stream$)'
+
+    TranscriptSegmentInput:
+      type: object
+      required: [text]
+      properties:
+        speakerName:
+          type: string
+          maxLength: 160
+        speakerId:
+          oneOf:
+            - type: string
+            - type: integer
+              minimum: 0
+        text:
+          type: string
+          minLength: 1
+          maxLength: 5000
+        meetingTitle:
+          type: string
+          maxLength: 240
+
+    AiAnalyzeRequest:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        meetingId:
+          type: string
+        recordingId:
+          type: string
+        meeting:
+          type: object
+          additionalProperties: true
+        segments:
+          type: array
+          maxItems: 500
+          items:
+            type: object
+            additionalProperties: true
+
+    AiPersonProfileRequest:
+      type: object
+      required: [personName, allSegments]
+      properties:
+        workspaceId:
+          type: string
+        meetingId:
+          type: string
+        personName:
+          type: string
+          minLength: 1
+          maxLength: 160
+        meetings:
+          type: array
+          maxItems: 100
+          items:
+            type: object
+            additionalProperties: true
+        allSegments:
+          type: array
+          maxItems: 1000
+          items:
+            $ref: '#/components/schemas/TranscriptSegmentInput'
+
+    AiSuggestTasksRequest:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        meetingId:
+          type: string
+        transcript:
+          type: array
+          maxItems: 500
+          items:
+            $ref: '#/components/schemas/TranscriptSegmentInput'
+        people:
+          type: array
+          maxItems: 100
+          items:
+            type: object
+            properties:
+              name:
+                type: string
+                maxLength: 160
+              email:
+                type: string
+                maxLength: 254
+
+    AiSearchRequest:
+      type: object
+      required: [query, items]
+      properties:
+        workspaceId:
+          type: string
+        meetingId:
+          type: string
+        query:
+          type: string
+          minLength: 2
+          maxLength: 200
+        items:
+          type: array
+          minItems: 1
+          maxItems: 100
+          items:
+            type: object
+            required: [id, title]
+            properties:
+              id:
+                type: string
+                minLength: 1
+                maxLength: 160
+              title:
+                type: string
+                minLength: 1
+                maxLength: 240
+              subtitle:
+                type: string
+                maxLength: 500
+              type:
+                type: string
+                maxLength: 80
+              group:
+                type: string
+                maxLength: 120
+
+    VoiceProfileFromSpeakerRequest:
+      type: object
+      required: [speakerId, speakerName]
+      properties:
+        speakerId:
+          oneOf:
+            - type: string
+              minLength: 1
+              maxLength: 160
+            - type: integer
+              minimum: 0
+        speakerName:
+          type: string
+          minLength: 1
+          maxLength: 160
+        segments:
+          type: array
+          maxItems: 100
+          items:
+            type: object
+            additionalProperties: true
+
+    VoiceCoachingRequest:
+      type: object
+      required: [speakerId]
+      properties:
+        speakerId:
+          oneOf:
+            - type: string
+              minLength: 1
+              maxLength: 160
+            - type: integer
+              minimum: 0
+        segments:
+          type: array
+          maxItems: 100
+          items:
+            type: object
+            additionalProperties: true
+
     User:
       type: object
       properties:

--- a/server/lib/apiRequestSchemas.ts
+++ b/server/lib/apiRequestSchemas.ts
@@ -1,0 +1,146 @@
+import { z, type ZodSchema } from 'zod';
+
+const optionalTrimmedString = (max = 200) => z.string().trim().min(1).max(max).optional();
+const workspaceIdSchema = optionalTrimmedString(160);
+const meetingIdSchema = optionalTrimmedString(160);
+const recordingIdSchema = optionalTrimmedString(160);
+
+export const processingModeSchema = z.enum(['fast', 'full']);
+
+export const transcriptionStartRequestSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    processingMode: processingModeSchema.optional(),
+  })
+  .passthrough();
+
+export const transcriptionRetryRequestSchema = transcriptionStartRequestSchema.extend({
+  force: z.boolean().optional(),
+});
+
+export const audioContentTypeSchema = z
+  .string()
+  .trim()
+  .toLowerCase()
+  .refine(
+    (value) =>
+      value.startsWith('audio/') ||
+      value.startsWith('multipart/form-data') ||
+      value === 'video/webm' ||
+      value === 'application/octet-stream',
+    'contentType musi wskazywac obslugiwany typ audio.'
+  );
+
+export const chunkFinalizeRequestSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    meetingId: meetingIdSchema,
+    contentType: audioContentTypeSchema.optional(),
+    total: z.coerce.number().int().positive().max(600),
+  })
+  .passthrough();
+
+const looseRecordSchema = z.record(z.string(), z.unknown());
+
+export const aiAnalyzeRequestSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    meetingId: meetingIdSchema,
+    recordingId: recordingIdSchema,
+    recording_id: recordingIdSchema,
+    meeting: looseRecordSchema.optional(),
+    segments: z.array(looseRecordSchema).max(500).optional(),
+  })
+  .passthrough();
+
+const transcriptSegmentSchema = z
+  .object({
+    speakerName: z.string().trim().max(160).optional(),
+    speakerId: z.union([z.number().int().nonnegative(), z.string().trim().min(1)]).optional(),
+    text: z.string().trim().min(1).max(5000),
+    meetingTitle: z.string().trim().max(240).optional(),
+  })
+  .passthrough();
+
+export const aiPersonProfileRequestSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    meetingId: meetingIdSchema,
+    personName: z.string().trim().min(1).max(160),
+    meetings: z.array(looseRecordSchema).max(100).default([]),
+    allSegments: z.array(transcriptSegmentSchema).max(1000),
+  })
+  .passthrough();
+
+export const aiSuggestTasksRequestSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    meetingId: meetingIdSchema,
+    transcript: z.array(transcriptSegmentSchema).max(500).default([]),
+    people: z
+      .array(
+        z
+          .object({
+            name: z.string().trim().max(160).optional(),
+            email: z.string().trim().max(254).optional(),
+          })
+          .passthrough()
+      )
+      .max(100)
+      .default([]),
+  })
+  .passthrough();
+
+export const aiSearchRequestSchema = z
+  .object({
+    workspaceId: workspaceIdSchema,
+    meetingId: meetingIdSchema,
+    query: z.string().trim().min(2).max(200),
+    items: z
+      .array(
+        z
+          .object({
+            id: z.string().trim().min(1).max(160),
+            title: z.string().trim().min(1).max(240),
+            subtitle: z.string().trim().max(500).optional(),
+            type: z.string().trim().max(80).optional(),
+            group: z.string().trim().max(120).optional(),
+          })
+          .passthrough()
+      )
+      .min(1)
+      .max(100),
+  })
+  .passthrough();
+
+export function aiRequestSchemaForPath(path: string): ZodSchema<unknown> {
+  if (path.endsWith('/person-profile')) return aiPersonProfileRequestSchema;
+  if (path.endsWith('/suggest-tasks')) return aiSuggestTasksRequestSchema;
+  return aiSearchRequestSchema;
+}
+
+export const voiceProfileFromSpeakerRequestSchema = z
+  .object({
+    speakerId: z.union([z.string().trim().min(1).max(160), z.number().int().nonnegative()]),
+    speakerName: z.string().trim().min(1).max(160),
+    segments: z.array(looseRecordSchema).max(100).optional(),
+  })
+  .passthrough();
+
+export const voiceCoachingRequestSchema = z
+  .object({
+    speakerId: z.union([z.string().trim().min(1).max(160), z.number().int().nonnegative()]),
+    segments: z.array(looseRecordSchema).max(100).optional(),
+  })
+  .passthrough();
+
+export const liveTranscriptionHeadersSchema = z.object({
+  contentType: audioContentTypeSchema,
+});
+
+export type AiAnalyzeRequestContract = z.infer<typeof aiAnalyzeRequestSchema>;
+export type ChunkFinalizeRequestContract = z.infer<typeof chunkFinalizeRequestSchema>;
+export type TranscriptionStartRequestContract = z.infer<typeof transcriptionStartRequestSchema>;
+export type VoiceProfileFromSpeakerRequestContract = z.infer<
+  typeof voiceProfileFromSpeakerRequestSchema
+>;

--- a/server/lib/requestValidation.ts
+++ b/server/lib/requestValidation.ts
@@ -1,0 +1,50 @@
+import type { Context } from 'hono';
+import type { ZodIssue, ZodSchema } from 'zod';
+
+type ValidationTarget = 'body' | 'query' | 'headers';
+
+function normalizePath(issue: ZodIssue, target: ValidationTarget) {
+  return issue.path.length ? issue.path.map(String).join('.') : target;
+}
+
+export function validationErrorPayload(issues: ZodIssue[], target: ValidationTarget = 'body') {
+  return {
+    code: 'validation_failed',
+    message: 'Nieprawidlowy payload zadania.',
+    stage: 'validation',
+    details: issues.map((issue) => ({
+      path: normalizePath(issue, target),
+      code: issue.code,
+      message: issue.message,
+    })),
+  };
+}
+
+export function validationFailure(
+  c: Context,
+  issues: ZodIssue[],
+  target: ValidationTarget = 'body'
+) {
+  return c.json(validationErrorPayload(issues, target), 422);
+}
+
+export function validatePayload<T>(
+  c: Context,
+  schema: ZodSchema<T>,
+  payload: unknown,
+  target: ValidationTarget = 'body'
+): { ok: true; data: T } | { ok: false; response: Response } {
+  const result = schema.safeParse(payload);
+  if (!result.success) {
+    return { ok: false, response: validationFailure(c, result.error.issues, target) };
+  }
+  return { ok: true, data: result.data };
+}
+
+export async function validateJsonBody<T>(
+  c: Context,
+  schema: ZodSchema<T>
+): Promise<{ ok: true; data: T } | { ok: false; response: Response }> {
+  const body = await c.req.json().catch(() => ({}));
+  return validatePayload(c, schema, body, 'body');
+}

--- a/server/routes/ai.ts
+++ b/server/routes/ai.ts
@@ -9,7 +9,9 @@ import type {
 import type { AppMiddlewares } from './middleware.ts';
 import type { AppServices } from './middleware.ts';
 import { config } from '../config.ts';
+import { aiRequestSchemaForPath } from '../lib/apiRequestSchemas.ts';
 import { createAiQuotaStore, type AiQuotaStore } from '../lib/aiQuotaStore.ts';
+import { validatePayload } from '../lib/requestValidation.ts';
 import { logger } from '../logger.ts';
 
 const ANTHROPIC_URL = 'https://api.anthropic.com/v1/messages';
@@ -241,7 +243,12 @@ export function createAiRoutes(services: AppServices, middlewares: AppMiddleware
         return c.json({ message: 'Brak uzytkownika w sesji.' }, 401);
       }
 
-      const body = await c.req.json().catch(() => ({}));
+      const rawBody = await c.req.json().catch(() => ({}));
+      const validatedBody = validatePayload(c, aiRequestSchemaForPath(c.req.path), rawBody);
+      if (validatedBody.ok === false) {
+        return validatedBody.response;
+      }
+      const body = validatedBody.data;
       c.set('aiBody', body);
 
       const endpoint = getEndpointFromPath(c.req.path);

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -16,8 +16,18 @@ import { streamSSE } from 'hono/streaming';
 import { AppServices, AppMiddlewares } from './middleware.ts';
 import { normalizeTranscriptionStatusPayload } from '../../src/shared/contracts.ts';
 import type { MediaAsset } from '../lib/types.ts';
+import {
+  aiAnalyzeRequestSchema,
+  chunkFinalizeRequestSchema,
+  liveTranscriptionHeadersSchema,
+  transcriptionRetryRequestSchema,
+  transcriptionStartRequestSchema,
+  voiceCoachingRequestSchema,
+  voiceProfileFromSpeakerRequestSchema,
+} from '../lib/apiRequestSchemas.ts';
 import { getMemoryPressure } from '../lib/serverUtils.ts';
 import { createProgressToken } from '../lib/progressTokens.ts';
+import { validateJsonBody, validatePayload } from '../lib/requestValidation.ts';
 import { DISK_SPACE_BLOCK_UPLOAD_BYTES } from '../lib/diskSpace.ts';
 import {
   MAX_RAW_UPLOAD_BYTES,
@@ -1316,7 +1326,9 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
     applyRateLimit('transcription-start', 5),
     async (c) => {
       const recordingId = c.req.param('recordingId');
-      const body = await c.req.json().catch(() => ({}));
+      const bodyValidation = await validateJsonBody(c, transcriptionStartRequestSchema);
+      if (bodyValidation.ok === false) return bodyValidation.response;
+      const body = bodyValidation.data;
       const asset = await transcriptionService.getMediaAsset(recordingId);
       if (!asset) return c.json({ message: 'Nie znaleziono nagrania.' }, 404);
       await ensureWorkspaceAccess(c, body.workspaceId || asset.workspace_id);
@@ -1411,7 +1423,9 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
     applyRateLimit('transcription-retry', 5),
     async (c) => {
       const recordingId = c.req.param('recordingId');
-      const body = await c.req.json().catch(() => ({}));
+      const bodyValidation = await validateJsonBody(c, transcriptionRetryRequestSchema);
+      if (bodyValidation.ok === false) return bodyValidation.response;
+      const body = bodyValidation.data;
       const asset = await transcriptionService.getMediaAsset(recordingId);
       if (!asset) return c.json({ message: 'Nie znaleziono nagrania.' }, 404);
       await ensureWorkspaceAccess(c, asset.workspace_id);
@@ -1721,7 +1735,9 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
   router.post('/recordings/:recordingId/voice-profiles/from-speaker/preflight', async (c) => {
     const requestId = c.get('reqId') || crypto.randomUUID();
     const recordingId = c.req.param('recordingId');
-    const body = await c.req.json().catch(() => ({}));
+    const bodyValidation = await validateJsonBody(c, voiceProfileFromSpeakerRequestSchema);
+    if (bodyValidation.ok === false) return bodyValidation.response;
+    const body = bodyValidation.data;
     const speakerId = String(body?.speakerId ?? '').trim();
     const speakerName = String(body?.speakerName ?? '').trim();
     if (!speakerId) {
@@ -1877,7 +1893,9 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
     const session = c.get('session') as any;
     const requestId = c.get('reqId') || crypto.randomUUID();
     const recordingId = c.req.param('recordingId');
-    const body = await c.req.json().catch(() => ({}));
+    const bodyValidation = await validateJsonBody(c, voiceProfileFromSpeakerRequestSchema);
+    if (bodyValidation.ok === false) return bodyValidation.response;
+    const body = bodyValidation.data;
     const speakerId = String(body?.speakerId ?? '').trim();
     const speakerName = String(body?.speakerName ?? '').trim();
     if (!speakerId) {
@@ -2014,9 +2032,9 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
     async (c) => {
       try {
         const recordingId = c.req.param('recordingId');
-        const body = await c.req.json().catch(() => ({}));
-        if (body.speakerId === undefined || body.speakerId === null)
-          return c.json({ message: 'Brakuje speakerId.' }, 400);
+        const bodyValidation = await validateJsonBody(c, voiceCoachingRequestSchema);
+        if (bodyValidation.ok === false) return bodyValidation.response;
+        const body = bodyValidation.data;
         const asset = await transcriptionService.getMediaAsset(recordingId);
         if (!asset) return c.json({ message: 'Nie znaleziono nagrania.' }, 404);
         await ensureWorkspaceAccess(c, asset.workspace_id);
@@ -2303,7 +2321,9 @@ Important:
   );
 
   router.post('/analyze', authMiddleware, applyRateLimit('analyze', 10), async (c) => {
-    const body = await c.req.json().catch(() => ({}));
+    const bodyValidation = await validateJsonBody(c, aiAnalyzeRequestSchema);
+    if (bodyValidation.ok === false) return bodyValidation.response;
+    const body = bodyValidation.data;
     const workspaceId = String(body.workspaceId || c.req.header('X-Workspace-Id') || '').trim();
     if (!workspaceId) {
       return c.json({ message: 'Brakuje workspaceId.' }, 400);
@@ -2455,11 +2475,13 @@ Important:
     async (c) => {
       const recordingId = c.req.param('recordingId');
       const session = c.get('session') as any;
-      const body = await c.req.json().catch(() => ({}));
+      const bodyValidation = await validateJsonBody(c, chunkFinalizeRequestSchema);
+      if (bodyValidation.ok === false) return bodyValidation.response;
+      const body = bodyValidation.data;
       const workspaceId = body.workspaceId || c.req.header('X-Workspace-Id') || '';
       const meetingId = body.meetingId || c.req.header('X-Meeting-Id') || '';
       const contentType = body.contentType || 'application/octet-stream';
-      const total = parseInt(body.total || '0', 10);
+      const total = body.total;
 
       if (!workspaceId) return c.json({ message: 'Brakuje workspaceId.' }, 400);
       if (!total || total <= 0) return c.json({ message: 'Brakuje total w ciele żądania.' }, 400);
@@ -2757,6 +2779,13 @@ export function createTranscribeRoutes(services: AppServices, middlewares: AppMi
     await ensureWorkspaceAccess(c, workspaceId);
 
     const contentType = c.req.header('content-type') || 'audio/webm';
+    const headerValidation = validatePayload(
+      c,
+      liveTranscriptionHeadersSchema,
+      { contentType },
+      'headers'
+    );
+    if (headerValidation.ok === false) return headerValidation.response;
     const bufferArray = await c.req.arrayBuffer();
     if (bufferArray.byteLength > 5 * 1024 * 1024)
       return c.json({ message: 'Payload too large' }, 413);

--- a/server/tests/contract/api-request-validation-openapi.test.ts
+++ b/server/tests/contract/api-request-validation-openapi.test.ts
@@ -1,0 +1,52 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+interface OpenApiOperation {
+  requestBody?: {
+    content: Record<string, { schema?: unknown }>;
+  };
+  responses?: Record<
+    string,
+    {
+      content: Record<string, { schema?: unknown }>;
+    }
+  >;
+}
+
+interface OpenApiSpec {
+  paths: Record<string, { post?: OpenApiOperation }>;
+}
+
+const spec = parse(readFileSync('openapi.yaml', 'utf8')) as OpenApiSpec;
+
+const validatedPostPaths = [
+  '/media/recordings/{recordingId}/audio/finalize',
+  '/media/recordings/{recordingId}/transcribe',
+  '/media/recordings/{recordingId}/retry-transcribe',
+  '/media/recordings/{recordingId}/voice-coaching',
+  '/media/recordings/{recordingId}/voice-profiles/from-speaker',
+  '/media/analyze',
+  '/transcribe/live',
+  '/ai/person-profile',
+  '/ai/suggest-tasks',
+  '/ai/search',
+];
+
+describe('OpenAPI request validation contracts', () => {
+  it('documents 422 validation errors for validated media and AI endpoints', () => {
+    for (const path of validatedPostPaths) {
+      expect(spec.paths[path]?.post?.responses?.['422'], path).toBeTruthy();
+      expect(spec.paths[path].post.responses['422'].content['application/json'].schema).toEqual({
+        $ref: '#/components/schemas/ValidationError',
+      });
+    }
+  });
+
+  it('documents request bodies for JSON validated endpoints', () => {
+    for (const path of validatedPostPaths.filter((entry) => entry !== '/transcribe/live')) {
+      expect(spec.paths[path]?.post?.requestBody, path).toBeTruthy();
+      expect(spec.paths[path].post.requestBody.content['application/json'].schema).toBeTruthy();
+    }
+  });
+});

--- a/server/tests/routes/ai.test.ts
+++ b/server/tests/routes/ai.test.ts
@@ -114,7 +114,7 @@ describe('AI Routes', () => {
       expect(json.mode).toBe('no-key');
     });
 
-    test('returns no-key mode when personName is missing', async () => {
+    test('returns 422 when personName is missing', async () => {
       const res = await app.request('/ai/person-profile', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-session' },
@@ -124,9 +124,12 @@ describe('AI Routes', () => {
         }),
       });
 
-      expect(res.status).toBe(200);
-      const json = await res.json();
-      expect(json.mode).toBe('no-key');
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        code: 'validation_failed',
+        stage: 'validation',
+        details: expect.arrayContaining([expect.objectContaining({ path: 'personName' })]),
+      });
     });
 
     test('returns no-key mode when allSegments has less than 5 items', async () => {
@@ -629,6 +632,31 @@ describe('AI Routes', () => {
       expect(res.status).toBe(401);
     });
 
+    test('returns safe 422 validation error before calling Anthropic for invalid search payload', async () => {
+      vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
+      global.fetch = vi.fn();
+
+      const res = await app.request('/ai/search', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: 'Bearer valid-session' },
+        body: JSON.stringify({
+          query: '',
+          items: [{ id: 'item-1' }],
+        }),
+      });
+
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        code: 'validation_failed',
+        stage: 'validation',
+        details: expect.arrayContaining([
+          expect.objectContaining({ path: 'query' }),
+          expect.objectContaining({ path: 'items.0.title' }),
+        ]),
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
     test('checks membership when search request includes meeting workspace context', async () => {
       const res = await app.request('/ai/search', {
         method: 'POST',
@@ -679,7 +707,7 @@ describe('AI Routes', () => {
       expect(json.matches).toEqual([]);
     });
 
-    test('returns no-key mode when query is empty or too short', async () => {
+    test('returns 422 when query is empty or too short', async () => {
       vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
 
       const res = await app.request('/ai/search', {
@@ -691,13 +719,15 @@ describe('AI Routes', () => {
         }),
       });
 
-      expect(res.status).toBe(200);
-      const json = await res.json();
-      expect(json.mode).toBe('no-key');
-      expect(json.matches).toEqual([]);
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        code: 'validation_failed',
+        stage: 'validation',
+        details: expect.arrayContaining([expect.objectContaining({ path: 'query' })]),
+      });
     });
 
-    test('returns no-key mode when items are empty', async () => {
+    test('returns 422 when items are empty', async () => {
       vi.stubEnv('ANTHROPIC_API_KEY', 'test-key');
 
       const res = await app.request('/ai/search', {
@@ -709,10 +739,12 @@ describe('AI Routes', () => {
         }),
       });
 
-      expect(res.status).toBe(200);
-      const json = await res.json();
-      expect(json.mode).toBe('no-key');
-      expect(json.matches).toEqual([]);
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        code: 'validation_failed',
+        stage: 'validation',
+        details: expect.arrayContaining([expect.objectContaining({ path: 'items' })]),
+      });
     });
 
     test('returns empty matches when Anthropic API fails', async () => {

--- a/server/tests/routes/media.additional.test.ts
+++ b/server/tests/routes/media.additional.test.ts
@@ -233,7 +233,7 @@ describe('Media Routes - Additional Coverage', () => {
       expect(data.coaching).toEqual({ tips: ['Speak louder', 'Slow down'] });
     });
 
-    it('returns 400 when speakerId is missing', async () => {
+    it('returns 422 when speakerId is missing', async () => {
       mockTranscriptionService.getMediaAsset.mockResolvedValue({
         id: 'rec_voice',
         workspace_id: 'ws_1',
@@ -249,9 +249,12 @@ describe('Media Routes - Additional Coverage', () => {
         body: JSON.stringify({}),
       });
 
-      expect(res.status).toBe(400);
-      const data = await res.json();
-      expect(data.message).toContain('Brakuje speakerId');
+      expect(res.status).toBe(422);
+      await expect(res.json()).resolves.toMatchObject({
+        code: 'validation_failed',
+        stage: 'validation',
+        details: expect.arrayContaining([expect.objectContaining({ path: 'speakerId' })]),
+      });
     });
 
     it('returns 404 when asset does not exist', async () => {
@@ -1024,6 +1027,28 @@ describe('Media Routes - Additional Coverage', () => {
         expect(res.status).toBe(401);
       });
 
+      it('validates finalize payload before asset lookup or chunk assembly', async () => {
+        const res = await app.request('/media/recordings/rec_invalid_finalize/audio/finalize', {
+          method: 'POST',
+          headers: {
+            Authorization: 'Bearer fake_token',
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify({ workspaceId: 'ws_1', total: 0, contentType: 'text/plain' }),
+        });
+
+        expect(res.status).toBe(422);
+        await expect(res.json()).resolves.toMatchObject({
+          code: 'validation_failed',
+          stage: 'validation',
+          details: expect.arrayContaining([
+            expect.objectContaining({ path: 'total' }),
+            expect.objectContaining({ path: 'contentType' }),
+          ]),
+        });
+        expect(mockTranscriptionService.getMediaAsset).not.toHaveBeenCalled();
+      });
+
       it('returns 400 when workspaceId is missing', async () => {
         const res = await app.request('/media/recordings/rec1/audio/finalize', {
           method: 'POST',
@@ -1037,7 +1062,7 @@ describe('Media Routes - Additional Coverage', () => {
         expect(res.status).toBe(400);
       });
 
-      it('returns 400 when total is missing or invalid', async () => {
+      it('returns 422 when total is missing or invalid', async () => {
         const res = await app.request('/media/recordings/rec1/audio/finalize', {
           method: 'POST',
           headers: {
@@ -1048,7 +1073,12 @@ describe('Media Routes - Additional Coverage', () => {
           body: JSON.stringify({ workspaceId: 'ws_1' }),
         });
 
-        expect(res.status).toBe(400);
+        expect(res.status).toBe(422);
+        await expect(res.json()).resolves.toMatchObject({
+          code: 'validation_failed',
+          stage: 'validation',
+          details: expect.arrayContaining([expect.objectContaining({ path: 'total' })]),
+        });
       });
 
       it('returns 400 when chunk assembly fails (missing chunks)', async () => {
@@ -1610,15 +1640,14 @@ describe('Media Routes - Additional Coverage', () => {
         }
       );
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(422);
       const data = await res.json();
-      expect(data.message).toContain('speakerId');
-      expect(data.code).toBe('missing_speaker_id');
+      expect(data.message).toBe('Nieprawidlowy payload zadania.');
+      expect(data.code).toBe('validation_failed');
       expect(data.stage).toBe('validation');
-      expect(data.retryable).toBe(false);
-      expect(data.userAction).toBe('select_speaker');
-      expect(data.recordingId).toBe('rec_vp_missing_speaker');
-      expect(data.requestId).toEqual(expect.any(String));
+      expect(data.details).toEqual(
+        expect.arrayContaining([expect.objectContaining({ path: 'speakerId' })])
+      );
       expect(mockTranscriptionService.createVoiceProfileFromSpeaker).not.toHaveBeenCalled();
     });
 
@@ -1644,16 +1673,13 @@ describe('Media Routes - Additional Coverage', () => {
         }
       );
 
-      expect(res.status).toBe(400);
+      expect(res.status).toBe(422);
       const data = await res.json();
       expect(data).toEqual(
         expect.objectContaining({
-          code: 'missing_speaker_name',
+          code: 'validation_failed',
           stage: 'validation',
-          retryable: false,
-          userAction: 'select_speaker',
-          recordingId: 'rec_vp_missing_name',
-          speakerId: '0',
+          details: expect.arrayContaining([expect.objectContaining({ path: 'speakerName' })]),
         })
       );
       expect(mockTranscriptionService.createVoiceProfileFromSpeaker).not.toHaveBeenCalled();

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -391,6 +391,22 @@ describe('Media Routes', () => {
     );
   });
 
+  it('POST /media/recordings/:recordingId/transcribe - validates body before asset lookup', async () => {
+    const res = await app.request('/media/recordings/rec_invalid_mode/transcribe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspaceId: 'ws_1', processingMode: 'turbo' }),
+    });
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'validation_failed',
+      stage: 'validation',
+      details: expect.arrayContaining([expect.objectContaining({ path: 'processingMode' })]),
+    });
+    expect(mockTranscriptionService.getMediaAsset).not.toHaveBeenCalled();
+  });
+
   // ---------------------------------------------------------------
   // Issue #1234 - active transcription requests should be idempotent
   // Date: 2026-06-28
@@ -1534,6 +1550,28 @@ describe('Media Routes', () => {
     );
   });
 
+  it('POST /media/recordings/:recordingId/voice-profiles/from-speaker validates speaker payload before asset lookup', async () => {
+    const res = await app.request(
+      '/media/recordings/rec_voice_invalid/voice-profiles/from-speaker',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ speakerId: '', speakerName: '' }),
+      }
+    );
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'validation_failed',
+      stage: 'validation',
+      details: expect.arrayContaining([
+        expect.objectContaining({ path: 'speakerId' }),
+        expect.objectContaining({ path: 'speakerName' }),
+      ]),
+    });
+    expect(mockTranscriptionService.getMediaAsset).not.toHaveBeenCalled();
+  });
+
   it('POST /media/recordings/:recordingId/rediarize returns no_changes when diarization fails', async () => {
     mockTranscriptionService.getMediaAsset.mockResolvedValue({
       id: 'rec_rediarize_fail',
@@ -1570,6 +1608,27 @@ describe('Media Routes', () => {
 
     expect(res.status).toBe(200);
     expect(await res.json()).toEqual({ mode: 'no-key' });
+  });
+
+  it('POST /media/analyze validates meeting payload before AI analysis', async () => {
+    mockTranscriptionService.analyzeMeetingWithOpenAI = vi.fn();
+
+    const res = await app.request('/media/analyze', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspaceId: 'ws_1', meeting: 'not-an-object', segments: 'raw text' }),
+    });
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'validation_failed',
+      stage: 'validation',
+      details: expect.arrayContaining([
+        expect.objectContaining({ path: 'meeting' }),
+        expect.objectContaining({ path: 'segments' }),
+      ]),
+    });
+    expect(mockTranscriptionService.analyzeMeetingWithOpenAI).not.toHaveBeenCalled();
   });
 
   it('POST /media/analyze writes a sanitized AI audit event without raw transcript text', async () => {

--- a/server/tests/routes/transcribe.test.ts
+++ b/server/tests/routes/transcribe.test.ts
@@ -51,6 +51,22 @@ describe('Transcribe Routes', () => {
     expect(await res.json()).toEqual({ message: 'Payload too large' });
   });
 
+  it('rejects non-audio live transcription content before provider call', async () => {
+    const res = await app.request('/transcribe/live', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'text/plain' },
+      body: Buffer.alloc(2000, 1),
+    });
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'validation_failed',
+      stage: 'validation',
+      details: expect.arrayContaining([expect.objectContaining({ path: 'contentType' })]),
+    });
+    expect(mockTranscriptionService.transcribeLiveChunk).not.toHaveBeenCalled();
+  });
+
   it('writes temp file, transcribes, and cleans up successful live chunk', async () => {
     mockTranscriptionService.transcribeLiveChunk = vi.fn().mockResolvedValue('hello live');
 


### PR DESCRIPTION
## Summary
- Adds shared Zod request contracts for critical media and AI routes.
- Returns a safe, consistent `422 validation_failed` payload before provider calls, media lookups, or chunk assembly for invalid requests.
- Aligns `openapi.yaml` with the validated request/response contracts and adds a contract test to keep 422 docs in sync.

Closes #1244

## Validation
- RED first: targeted new validation tests failed with the old behavior (`200/400/404` instead of `422`).
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\integration\api-critical.test.ts server\tests\routes\transcribe.test.ts server\tests\contract\api-request-validation-openapi.test.ts --coverage.enabled=false`
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts --retry=3 --coverage.enabled=false`
- `node_modules\.bin\tsc.cmd --project server\tsconfig.server.json --noEmit`
- `node_modules\.bin\tsc.cmd --noEmit`
- `node_modules\.bin\eslint.cmd server\lib\apiRequestSchemas.ts server\lib\requestValidation.ts server\routes\ai.ts server\routes\media.ts server\tests\routes\ai.test.ts server\tests\routes\media.test.ts server\tests\routes\media.additional.test.ts server\tests\routes\transcribe.test.ts server\tests\contract\api-request-validation-openapi.test.ts --max-warnings=0`
- `npx --yes prettier@3.9.4 --check openapi.yaml server\lib\apiRequestSchemas.ts server\lib\requestValidation.ts server\routes\ai.ts server\routes\media.ts server\tests\routes\ai.test.ts server\tests\routes\media.test.ts server\tests\routes\media.additional.test.ts server\tests\routes\transcribe.test.ts server\tests\contract\api-request-validation-openapi.test.ts`
- `node scripts\audit-mojibake.mjs`
- `git diff --check`
- Pre-push release guard passed: `pnpm run test:server:retry`, targeted frontend/runtime guard tests, and `pnpm run audit:build-warnings`.

## Risk / Rollback
- Behavior intentionally changes malformed AI/media requests from ad-hoc `200/400/404` fallbacks to `422 validation_failed` where the route contract is invalid.
- Live transcription keeps existing multipart/form-data compatibility while still rejecting non-audio content types such as `text/plain`.
- Rollback: revert commit `1ca46be` if downstream clients depend on the previous permissive validation behavior.