### PR TITLE
[#1245] Add transcription job operations API

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Root stays intentionally small:
 
 - `adr/` - architecture decision records
 - `ops/` - deployment, runtime, monitoring, APM, disk, and Node setup notes
+  - `ops/TRANSCRIPTION_JOB_OPERATIONS.md` - operator workflow for durable transcription jobs
 - `automation/` - automation workflows, task runners, and historical automation notes
 - `testing/` - coverage, QA, push, and route test reports
 - `archive/audits/` - historical audits and one-off reports

--- a/docs/ops/TRANSCRIPTION_JOB_OPERATIONS.md
+++ b/docs/ops/TRANSCRIPTION_JOB_OPERATIONS.md
@@ -1,0 +1,88 @@
+# Transcription Job Operations
+
+Issue #1245 adds an API-only operator workflow for inspecting and safely acting on durable transcription jobs without direct database access.
+
+## Access
+
+All endpoints require the production ops token through one of these headers:
+
+```bash
+Authorization: Bearer $VOICELOG_ADMIN_TOKEN
+```
+
+or:
+
+```bash
+X-Admin-Token: $VOICELOG_ADMIN_TOKEN
+```
+
+If `VOICELOG_ADMIN_TOKEN` is not configured, the endpoints return `403` and stay disabled.
+
+## List Jobs
+
+```bash
+curl -sS "$VOICELOG_API_URL/api/admin/transcription-jobs?workspaceId=ws_123&status=failed&olderThanMinutes=30&limit=25" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN"
+```
+
+Supported filters:
+
+- `workspaceId`
+- `status`: `queued`, `running`, `retryable_failed`, `failed`, `completed`, `cancelled`
+- `recordingId`
+- `olderThanMinutes`
+- `limit`, capped at 100
+
+The response includes job metadata, timing, lock state, and the last safe error fields. It does not include transcript text, audio paths, or raw audio content.
+
+## Inspect Diagnostics
+
+```bash
+curl -sS "$VOICELOG_API_URL/api/admin/transcription-jobs/tj_123" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN"
+```
+
+Use this before mutating a job. Confirm `workspaceId`, `recordingId`, current `status`, `attemptCount`, and `diagnostics.lastErrorMessage`.
+
+## Retry A Job
+
+```bash
+curl -sS -X POST "$VOICELOG_API_URL/api/admin/transcription-jobs/tj_123/retry" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"operator retry after provider outage"}'
+```
+
+This clears locks and previous error fields, resets attempts to `0`, sets the job to `queued`, and syncs the media asset status to `queued`.
+
+## Cancel A Job
+
+```bash
+curl -sS -X POST "$VOICELOG_API_URL/api/admin/transcription-jobs/tj_123/cancel" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"duplicate upload superseded by a newer recording"}'
+```
+
+This marks the durable job as `cancelled`, clears any lease, and syncs the media asset to the failed/attention state used by the recording UI. A running STT provider request is not force-aborted; the database guard prevents a late completion from overwriting the cancelled job.
+
+## Mark Failed
+
+```bash
+curl -sS -X POST "$VOICELOG_API_URL/api/admin/transcription-jobs/tj_123/mark-failed" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"audio source unavailable after storage incident"}'
+```
+
+This marks the durable job as `failed`, clears any lease, records `OPERATOR_MARK_FAILED`, and syncs the media asset to `failed`.
+
+## Audit And Safety
+
+Every mutating action writes a best-effort audit event:
+
+- `operator.transcription_job.retry`
+- `operator.transcription_job.cancel`
+- `operator.transcription_job.mark_failed`
+
+The audit metadata includes job id, recording id, meeting id, resulting status, and reason. Do not put secrets, transcript text, file paths, or raw provider payloads in the `reason`.

--- a/server/database.ts
+++ b/server/database.ts
@@ -3007,6 +3007,10 @@ export class Database {
     result: TranscriptionResult = {}
   ): Promise<MediaAsset | null> {
     const existing = await this.getMediaAsset(recordingId);
+    const existingJob = await this.getTranscriptionJobByRecordingId(recordingId);
+    if (existingJob && String(existingJob.status) === 'cancelled') {
+      return existing;
+    }
     const existingDiarization = this._safeJsonParse(existing?.diarization_json, {});
     const defaultPipelineMetadata = this._buildPipelineMetadata();
     const pipelineMetadata = {
@@ -3055,7 +3059,7 @@ export class Database {
         recordingId,
       ]
     );
-    const job = await this.getTranscriptionJobByRecordingId(recordingId);
+    const job = existingJob || (await this.getTranscriptionJobByRecordingId(recordingId));
     if (job && job.status !== 'completed') {
       const timestamp = this.nowIso();
       await this._execute(
@@ -3536,6 +3540,138 @@ export class Database {
       [this.nowIso(), jobId, workerId]
     );
     return this._get('SELECT * FROM transcription_jobs WHERE id = ?', [jobId]);
+  }
+
+  async getTranscriptionJobById(jobId: string): Promise<any | null> {
+    const safeJobId = String(jobId || '').trim();
+    if (!safeJobId) return null;
+    return this._get('SELECT * FROM transcription_jobs WHERE id = ?', [safeJobId]);
+  }
+
+  async listTranscriptionJobsForOperations(
+    options: {
+      workspaceId?: string;
+      status?: string;
+      recordingId?: string;
+      olderThanMinutes?: number;
+      limit?: number;
+      now?: string;
+    } = {}
+  ): Promise<any[]> {
+    const where: string[] = [];
+    const params: unknown[] = [];
+    const workspaceId = String(options.workspaceId || '').trim();
+    const status = String(options.status || '').trim();
+    const recordingId = String(options.recordingId || '').trim();
+
+    if (workspaceId) {
+      where.push('workspace_id = ?');
+      params.push(workspaceId);
+    }
+    if (status) {
+      where.push('status = ?');
+      params.push(status);
+    }
+    if (recordingId) {
+      where.push('recording_id = ?');
+      params.push(recordingId);
+    }
+    const olderThanMinutes = Number(options.olderThanMinutes || 0);
+    if (Number.isFinite(olderThanMinutes) && olderThanMinutes > 0) {
+      const baseMs = Date.parse(String(options.now || this.nowIso()));
+      const cutoff = new Date(
+        (Number.isFinite(baseMs) ? baseMs : Date.now()) - olderThanMinutes * 60_000
+      ).toISOString();
+      where.push('updated_at <= ?');
+      params.push(cutoff);
+    }
+
+    const limitInput = Number(options.limit ?? 50);
+    const limit = Math.min(
+      100,
+      Math.max(1, Number.isFinite(limitInput) ? Math.floor(limitInput) : 50)
+    );
+    const clause = where.length ? `WHERE ${where.join(' AND ')}` : '';
+    return this._query(
+      `SELECT * FROM transcription_jobs
+       ${clause}
+       ORDER BY updated_at DESC, created_at DESC
+       LIMIT ?`,
+      [...params, limit]
+    );
+  }
+
+  async retryTranscriptionJobForOperations(
+    jobId: string,
+    _options: { reason?: string } = {}
+  ): Promise<any | null> {
+    const job = await this.getTranscriptionJobById(jobId);
+    if (!job) return null;
+    const now = this.nowIso();
+    await this._execute(
+      `UPDATE transcription_jobs
+       SET status = 'queued',
+           attempt_count = 0,
+           locked_by = '',
+           locked_until = '',
+           next_run_at = ?,
+           last_error_code = '',
+           last_error_message = '',
+           completed_at = NULL,
+           updated_at = ?
+       WHERE id = ?`,
+      [now, now, job.id]
+    );
+    await this._syncMediaAssetTranscriptionStatus(job.recording_id, 'queued');
+    return this.getTranscriptionJobById(job.id);
+  }
+
+  async cancelTranscriptionJobForOperations(
+    jobId: string,
+    options: { reason?: string } = {}
+  ): Promise<any | null> {
+    const job = await this.getTranscriptionJobById(jobId);
+    if (!job) return null;
+    const now = this.nowIso();
+    const reason = this._clean(options.reason || 'Operator cancelled transcription job.');
+    await this._execute(
+      `UPDATE transcription_jobs
+       SET status = 'cancelled',
+           locked_by = '',
+           locked_until = '',
+           last_error_code = 'OPERATOR_CANCELLED',
+           last_error_message = ?,
+           completed_at = ?,
+           updated_at = ?
+       WHERE id = ?`,
+      [reason, now, now, job.id]
+    );
+    await this._syncMediaAssetTranscriptionStatus(job.recording_id, 'cancelled');
+    return this.getTranscriptionJobById(job.id);
+  }
+
+  async markTranscriptionJobFailedForOperations(
+    jobId: string,
+    options: { reason?: string } = {}
+  ): Promise<any | null> {
+    const job = await this.getTranscriptionJobById(jobId);
+    if (!job) return null;
+    const now = this.nowIso();
+    const reason = this._clean(options.reason || 'Operator marked transcription job as failed.');
+    await this._execute(
+      `UPDATE transcription_jobs
+       SET status = 'failed',
+           locked_by = '',
+           locked_until = '',
+           last_error_code = 'OPERATOR_MARK_FAILED',
+           last_error_message = ?,
+           completed_at = ?,
+           updated_at = ?
+       WHERE id = ?`,
+      [reason, now, now, job.id]
+    );
+    await this._syncMediaAssetTranscriptionStatus(job.recording_id, 'failed');
+    return this.getTranscriptionJobById(job.id);
   }
 
   async updateWorkspaceMemberRole(workspaceId, targetUserId, memberRole) {

--- a/server/http/app-routes.ts
+++ b/server/http/app-routes.ts
@@ -39,6 +39,73 @@ function requireOpsAccess(c: any, services: AppServices) {
   return null;
 }
 
+function cleanQueryValue(value: unknown, maxLength = 160) {
+  return String(value || '')
+    .trim()
+    .slice(0, maxLength);
+}
+
+function parsePositiveInt(value: unknown, fallback?: number) {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return Math.floor(parsed);
+}
+
+function safeJobReason(value: unknown) {
+  return cleanQueryValue(value, 500);
+}
+
+function serializeTranscriptionJob(job: any) {
+  if (!job) return null;
+  return {
+    id: String(job.id || ''),
+    recordingId: String(job.recording_id || ''),
+    workspaceId: String(job.workspace_id || ''),
+    meetingId: String(job.meeting_id || ''),
+    status: String(job.status || ''),
+    attemptCount: Number(job.attempt_count || 0),
+    maxAttempts: Number(job.max_attempts || 0),
+    nextRunAt: String(job.next_run_at || ''),
+    createdAt: String(job.created_at || ''),
+    updatedAt: String(job.updated_at || ''),
+    completedAt: String(job.completed_at || ''),
+    diagnostics: {
+      lockedBy: String(job.locked_by || ''),
+      lockedUntil: String(job.locked_until || ''),
+      lastErrorCode: String(job.last_error_code || ''),
+      lastErrorMessage: String(job.last_error_message || ''),
+    },
+  };
+}
+
+async function writeTranscriptionJobOperatorAudit(
+  services: AppServices,
+  action: string,
+  job: any,
+  reason: string,
+  requestId: string
+) {
+  const auditTarget =
+    typeof services.db?.writeAuditLogBestEffort === 'function' ? services.db : null;
+  if (!auditTarget || !job?.workspace_id || !job?.id) return;
+
+  await auditTarget.writeAuditLogBestEffort({
+    workspaceId: String(job.workspace_id),
+    actorUserId: 'ops-token',
+    action,
+    entityType: 'transcription_job',
+    entityId: String(job.id),
+    metadata: {
+      recordingId: String(job.recording_id || ''),
+      meetingId: String(job.meeting_id || ''),
+      status: String(job.status || ''),
+      reason,
+      requestId,
+      source: 'api',
+    },
+  });
+}
+
 export function registerAppRoutes(
   app: Hono<any>,
   services: AppServices,
@@ -78,6 +145,101 @@ export function registerAppRoutes(
     v8.writeHeapSnapshot(filepath);
     return c.json({ message: 'Heap snapshot created', fileName: filename });
   });
+
+  app.get(
+    '/api/admin/transcription-jobs',
+    middlewares.applyRateLimit('admin-sensitive', 20),
+    async (c) => {
+      const denied = requireOpsAccess(c, services);
+      if (denied) return denied;
+      if (typeof services.db?.listTranscriptionJobsForOperations !== 'function') {
+        return c.json({ message: 'Transcription job operations are unavailable.' }, 501);
+      }
+
+      const filters = {
+        workspaceId: cleanQueryValue(c.req.query('workspaceId')),
+        status: cleanQueryValue(c.req.query('status'), 60),
+        recordingId: cleanQueryValue(c.req.query('recordingId')),
+        olderThanMinutes: parsePositiveInt(c.req.query('olderThanMinutes')),
+        limit: parsePositiveInt(c.req.query('limit'), 50),
+      };
+      const jobs = await services.db.listTranscriptionJobsForOperations(filters);
+      return c.json(
+        { jobs: jobs.map(serializeTranscriptionJob), count: jobs.length, filters },
+        200
+      );
+    }
+  );
+
+  app.get(
+    '/api/admin/transcription-jobs/:jobId',
+    middlewares.applyRateLimit('admin-sensitive', 20),
+    async (c) => {
+      const denied = requireOpsAccess(c, services);
+      if (denied) return denied;
+      if (typeof services.db?.getTranscriptionJobById !== 'function') {
+        return c.json({ message: 'Transcription job operations are unavailable.' }, 501);
+      }
+
+      const job = await services.db.getTranscriptionJobById(c.req.param('jobId'));
+      if (!job) return c.json({ message: 'Nie znaleziono zadania transkrypcji.' }, 404);
+      return c.json({ job: serializeTranscriptionJob(job) }, 200);
+    }
+  );
+
+  const runTranscriptionJobAction = async (c: any, methodName: string, auditAction: string) => {
+    const denied = requireOpsAccess(c, services);
+    if (denied) return denied;
+    if (typeof services.db?.[methodName] !== 'function') {
+      return c.json({ message: 'Transcription job operations are unavailable.' }, 501);
+    }
+
+    const body = await c.req.json().catch(() => ({}));
+    const reason = safeJobReason(body?.reason);
+    const job = await services.db[methodName](c.req.param('jobId'), { reason });
+    if (!job) return c.json({ message: 'Nie znaleziono zadania transkrypcji.' }, 404);
+    await writeTranscriptionJobOperatorAudit(
+      services,
+      auditAction,
+      job,
+      reason,
+      c.get('reqId') || ''
+    );
+    return c.json({ job: serializeTranscriptionJob(job) }, 200);
+  };
+
+  app.post(
+    '/api/admin/transcription-jobs/:jobId/retry',
+    middlewares.applyRateLimit('admin-sensitive', 10),
+    (c) =>
+      runTranscriptionJobAction(
+        c,
+        'retryTranscriptionJobForOperations',
+        'operator.transcription_job.retry'
+      )
+  );
+
+  app.post(
+    '/api/admin/transcription-jobs/:jobId/cancel',
+    middlewares.applyRateLimit('admin-sensitive', 10),
+    (c) =>
+      runTranscriptionJobAction(
+        c,
+        'cancelTranscriptionJobForOperations',
+        'operator.transcription_job.cancel'
+      )
+  );
+
+  app.post(
+    '/api/admin/transcription-jobs/:jobId/mark-failed',
+    middlewares.applyRateLimit('admin-sensitive', 10),
+    (c) =>
+      runTranscriptionJobAction(
+        c,
+        'markTranscriptionJobFailedForOperations',
+        'operator.transcription_job.mark_failed'
+      )
+  );
 
   app.route('/auth', createAuthRoutes(services, middlewares));
   app.route('/', createWorkspacesRoutes(services, middlewares));

--- a/server/tests/database/transcriptionJobs.test.ts
+++ b/server/tests/database/transcriptionJobs.test.ts
@@ -454,4 +454,139 @@ describe('transcription_jobs durable queue', () => {
       await db.shutdown();
     }
   });
+
+  test('operator listing filters jobs by workspace, status, recording, and age', async () => {
+    const db = await createDb();
+    try {
+      await insertAsset(db, 'rec_ops_old', 'ws_ops');
+      await insertAsset(db, 'rec_ops_other', 'ws_other');
+      const oldJob = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_ops_old',
+        workspaceId: 'ws_ops',
+      });
+      await db.enqueueTranscriptionJob({
+        recordingId: 'rec_ops_other',
+        workspaceId: 'ws_other',
+      });
+      await db._execute(
+        `UPDATE transcription_jobs
+         SET status = 'failed', updated_at = ?, last_error_code = 'STT_FAILED'
+         WHERE id = ?`,
+        ['2026-07-03T09:00:00.000Z', oldJob.id]
+      );
+
+      const jobs = await db.listTranscriptionJobsForOperations({
+        workspaceId: 'ws_ops',
+        status: 'failed',
+        recordingId: 'rec_ops_old',
+        olderThanMinutes: 30,
+        now: '2026-07-03T10:00:00.000Z',
+      });
+
+      expect(jobs).toHaveLength(1);
+      expect(jobs[0]).toMatchObject({
+        id: oldJob.id,
+        workspace_id: 'ws_ops',
+        recording_id: 'rec_ops_old',
+        status: 'failed',
+        last_error_code: 'STT_FAILED',
+      });
+    } finally {
+      await db.shutdown();
+    }
+  });
+
+  test('operator actions retry, cancel, and mark failed while syncing media status', async () => {
+    const db = await createDb();
+    try {
+      await insertAsset(db, 'rec_ops_retry', 'ws_ops');
+      await insertAsset(db, 'rec_ops_cancel', 'ws_ops');
+      await insertAsset(db, 'rec_ops_fail', 'ws_ops');
+
+      const retryJob = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_ops_retry',
+        workspaceId: 'ws_ops',
+      });
+      const cancelJob = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_ops_cancel',
+        workspaceId: 'ws_ops',
+      });
+      const failJob = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_ops_fail',
+        workspaceId: 'ws_ops',
+      });
+      await db._execute(
+        "UPDATE transcription_jobs SET status = 'failed', attempt_count = 3, last_error_message = 'old' WHERE id = ?",
+        [retryJob.id]
+      );
+
+      const retried = await db.retryTranscriptionJobForOperations(retryJob.id, {
+        reason: 'operator retry',
+      });
+      const cancelled = await db.cancelTranscriptionJobForOperations(cancelJob.id, {
+        reason: 'operator cancel',
+      });
+      const failed = await db.markTranscriptionJobFailedForOperations(failJob.id, {
+        reason: 'operator failed',
+      });
+
+      expect(retried).toMatchObject({
+        id: retryJob.id,
+        status: 'queued',
+        attempt_count: 0,
+        last_error_message: '',
+      });
+      expect(cancelled).toMatchObject({
+        id: cancelJob.id,
+        status: 'cancelled',
+        last_error_code: 'OPERATOR_CANCELLED',
+      });
+      expect(failed).toMatchObject({
+        id: failJob.id,
+        status: 'failed',
+        last_error_code: 'OPERATOR_MARK_FAILED',
+        last_error_message: 'operator failed',
+      });
+      await expect(db.getMediaAsset('rec_ops_retry')).resolves.toMatchObject({
+        transcription_status: 'queued',
+      });
+      await expect(db.getMediaAsset('rec_ops_cancel')).resolves.toMatchObject({
+        transcription_status: 'failed',
+      });
+      await expect(db.getMediaAsset('rec_ops_fail')).resolves.toMatchObject({
+        transcription_status: 'failed',
+      });
+    } finally {
+      await db.shutdown();
+    }
+  });
+
+  test('cancelled running jobs are not overwritten by a late worker completion', async () => {
+    const db = await createDb();
+    try {
+      await insertAsset(db, 'rec_ops_running', 'ws_ops');
+      const job = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_ops_running',
+        workspaceId: 'ws_ops',
+      });
+      await db.acquireTranscriptionJobLease({
+        workerId: 'worker-running',
+        recordingId: 'rec_ops_running',
+      });
+
+      await db.cancelTranscriptionJobForOperations(job.id, { reason: 'operator cancel' });
+      await db.saveTranscriptionResult('rec_ops_running', {
+        pipelineStatus: 'completed',
+        segments: [{ text: 'late result' }],
+      });
+
+      const currentJob = await db.getTranscriptionJobById(job.id);
+      const asset = await db.getMediaAsset('rec_ops_running');
+      expect(currentJob).toMatchObject({ status: 'cancelled' });
+      expect(asset).toMatchObject({ transcription_status: 'failed' });
+      expect(asset?.transcript_json).toBe('[]');
+    } finally {
+      await db.shutdown();
+    }
+  });
 });

