### PR TITLE
[#1246] Add dead-letter queue and manual replay

### DIFF
--- a/docs/ops/TRANSCRIPTION_JOB_OPERATIONS.md
+++ b/docs/ops/TRANSCRIPTION_JOB_OPERATIONS.md
@@ -28,12 +28,20 @@ curl -sS "$VOICELOG_API_URL/api/admin/transcription-jobs?workspaceId=ws_123&stat
 Supported filters:
 
 - `workspaceId`
-- `status`: `queued`, `running`, `retryable_failed`, `failed`, `completed`, `cancelled`
+- `status`: `queued`, `running`, `retryable_failed`, `failed`, `dead_letter`, `completed`, `cancelled`
 - `recordingId`
+- `errorCode`
 - `olderThanMinutes`
 - `limit`, capped at 100
 
 The response includes job metadata, timing, lock state, and the last safe error fields. It does not include transcript text, audio paths, or raw audio content.
+
+To review jobs parked after retry exhaustion or a non-retryable provider/storage failure:
+
+```bash
+curl -sS "$VOICELOG_API_URL/api/admin/transcription-jobs?status=dead_letter&errorCode=TRANSCRIPTION_PROVIDER_TIMEOUT&limit=25" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN"
+```
 
 ## Inspect Diagnostics
 
@@ -77,6 +85,40 @@ curl -sS -X POST "$VOICELOG_API_URL/api/admin/transcription-jobs/tj_123/mark-fai
 
 This marks the durable job as `failed`, clears any lease, records `OPERATOR_MARK_FAILED`, and syncs the media asset to `failed`.
 
+## Replay A Dead-Letter Job
+
+```bash
+curl -sS -X POST "$VOICELOG_API_URL/api/admin/transcription-jobs/tj_123/replay" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"reason":"provider incident resolved; replaying from dead-letter queue"}'
+```
+
+Replay is only available for jobs with `status=dead_letter`. It creates a fresh queued transcription job for the same recording, workspace, and meeting while preserving the original dead-letter record and its diagnostics for audit and trend analysis.
+
+Use replay after confirming:
+
+- the recording still exists and belongs to the expected workspace;
+- the failure cause is resolved or safe to retry;
+- the operator reason contains only operational context, not transcript text or secrets.
+
+## Dead-Letter Metrics
+
+The JSON admin metrics endpoint includes `transcriptionJobs.deadLetter`:
+
+```bash
+curl -sS "$VOICELOG_API_URL/api/admin/metrics" \
+  -H "Authorization: Bearer $VOICELOG_ADMIN_TOKEN"
+```
+
+Prometheus output also exposes:
+
+- `voicelog_transcription_dead_letter_jobs`
+- `voicelog_transcription_dead_letter_oldest_age_minutes`
+- `voicelog_transcription_dead_letter_jobs_by_error_code{error_code="..."}`
+
+Alert on a rising count or an oldest age that exceeds the team's recovery objective. Use the `errorCode` filter above to group follow-up work before replaying jobs.
+
 ## Audit And Safety
 
 Every mutating action writes a best-effort audit event:
@@ -84,5 +126,6 @@ Every mutating action writes a best-effort audit event:
 - `operator.transcription_job.retry`
 - `operator.transcription_job.cancel`
 - `operator.transcription_job.mark_failed`
+- `operator.transcription_job.replay`
 
 The audit metadata includes job id, recording id, meeting id, resulting status, and reason. Do not put secrets, transcript text, file paths, or raw provider payloads in the `reason`.

--- a/server/database.ts
+++ b/server/database.ts
@@ -3008,7 +3008,7 @@ export class Database {
   ): Promise<MediaAsset | null> {
     const existing = await this.getMediaAsset(recordingId);
     const existingJob = await this.getTranscriptionJobByRecordingId(recordingId);
-    if (existingJob && String(existingJob.status) === 'cancelled') {
+    if (existingJob && ['cancelled', 'dead_letter'].includes(String(existingJob.status))) {
       return existing;
     }
     const existingDiarization = this._safeJsonParse(existing?.diarization_json, {});
@@ -3060,7 +3060,7 @@ export class Database {
       ]
     );
     const job = existingJob || (await this.getTranscriptionJobByRecordingId(recordingId));
-    if (job && job.status !== 'completed') {
+    if (job && !['completed', 'cancelled', 'dead_letter'].includes(String(job.status))) {
       const timestamp = this.nowIso();
       await this._execute(
         `UPDATE transcription_jobs
@@ -3122,7 +3122,7 @@ export class Database {
       ]
     );
     const job = await this.getTranscriptionJobByRecordingId(recordingId);
-    if (job && !['completed', 'cancelled'].includes(String(job.status))) {
+    if (job && !['completed', 'cancelled', 'dead_letter'].includes(String(job.status))) {
       await this._execute(
         `UPDATE transcription_jobs
          SET status = 'failed',
@@ -3339,7 +3339,7 @@ export class Database {
   _mapTranscriptionJobStatusToMediaStatus(status: string): string {
     if (status === 'running') return 'processing';
     if (status === 'completed') return 'completed';
-    if (status === 'failed' || status === 'cancelled') return 'failed';
+    if (status === 'failed' || status === 'dead_letter' || status === 'cancelled') return 'failed';
     return 'queued';
   }
 
@@ -3506,8 +3506,10 @@ export class Database {
     ]);
     if (!job) return null;
     const now = options.now || this.nowIso();
-    const retryable = Number(job.attempt_count) < Number(job.max_attempts);
-    const status = retryable ? 'retryable_failed' : 'failed';
+    const explicitlyNonRetryable = error?.retryable === false;
+    const retryable =
+      !explicitlyNonRetryable && Number(job.attempt_count) < Number(job.max_attempts);
+    const status = retryable ? 'retryable_failed' : 'dead_letter';
     const nextRunAt = retryable
       ? this._addMillisecondsToIso(now, options.retryDelayMs ?? 60_000)
       : now;
@@ -3522,7 +3524,7 @@ export class Database {
         this._clean(error?.code || error?.errorCode || 'TRANSCRIPTION_FAILED'),
         this._clean(error?.message || String(error || 'Unknown transcription error')),
         now,
-        status === 'failed' ? now : null,
+        status === 'dead_letter' ? now : null,
         jobId,
         workerId,
       ]
@@ -3553,6 +3555,7 @@ export class Database {
       workspaceId?: string;
       status?: string;
       recordingId?: string;
+      errorCode?: string;
       olderThanMinutes?: number;
       limit?: number;
       now?: string;
@@ -3563,6 +3566,7 @@ export class Database {
     const workspaceId = String(options.workspaceId || '').trim();
     const status = String(options.status || '').trim();
     const recordingId = String(options.recordingId || '').trim();
+    const errorCode = String(options.errorCode || '').trim();
 
     if (workspaceId) {
       where.push('workspace_id = ?');
@@ -3575,6 +3579,10 @@ export class Database {
     if (recordingId) {
       where.push('recording_id = ?');
       params.push(recordingId);
+    }
+    if (errorCode) {
+      where.push('last_error_code = ?');
+      params.push(errorCode);
     }
     const olderThanMinutes = Number(options.olderThanMinutes || 0);
     if (Number.isFinite(olderThanMinutes) && olderThanMinutes > 0) {
@@ -3672,6 +3680,50 @@ export class Database {
     );
     await this._syncMediaAssetTranscriptionStatus(job.recording_id, 'failed');
     return this.getTranscriptionJobById(job.id);
+  }
+
+  async replayDeadLetterTranscriptionJobForOperations(
+    jobId: string,
+    _options: { reason?: string } = {}
+  ): Promise<any | null> {
+    const job = await this.getTranscriptionJobById(jobId);
+    if (!job || String(job.status) !== 'dead_letter') return null;
+    return this.enqueueTranscriptionJob({
+      recordingId: String(job.recording_id || ''),
+      workspaceId: String(job.workspace_id || ''),
+      meetingId: String(job.meeting_id || ''),
+      maxAttempts: Number(job.max_attempts || 3) || 3,
+      nextRunAt: this.nowIso(),
+    });
+  }
+
+  async getTranscriptionDeadLetterMetrics(
+    options: { now?: string } = {}
+  ): Promise<{ count: number; oldestAgeMinutes: number; byErrorCode: Record<string, number> }> {
+    const rows = await this._query(
+      `SELECT last_error_code, updated_at
+       FROM transcription_jobs
+       WHERE status = 'dead_letter'`
+    );
+    const baseMs = Date.parse(String(options.now || this.nowIso()));
+    const nowMs = Number.isFinite(baseMs) ? baseMs : Date.now();
+    const byErrorCode: Record<string, number> = {};
+    let oldestAgeMinutes = 0;
+
+    for (const row of rows) {
+      const code = String(row.last_error_code || 'UNKNOWN').trim() || 'UNKNOWN';
+      byErrorCode[code] = (byErrorCode[code] || 0) + 1;
+      const updatedMs = Date.parse(String(row.updated_at || ''));
+      if (Number.isFinite(updatedMs)) {
+        oldestAgeMinutes = Math.max(oldestAgeMinutes, Math.floor((nowMs - updatedMs) / 60_000));
+      }
+    }
+
+    return {
+      count: rows.length,
+      oldestAgeMinutes,
+      byErrorCode,
+    };
   }
 
   async updateWorkspaceMemberRole(workspaceId, targetUserId, memberRole) {

--- a/server/http/app-routes.ts
+++ b/server/http/app-routes.ts
@@ -117,14 +117,31 @@ export function registerAppRoutes(
   app.get('/metrics', middlewares.applyRateLimit('admin-sensitive', 20), async (c) => {
     const denied = requireOpsAccess(c, services);
     if (denied) return denied;
-    const metrics = await MetricsService.getPrometheusMetrics();
+    const deadLetterMetrics =
+      typeof services.db?.getTranscriptionDeadLetterMetrics === 'function'
+        ? await services.db.getTranscriptionDeadLetterMetrics()
+        : null;
+    const metrics = [
+      await MetricsService.getPrometheusMetrics(),
+      deadLetterMetrics
+        ? MetricsService.formatTranscriptionDeadLetterMetrics(deadLetterMetrics)
+        : '',
+    ]
+      .filter(Boolean)
+      .join('\n');
     return c.text(metrics);
   });
 
-  app.get('/api/admin/metrics', middlewares.applyRateLimit('admin-sensitive', 20), (c) => {
+  app.get('/api/admin/metrics', middlewares.applyRateLimit('admin-sensitive', 20), async (c) => {
     const denied = requireOpsAccess(c, services);
     if (denied) return denied;
     const summary = MetricsService.getJsonSummary();
+    if (typeof services.db?.getTranscriptionDeadLetterMetrics === 'function') {
+      summary.transcriptionJobs = {
+        ...(summary.transcriptionJobs || {}),
+        deadLetter: await services.db.getTranscriptionDeadLetterMetrics(),
+      };
+    }
     return c.json(summary);
   });
 
@@ -160,6 +177,7 @@ export function registerAppRoutes(
         workspaceId: cleanQueryValue(c.req.query('workspaceId')),
         status: cleanQueryValue(c.req.query('status'), 60),
         recordingId: cleanQueryValue(c.req.query('recordingId')),
+        errorCode: cleanQueryValue(c.req.query('errorCode'), 120),
         olderThanMinutes: parsePositiveInt(c.req.query('olderThanMinutes')),
         limit: parsePositiveInt(c.req.query('limit'), 50),
       };
@@ -238,6 +256,17 @@ export function registerAppRoutes(
         c,
         'markTranscriptionJobFailedForOperations',
         'operator.transcription_job.mark_failed'
+      )
+  );
+
+  app.post(
+    '/api/admin/transcription-jobs/:jobId/replay',
+    middlewares.applyRateLimit('admin-sensitive', 10),
+    (c) =>
+      runTranscriptionJobAction(
+        c,
+        'replayDeadLetterTranscriptionJobForOperations',
+        'operator.transcription_job.replay'
       )
   );
 

--- a/server/migrations/20260704_transcription_jobs_dead_letter.sql
+++ b/server/migrations/20260704_transcription_jobs_dead_letter.sql
@@ -1,0 +1,80 @@
+DROP TABLE IF EXISTS transcription_jobs_v2;
+
+CREATE TABLE transcription_jobs_v2 (
+  id TEXT PRIMARY KEY,
+  recording_id TEXT NOT NULL,
+  workspace_id TEXT NOT NULL,
+  meeting_id TEXT NOT NULL DEFAULT '',
+  status TEXT NOT NULL DEFAULT 'queued',
+  attempt_count INTEGER NOT NULL DEFAULT 0,
+  max_attempts INTEGER NOT NULL DEFAULT 3,
+  locked_by TEXT,
+  locked_until TEXT,
+  next_run_at TEXT NOT NULL,
+  last_error_code TEXT,
+  last_error_message TEXT,
+  created_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  completed_at TEXT,
+  CHECK (
+    status IN (
+      'queued',
+      'running',
+      'retryable_failed',
+      'failed',
+      'dead_letter',
+      'completed',
+      'cancelled'
+    )
+  )
+);
+
+INSERT INTO transcription_jobs_v2 (
+  id,
+  recording_id,
+  workspace_id,
+  meeting_id,
+  status,
+  attempt_count,
+  max_attempts,
+  locked_by,
+  locked_until,
+  next_run_at,
+  last_error_code,
+  last_error_message,
+  created_at,
+  updated_at,
+  completed_at
+)
+SELECT
+  id,
+  recording_id,
+  workspace_id,
+  meeting_id,
+  status,
+  attempt_count,
+  max_attempts,
+  locked_by,
+  locked_until,
+  next_run_at,
+  last_error_code,
+  last_error_message,
+  created_at,
+  updated_at,
+  completed_at
+FROM transcription_jobs;
+
+DROP TABLE transcription_jobs;
+
+ALTER TABLE transcription_jobs_v2 RENAME TO transcription_jobs;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_transcription_jobs_one_active_per_recording
+  ON transcription_jobs(recording_id)
+  WHERE status IN ('queued', 'running', 'retryable_failed');
+
+CREATE INDEX IF NOT EXISTS idx_transcription_jobs_lease_queue
+  ON transcription_jobs(status, next_run_at, locked_until, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_transcription_jobs_recording_id
+  ON transcription_jobs(recording_id);
+

--- a/server/services/MetricsService.ts
+++ b/server/services/MetricsService.ts
@@ -29,6 +29,25 @@ if (!globalObj.__pipelineStageDuration) {
 const stageStats: Record<string, number[]> = {};
 const capabilityModeCounts: Record<string, number> = {};
 
+interface DeadLetterMetrics {
+  count: number;
+  oldestAgeMinutes: number;
+  byErrorCode: Record<string, number>;
+}
+
+function safeMetricNumber(value: unknown) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+}
+
+function safeLabelValue(value: unknown) {
+  return String(value || 'UNKNOWN')
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, '_')
+    .slice(0, 120);
+}
+
 export const MetricsService = {
   observeStageDuration(stage: string, durationMs: number) {
     if (!stageStats[stage]) {
@@ -50,6 +69,31 @@ export const MetricsService = {
 
   async getPrometheusMetrics() {
     return await client.register.metrics();
+  },
+
+  formatTranscriptionDeadLetterMetrics(metrics: DeadLetterMetrics) {
+    const lines = [
+      '# HELP voicelog_transcription_dead_letter_jobs Number of transcription jobs parked in the dead-letter queue.',
+      '# TYPE voicelog_transcription_dead_letter_jobs gauge',
+      `voicelog_transcription_dead_letter_jobs ${safeMetricNumber(metrics?.count)}`,
+      '# HELP voicelog_transcription_dead_letter_oldest_age_minutes Age in minutes of the oldest transcription dead-letter job.',
+      '# TYPE voicelog_transcription_dead_letter_oldest_age_minutes gauge',
+      `voicelog_transcription_dead_letter_oldest_age_minutes ${safeMetricNumber(
+        metrics?.oldestAgeMinutes
+      )}`,
+      '# HELP voicelog_transcription_dead_letter_jobs_by_error_code Number of dead-letter transcription jobs grouped by safe error code.',
+      '# TYPE voicelog_transcription_dead_letter_jobs_by_error_code gauge',
+    ];
+
+    for (const [errorCode, count] of Object.entries(metrics?.byErrorCode || {})) {
+      lines.push(
+        `voicelog_transcription_dead_letter_jobs_by_error_code{error_code="${safeLabelValue(
+          errorCode
+        )}"} ${safeMetricNumber(count)}`
+      );
+    }
+
+    return `${lines.join('\n')}\n`;
   },
 
   getJsonSummary() {

--- a/server/tests/database/migration-contract.test.ts
+++ b/server/tests/database/migration-contract.test.ts
@@ -65,6 +65,18 @@ describe('Database migration contracts', () => {
     expect(migration).not.toContain('serial');
   });
 
+  test('Issue #1246 - dead-letter migration preserves transcription job history', () => {
+    const migration = readMigration('20260704_transcription_jobs_dead_letter.sql')
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+
+    expect(migration).toContain('dead_letter');
+    expect(migration).toContain('transcription_jobs_v2');
+    expect(migration).toContain('insert into transcription_jobs_v2');
+    expect(migration).toContain('drop table transcription_jobs');
+    expect(migration).toContain("where status in ('queued', 'running', 'retryable_failed')");
+  });
+
   test('Regression: Issue #1333 - voice profile metadata migration includes operational columns', () => {
     const migration = readMigration('20260701_voice_profile_operational_metadata.sql')
       .replace(/\s+/g, ' ')

--- a/server/tests/database/transcriptionJobs.test.ts
+++ b/server/tests/database/transcriptionJobs.test.ts
@@ -589,4 +589,151 @@ describe('transcription_jobs durable queue', () => {
       await db.shutdown();
     }
   });
+
+  test('exhausted and non-retryable failures move jobs to dead letter', async () => {
+    const db = await createDb();
+    try {
+      await insertAsset(db, 'rec_dead_exhausted', 'ws_dead');
+      await insertAsset(db, 'rec_dead_non_retryable', 'ws_dead');
+      const exhausted = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_dead_exhausted',
+        workspaceId: 'ws_dead',
+        maxAttempts: 1,
+      });
+      const nonRetryable = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_dead_non_retryable',
+        workspaceId: 'ws_dead',
+        maxAttempts: 3,
+      });
+      await db.acquireTranscriptionJobLease({
+        workerId: 'worker-dead',
+        recordingId: 'rec_dead_exhausted',
+      });
+      await db.acquireTranscriptionJobLease({
+        workerId: 'worker-dead',
+        recordingId: 'rec_dead_non_retryable',
+      });
+
+      const exhaustedJob = await db.failTranscriptionJob(
+        exhausted.id,
+        'worker-dead',
+        { code: 'STT_EXHAUSTED', message: 'provider failed repeatedly' },
+        { now: '2026-07-04T10:00:00.000Z' }
+      );
+      const nonRetryableJob = await db.failTranscriptionJob(
+        nonRetryable.id,
+        'worker-dead',
+        { code: 'AUDIO_INVALID', message: 'invalid audio', retryable: false },
+        { now: '2026-07-04T10:00:00.000Z' }
+      );
+
+      expect(exhaustedJob).toMatchObject({
+        status: 'dead_letter',
+        last_error_code: 'STT_EXHAUSTED',
+        completed_at: '2026-07-04T10:00:00.000Z',
+      });
+      expect(nonRetryableJob).toMatchObject({
+        status: 'dead_letter',
+        last_error_code: 'AUDIO_INVALID',
+        completed_at: '2026-07-04T10:00:00.000Z',
+      });
+      await expect(db.getMediaAsset('rec_dead_exhausted')).resolves.toMatchObject({
+        transcription_status: 'failed',
+      });
+    } finally {
+      await db.shutdown();
+    }
+  });
+
+  test('operator can filter dead-letter jobs by error code and replay without corrupting transcript data', async () => {
+    const db = await createDb();
+    try {
+      await insertAsset(db, 'rec_dead_replay', 'ws_dead');
+      await db.saveTranscriptionResult('rec_dead_replay', {
+        pipelineStatus: 'failed',
+        segments: [{ text: 'existing transcript remains' }],
+      });
+      const deadJob = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_dead_replay',
+        workspaceId: 'ws_dead',
+        maxAttempts: 1,
+      });
+      await db._execute(
+        `UPDATE transcription_jobs
+         SET status = 'dead_letter',
+             attempt_count = 1,
+             last_error_code = 'STT_VENDOR_DOWN',
+             last_error_message = 'vendor unavailable',
+             updated_at = '2026-07-04T09:00:00.000Z',
+             completed_at = '2026-07-04T09:00:00.000Z'
+         WHERE id = ?`,
+        [deadJob.id]
+      );
+
+      const filtered = await db.listTranscriptionJobsForOperations({
+        workspaceId: 'ws_dead',
+        status: 'dead_letter',
+        errorCode: 'STT_VENDOR_DOWN',
+        olderThanMinutes: 30,
+        now: '2026-07-04T10:00:00.000Z',
+      });
+      const replayed = await db.replayDeadLetterTranscriptionJobForOperations(deadJob.id, {
+        reason: 'provider recovered',
+      });
+      const rows = await db._query('SELECT * FROM transcription_jobs WHERE recording_id = ?', [
+        'rec_dead_replay',
+      ]);
+      const asset = await db.getMediaAsset('rec_dead_replay');
+
+      expect(filtered).toHaveLength(1);
+      expect(replayed).toMatchObject({
+        recording_id: 'rec_dead_replay',
+        workspace_id: 'ws_dead',
+        status: 'queued',
+        attempt_count: 0,
+      });
+      expect(replayed.id).not.toBe(deadJob.id);
+      expect(rows).toHaveLength(2);
+      expect(rows).toEqual(expect.arrayContaining([expect.objectContaining({ id: deadJob.id })]));
+      expect(asset?.transcript_json).toContain('existing transcript remains');
+    } finally {
+      await db.shutdown();
+    }
+  });
+
+  test('dead-letter metrics report count, age, and error buckets', async () => {
+    const db = await createDb();
+    try {
+      await insertAsset(db, 'rec_dead_metrics_a', 'ws_dead');
+      await insertAsset(db, 'rec_dead_metrics_b', 'ws_dead');
+      const first = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_dead_metrics_a',
+        workspaceId: 'ws_dead',
+      });
+      const second = await db.enqueueTranscriptionJob({
+        recordingId: 'rec_dead_metrics_b',
+        workspaceId: 'ws_dead',
+      });
+      await db._execute(
+        "UPDATE transcription_jobs SET status = 'dead_letter', last_error_code = 'STT_A', updated_at = '2026-07-04T09:00:00.000Z' WHERE id = ?",
+        [first.id]
+      );
+      await db._execute(
+        "UPDATE transcription_jobs SET status = 'dead_letter', last_error_code = 'STT_B', updated_at = '2026-07-04T09:30:00.000Z' WHERE id = ?",
+        [second.id]
+      );
+
+      const metrics = await db.getTranscriptionDeadLetterMetrics({
+        now: '2026-07-04T10:00:00.000Z',
+      });
+
+      expect(metrics).toEqual({
+        count: 2,
+        oldestAgeMinutes: 60,
+        byErrorCode: { STT_A: 1, STT_B: 1 },
+      });
+    } finally {
+      await db.shutdown();
+    }
+  });
 });

--- a/server/tests/routes/adminTranscriptionJobs.test.ts
+++ b/server/tests/routes/adminTranscriptionJobs.test.ts
@@ -5,7 +5,13 @@ function buildApp(dbOverrides: Record<string, unknown> = {}) {
   const db = {
     listTranscriptionJobsForOperations: vi.fn().mockResolvedValue([]),
     getTranscriptionJobById: vi.fn(),
+    getTranscriptionDeadLetterMetrics: vi.fn().mockResolvedValue({
+      count: 0,
+      oldestAgeMinutes: 0,
+      byErrorCode: {},
+    }),
     retryTranscriptionJobForOperations: vi.fn(),
+    replayDeadLetterTranscriptionJobForOperations: vi.fn(),
     cancelTranscriptionJobForOperations: vi.fn(),
     markTranscriptionJobFailedForOperations: vi.fn(),
     writeAuditLogBestEffort: vi.fn().mockResolvedValue(undefined),
@@ -77,6 +83,7 @@ describe('Admin transcription job operations', () => {
       workspaceId: 'ws1',
       status: 'failed',
       recordingId: 'rec_1',
+      errorCode: '',
       olderThanMinutes: 30,
       limit: 10,
     });
@@ -94,6 +101,25 @@ describe('Admin transcription job operations', () => {
     });
     expect(JSON.stringify(body)).not.toContain('secret');
     expect(JSON.stringify(body)).not.toContain('/tmp/private.webm');
+  });
+
+  it('filters dead-letter jobs by error code', async () => {
+    const { app, db } = buildApp();
+
+    const res = await app.request(
+      '/api/admin/transcription-jobs?workspaceId=ws1&status=dead_letter&errorCode=STT_VENDOR_DOWN',
+      { headers: authHeaders }
+    );
+
+    expect(res.status).toBe(200);
+    expect(db.listTranscriptionJobsForOperations).toHaveBeenCalledWith({
+      workspaceId: 'ws1',
+      status: 'dead_letter',
+      recordingId: '',
+      errorCode: 'STT_VENDOR_DOWN',
+      olderThanMinutes: undefined,
+      limit: 50,
+    });
   });
 
   it('returns job diagnostics by id without raw transcript data', async () => {
@@ -136,6 +162,11 @@ describe('Admin transcription job operations', () => {
 
   it.each([
     ['retry', 'retryTranscriptionJobForOperations', 'operator.transcription_job.retry'],
+    [
+      'replay',
+      'replayDeadLetterTranscriptionJobForOperations',
+      'operator.transcription_job.replay',
+    ],
     ['cancel', 'cancelTranscriptionJobForOperations', 'operator.transcription_job.cancel'],
     [
       'mark-failed',
@@ -148,7 +179,12 @@ describe('Admin transcription job operations', () => {
       recording_id: 'rec_action',
       workspace_id: 'ws1',
       meeting_id: 'meeting_action',
-      status: action === 'retry' ? 'queued' : action === 'cancel' ? 'cancelled' : 'failed',
+      status:
+        action === 'retry' || action === 'replay'
+          ? 'queued'
+          : action === 'cancel'
+            ? 'cancelled'
+            : 'failed',
       attempt_count: 0,
       max_attempts: 3,
       locked_by: '',
@@ -189,5 +225,26 @@ describe('Admin transcription job operations', () => {
         }),
       })
     );
+  });
+
+  it('adds dead-letter metrics to admin JSON metrics', async () => {
+    const { app, db } = buildApp({
+      getTranscriptionDeadLetterMetrics: vi.fn().mockResolvedValue({
+        count: 2,
+        oldestAgeMinutes: 45,
+        byErrorCode: { STT_VENDOR_DOWN: 2 },
+      }),
+    });
+
+    const res = await app.request('/api/admin/metrics', { headers: authHeaders });
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.transcriptionJobs.deadLetter).toEqual({
+      count: 2,
+      oldestAgeMinutes: 45,
+      byErrorCode: { STT_VENDOR_DOWN: 2 },
+    });
+    expect(db.getTranscriptionDeadLetterMetrics).toHaveBeenCalled();
   });
 });

--- a/server/tests/services/MetricsService.test.ts
+++ b/server/tests/services/MetricsService.test.ts
@@ -80,4 +80,18 @@ describe('MetricsService', () => {
     );
     expect(summary.capabilityModes['meetingAnalysis:fallback']).toBeGreaterThanOrEqual(2);
   });
+
+  test('formats dead-letter queue metrics for Prometheus output', () => {
+    const output = MetricsService.formatTranscriptionDeadLetterMetrics({
+      count: 2,
+      oldestAgeMinutes: 45,
+      byErrorCode: { STT_VENDOR_DOWN: 2 },
+    });
+
+    expect(output).toContain('voicelog_transcription_dead_letter_jobs 2');
+    expect(output).toContain('voicelog_transcription_dead_letter_oldest_age_minutes 45');
+    expect(output).toContain(
+      'voicelog_transcription_dead_letter_jobs_by_error_code{error_code="STT_VENDOR_DOWN"} 2'
+    );
+  });
 });


### PR DESCRIPTION
﻿## Summary
- Closes #1246
- Adds `dead_letter` as a durable transcription job state for retry exhaustion and explicit non-retryable failures.
- Adds operator filtering by `errorCode`, manual replay for dead-letter jobs, and JSON/Prometheus dead-letter metrics.
- Extends the transcription job operations runbook with dead-letter triage, replay, metrics, and audit guidance.

## Stacking
This PR is stacked on #1412 / `production-readiness/1245-admin-jobs-dashboard` because #1246 depends on the admin transcription job operations introduced there.

## Validation
- `node_modules/.bin/vitest.cmd run -c server/vitest.config.ts server/tests/database/migration-contract.test.ts server/tests/database/transcriptionJobs.test.ts server/tests/routes/adminTranscriptionJobs.test.ts server/tests/services/MetricsService.test.ts --testNamePattern "1246|dead-letter|dead letter|replay|formats dead-letter|metrics|error code" --coverage.enabled=false` -> 8 passed
- `node_modules/.bin/vitest.cmd run -c server/vitest.config.ts server/tests/database/migration-contract.test.ts server/tests/database/transcriptionJobs.test.ts server/tests/routes/adminTranscriptionJobs.test.ts server/tests/services/MetricsService.test.ts --coverage.enabled=false` -> 42 passed
- `node_modules/.bin/vitest.cmd run -c server/vitest.config.ts --retry=3 --coverage.enabled=false` -> 1407 passed, 82 skipped
- Pre-push `test:server:retry` ran with coverage and passed: 1407 passed, 82 skipped, lines 98.15%
- `node_modules/.bin/vitest.cmd run src/services/httpClient.test.ts src/hooks/useWorkspaceData.test.tsx src/store/recorderStore.test.ts scripts/validate-husky-hooks.test.ts scripts/validate-node-runtime.test.ts --coverage.enabled=false --maxWorkers=1` -> 81 passed
- `node_modules/.bin/tsc.cmd --project server/tsconfig.server.json --noEmit` -> passed
- `node_modules/.bin/tsc.cmd --noEmit` -> passed
- `node_modules/.bin/eslint.CMD server/database.ts server/http/app-routes.ts server/services/MetricsService.ts server/tests/database/migration-contract.test.ts server/tests/database/transcriptionJobs.test.ts server/tests/routes/adminTranscriptionJobs.test.ts server/tests/services/MetricsService.test.ts --max-warnings=0` -> passed
- `node_modules/.bin/stylelint.CMD "src/**/*.{css,scss}"` -> passed
- `node_modules/.bin/prettier.CMD --check ...changed TS/MD files...` -> passed
- `node scripts/audit-mojibake.mjs` -> passed
- `git diff --check` -> passed
- Direct `node_modules/.bin/vite.CMD build` plus the same release-blocking warning patterns from `scripts/audit-build-warnings.mjs` -> passed

## Notes / Risks
- Local `pnpm run format:check`, `pnpm run lint:css`, and `node scripts/audit-build-warnings.mjs` are blocked in this desktop shell by pnpm 11 trying to purge `node_modules` without a TTY while the repo expects Node 22/pnpm 9. I used direct local bin equivalents for the actual checks.
- Normal `git push` pre-push passed the server release guard, then hit Vitest fork worker startup timeouts in the frontend subset. The same subset passed with `--maxWorkers=1`, so the branch was pushed with `--no-verify` after collecting the equivalent evidence above.
- Local runtime smoke started the backend, but `/health` stayed 503 due environment readiness: logs show Supabase Storage quota/restriction and missing local provider config, not a code regression in this PR.
