### PR TITLE
test(media): cover upload boundaries and resume behavior (#1250)

### DIFF
--- a/server/tests/routes/media.additional.test.ts
+++ b/server/tests/routes/media.additional.test.ts
@@ -746,6 +746,31 @@ describe('Media Routes - Additional Coverage', () => {
           resumable: false,
         });
       });
+
+      it('returns the first missing chunk as nextIndex so clients can resume safely', async () => {
+        const recordingId = 'rec_chunkstat_sparse_resume';
+        await uploadChunk(recordingId, 0, 4, Buffer.from('first'));
+        await uploadChunk(recordingId, 2, 4, Buffer.from('third'));
+
+        const res = await app.request(
+          `/media/recordings/${recordingId}/audio/chunk-status?total=4`,
+          {
+            method: 'GET',
+            headers: {
+              Authorization: 'Bearer fake_token',
+              'X-Workspace-Id': 'ws_1',
+            },
+          }
+        );
+
+        expect(res.status).toBe(200);
+        await expect(res.json()).resolves.toEqual({
+          nextIndex: 1,
+          uploaded: 1,
+          total: 4,
+          resumable: true,
+        });
+      });
     });
 
     describe('PUT /media/recordings/:recordingId/audio/chunk', () => {
@@ -799,6 +824,9 @@ describe('Media Routes - Additional Coverage', () => {
         });
 
         expect(res.status).toBe(413);
+        await expect(res.json()).resolves.toMatchObject({
+          message: expect.stringContaining('max 6MB'),
+        });
       });
 
       it('returns 200 and saves chunk when valid', async () => {
@@ -1098,6 +1126,22 @@ describe('Media Routes - Additional Coverage', () => {
         expect(res.status).toBe(400);
         const data = await res.json();
         expect(data.message).toBeTruthy(); // Error varies by Node.js stream implementation
+        expect(listAssembledFiles(recordingId)).toEqual([]);
+      });
+
+      it('keeps partial chunks retryable and removes assembled temp files when a middle chunk is missing', async () => {
+        const recordingId = 'rec_finalize_missing_middle';
+        await uploadChunk(recordingId, 0, 3, Buffer.from('first'));
+        await uploadChunk(recordingId, 2, 3, Buffer.from('third'));
+
+        const res = await finalizeUpload(recordingId, 3);
+
+        expect(res.status).toBe(400);
+        await expect(res.json()).resolves.toMatchObject({
+          message: expect.stringContaining('1 z 3'),
+        });
+        expect(existsSync(chunkPathFor(recordingId, 0))).toBe(true);
+        expect(existsSync(chunkPathFor(recordingId, 2))).toBe(true);
         expect(listAssembledFiles(recordingId)).toEqual([]);
       });
 

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -1228,6 +1228,42 @@ describe('Media Routes', () => {
     expect(oversize.headers.get('Vary')).toContain('Origin');
   });
 
+  it('PUT /media/recordings/:recordingId/audio - accepts upload at raw size policy boundary', async () => {
+    mockTranscriptionService.upsertMediaAssetFromPath.mockResolvedValue({
+      id: 'rec_boundary_ok',
+      workspace_id: 'ws_1',
+      size_bytes: 128,
+      storage_mode: 'single',
+      source_size_bytes: 128,
+      normalized_size_bytes: 128,
+    });
+
+    const res = await app.request('/media/recordings/rec_boundary_ok/audio', {
+      method: 'PUT',
+      headers: {
+        Authorization: 'Bearer fake_token',
+        'Content-Type': 'audio/webm',
+        'Content-Length': String(MAX_RAW_UPLOAD_BYTES),
+        'X-Workspace-Id': 'ws_1',
+      },
+      body: Buffer.from('boundary-audio'),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      id: 'rec_boundary_ok',
+      workspaceId: 'ws_1',
+      sizeBytes: 128,
+    });
+    expect(mockTranscriptionService.upsertMediaAssetFromPath).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recordingId: 'rec_boundary_ok',
+        workspaceId: 'ws_1',
+        contentType: 'audio/webm',
+      })
+    );
+  });
+
   it('GET /media/recordings/:recordingId/audio - returns 404 for missing assets and files', async () => {
     mockTranscriptionService.getMediaAsset.mockResolvedValueOnce(null);
     const missingAsset = await app.request('/media/recordings/rec_missing/audio', {


### PR DESCRIPTION
## Summary
- Adds focused backend route coverage for media upload policy boundaries.
- Covers sparse chunk resume behavior via chunk-status.
- Covers stable 413 payload for oversized chunks.
- Covers finalize retryability when a middle chunk is missing and assembled temp files must not linger.

Closes #1250

## Validation
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\routes\media.test.ts server\tests\routes\media.additional.test.ts --coverage.enabled=false` -> 2 files passed, 119 tests passed
- `node_modules\.bin\prettier.CMD --check server\tests\routes\media.test.ts server\tests\routes\media.additional.test.ts` -> passed
- `node_modules\.bin\tsc.cmd --project server\tsconfig.server.json --noEmit` -> passed
- `git diff --check` -> passed, with existing Windows LF/CRLF warnings only

## Review
- Runtime behavior is unchanged; this is a test-only hardening PR.
- I did not add a heavyweight streamed >200MB fixture because that would be slow and brittle in CI. The raw-size rejection remains covered by header rejection plus policy tests, while this PR adds the exact-boundary acceptance path.