--- a/server/tests/routes/adminTranscriptionJobs.test.ts
+++ b/server/tests/routes/adminTranscriptionJobs.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createApp } from '../../app.ts';
+
+function buildApp(dbOverrides: Record<string, unknown> = {}) {
+  const db = {
+    listTranscriptionJobsForOperations: vi.fn().mockResolvedValue([]),
+    getTranscriptionJobById: vi.fn(),
+    retryTranscriptionJobForOperations: vi.fn(),
+    cancelTranscriptionJobForOperations: vi.fn(),
+    markTranscriptionJobFailedForOperations: vi.fn(),
+    writeAuditLogBestEffort: vi.fn().mockResolvedValue(undefined),
+    checkHealth: vi.fn().mockResolvedValue({ ok: true }),
+    ...dbOverrides,
+  };
+  const app = createApp({
+    authService: { getSession: vi.fn() },
+    workspaceService: { getMembership: vi.fn() },
+    transcriptionService: {},
+    db,
+    config: {
+      allowedOrigins: '*',
+      trustProxy: false,
+      uploadDir: '/tmp',
+      adminToken: 'ops-secret',
+    },
+  });
+  return { app, db };
+}
+
+const authHeaders = {
+  Authorization: 'Bearer ops-secret',
+  'Content-Type': 'application/json',
+};
+
+describe('Admin transcription job operations', () => {
+  it('blocks job operations without the admin token', async () => {
+    const { app, db } = buildApp();
+
+    const res = await app.request('/api/admin/transcription-jobs?workspaceId=ws1');
+
+    expect(res.status).toBe(401);
+    expect(db.listTranscriptionJobsForOperations).not.toHaveBeenCalled();
+  });
+
+  it('lists filtered jobs without exposing transcript or audio content', async () => {
+    const { app, db } = buildApp({
+      listTranscriptionJobsForOperations: vi.fn().mockResolvedValue([
+        {
+          id: 'tj_1',
+          recording_id: 'rec_1',
+          workspace_id: 'ws1',
+          meeting_id: 'meeting_1',
+          status: 'failed',
+          attempt_count: 2,
+          max_attempts: 3,
+          locked_by: '',
+          locked_until: '',
+          next_run_at: '2026-07-03T10:00:00.000Z',
+          last_error_code: 'STT_FAILED',
+          last_error_message: 'provider failed',
+          created_at: '2026-07-03T09:00:00.000Z',
+          updated_at: '2026-07-03T09:10:00.000Z',
+          completed_at: '',
+          transcript_json: '[{"text":"secret"}]',
+          file_path: '/tmp/private.webm',
+        },
+      ]),
+    });
+
+    const res = await app.request(
+      '/api/admin/transcription-jobs?workspaceId=ws1&status=failed&recordingId=rec_1&olderThanMinutes=30&limit=10',
+      { headers: authHeaders }
+    );
+
+    expect(res.status).toBe(200);
+    expect(db.listTranscriptionJobsForOperations).toHaveBeenCalledWith({
+      workspaceId: 'ws1',
+      status: 'failed',
+      recordingId: 'rec_1',
+      olderThanMinutes: 30,
+      limit: 10,
+    });
+    const body = await res.json();
+    expect(body.jobs).toHaveLength(1);
+    expect(body.jobs[0]).toMatchObject({
+      id: 'tj_1',
+      recordingId: 'rec_1',
+      workspaceId: 'ws1',
+      status: 'failed',
+      diagnostics: {
+        lastErrorCode: 'STT_FAILED',
+        lastErrorMessage: 'provider failed',
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain('secret');
+    expect(JSON.stringify(body)).not.toContain('/tmp/private.webm');
+  });
+
+  it('returns job diagnostics by id without raw transcript data', async () => {
+    const { app, db } = buildApp({
+      getTranscriptionJobById: vi.fn().mockResolvedValue({
+        id: 'tj_diag',
+        recording_id: 'rec_diag',
+        workspace_id: 'ws1',
+        meeting_id: 'meeting_diag',
+        status: 'running',
+        attempt_count: 1,
+        max_attempts: 3,
+        locked_by: 'worker-1',
+        locked_until: '2026-07-03T10:05:00.000Z',
+        next_run_at: '2026-07-03T10:00:00.000Z',
+        last_error_code: '',
+        last_error_message: '',
+        created_at: '2026-07-03T09:00:00.000Z',
+        updated_at: '2026-07-03T10:00:00.000Z',
+        transcript_json: '[{"text":"secret"}]',
+      }),
+    });
+
+    const res = await app.request('/api/admin/transcription-jobs/tj_diag', {
+      headers: authHeaders,
+    });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.job).toMatchObject({
+      id: 'tj_diag',
+      recordingId: 'rec_diag',
+      status: 'running',
+      diagnostics: {
+        lockedBy: 'worker-1',
+      },
+    });
+    expect(JSON.stringify(body)).not.toContain('secret');
+  });
+
+  it.each([
+    ['retry', 'retryTranscriptionJobForOperations', 'operator.transcription_job.retry'],
+    ['cancel', 'cancelTranscriptionJobForOperations', 'operator.transcription_job.cancel'],
+    [
+      'mark-failed',
+      'markTranscriptionJobFailedForOperations',
+      'operator.transcription_job.mark_failed',
+    ],
+  ])('runs the %s action and writes an audit event', async (action, methodName, auditAction) => {
+    const updatedJob = {
+      id: 'tj_action',
+      recording_id: 'rec_action',
+      workspace_id: 'ws1',
+      meeting_id: 'meeting_action',
+      status: action === 'retry' ? 'queued' : action === 'cancel' ? 'cancelled' : 'failed',
+      attempt_count: 0,
+      max_attempts: 3,
+      locked_by: '',
+      locked_until: '',
+      next_run_at: '2026-07-03T10:00:00.000Z',
+      last_error_code: '',
+      last_error_message: '',
+      created_at: '2026-07-03T09:00:00.000Z',
+      updated_at: '2026-07-03T10:00:00.000Z',
+    };
+    const { app, db } = buildApp({
+      [methodName]: vi.fn().mockResolvedValue(updatedJob),
+    });
+
+    const res = await app.request(`/api/admin/transcription-jobs/tj_action/${action}`, {
+      method: 'POST',
+      headers: authHeaders,
+      body: JSON.stringify({ reason: 'manual operator action' }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(db[methodName as keyof typeof db]).toHaveBeenCalledWith('tj_action', {
+      reason: 'manual operator action',
+    });
+    expect(db.writeAuditLogBestEffort).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspaceId: 'ws1',
+        actorUserId: 'ops-token',
+        action: auditAction,
+        entityType: 'transcription_job',
+        entityId: 'tj_action',
+        metadata: expect.objectContaining({
+          recordingId: 'rec_action',
+          reason: 'manual operator action',
+          status: updatedJob.status,
+          requestId: expect.any(String),
+          source: 'api',
+        }),
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Adds ops-token protected `/api/admin/transcription-jobs` endpoints for listing, diagnostics, retry, cancel, and mark-failed actions.
- Adds durable job DB helpers that filter jobs, reset failed jobs back to queued, cancel jobs, and mark jobs failed while keeping media asset status synchronized.
- Adds an API-only operator runbook under `docs/ops/TRANSCRIPTION_JOB_OPERATIONS.md` and links it from the docs index.

Closes #1245

## Validation
- RED first: new route/DB tests failed before endpoints and DB helpers existed.
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\routes\adminTranscriptionJobs.test.ts server\tests\database\transcriptionJobs.test.ts --testNamePattern "Admin transcription|operator" --coverage.enabled=false`
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\routes\adminTranscriptionJobs.test.ts server\tests\database\transcriptionJobs.test.ts server\tests\integration\api-critical.test.ts server\tests\security.test.ts --coverage.enabled=false`
- `node_modules\.bin\vitest.cmd run src\docsStructure.test.ts --coverage.enabled=false`
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts --retry=3 --coverage.enabled=false`
- `node_modules\.bin\tsc.cmd --project server\tsconfig.server.json --noEmit`
- `node_modules\.bin\tsc.cmd --noEmit`
- `node_modules\.bin\eslint.cmd server\http\app-routes.ts server\database.ts server\tests\routes\adminTranscriptionJobs.test.ts server\tests\database\transcriptionJobs.test.ts --max-warnings=0`
- `npx --yes prettier@3.9.4 --check docs\README.md docs\ops\TRANSCRIPTION_JOB_OPERATIONS.md server\http\app-routes.ts server\database.ts server\tests\routes\adminTranscriptionJobs.test.ts server\tests\database\transcriptionJobs.test.ts`
- `node scripts\audit-mojibake.mjs`
- `git diff --check`
- Pre-push release guard passed: `pnpm run test:server:retry`, targeted frontend/runtime guard tests, and `pnpm run audit:build-warnings`.

## Risk / Rollback
- Cancel is intentionally best-effort for already-running provider calls: it clears durable job state and prevents late DB completion from overwriting a cancelled job, but it does not abort an in-flight STT request.
- Admin actions use the existing global ops token pattern, so audit actor is recorded as `ops-token`; per-user workspace operator auth can be layered later if needed.
- Rollback: revert commit `e9bc14d`.
