### PR TITLE
feat(cost): add provider quotas for AI and STT (#1251)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,26 @@ VOICELOG_STT_MODEL_FAST=whisper-tiny
 VOICELOG_STT_MODEL_FULL=whisper-1
 STT_CONCURRENCY_LIMIT=2
 
+# Provider quota controls (production cost guardrails)
+# Store: auto uses DB outside local/test when a DB adapter is available.
+VOICELOG_AI_QUOTA_STORE=auto
+# Global provider defaults; endpoint-specific values override these.
+# VOICELOG_PROVIDER_USER_QUOTA_PER_HOUR=20
+# VOICELOG_PROVIDER_WORKSPACE_QUOTA_PER_DAY=200
+# VOICELOG_PROVIDER_IP_QUOTA_PER_MINUTE=30
+# STT recording/retry transcription quotas.
+# VOICELOG_STT_USER_QUOTA_PER_HOUR=20
+# VOICELOG_STT_WORKSPACE_QUOTA_PER_DAY=300
+# VOICELOG_STT_RECORDING_TRANSCRIBE_USER_QUOTA_PER_HOUR=20
+# Live transcription quotas.
+# VOICELOG_LIVE_TRANSCRIPTION_USER_QUOTA_PER_HOUR=120
+# VOICELOG_LIVE_TRANSCRIPTION_WORKSPACE_QUOTA_PER_DAY=1200
+# Image/sketchnote quotas.
+# VOICELOG_IMAGE_USER_QUOTA_PER_HOUR=8
+# VOICELOG_IMAGE_SKETCHNOTE_USER_QUOTA_PER_HOUR=8
+# Embedding quotas for voice profiles/RAG-like operations.
+# VOICELOG_EMBEDDING_USER_QUOTA_PER_HOUR=40
+
 # ─────────────────────────────────────────────────────────────────────────────
 # AI / LLM (optional — for meeting analysis, transcript correction)
 # ─────────────────────────────────────────────────────────────────────────────

--- a/docs/README.md
+++ b/docs/README.md
@@ -27,6 +27,7 @@ Root stays intentionally small:
 - `adr/` - architecture decision records
 - `ops/` - deployment, runtime, monitoring, APM, disk, and Node setup notes
   - `ops/TRANSCRIPTION_JOB_OPERATIONS.md` - operator workflow for durable transcription jobs
+  - `ops/PROVIDER_QUOTAS.md` - cost controls for AI, STT, live transcription, images, and embeddings
 - `automation/` - automation workflows, task runners, and historical automation notes
 - `testing/` - coverage, QA, push, and route test reports
 - `archive/audits/` - historical audits and one-off reports

--- a/docs/ops/PROVIDER_QUOTAS.md
+++ b/docs/ops/PROVIDER_QUOTAS.md
@@ -1,0 +1,78 @@
+# Provider quota controls
+
+VoiceLog gates costly provider paths before making external calls. Quotas use
+the existing `ai_quota_counters` store and are keyed by provider family, user,
+workspace, endpoint, and IP.
+
+## Covered paths
+
+- AI: `/ai/*`, `/media/analyze`, voice coaching.
+- STT: recording transcription and retry transcription.
+- Live transcription: `/transcribe/live`.
+- Image generation: sketchnote generation.
+- Embeddings: voice profile enrollment.
+
+Quota failures return HTTP `429`, set `Retry-After`, and include:
+
+```json
+{
+  "code": "stt_quota_exceeded",
+  "message": "Przekroczono limit uzycia dostawcy. Sprobuj ponownie pozniej.",
+  "retryAfter": 3600,
+  "providerFamily": "stt",
+  "endpoint": "recording-transcribe"
+}
+```
+
+## Defaults
+
+| Family             | User / hour | Workspace / day | IP / minute |
+| ------------------ | ----------: | --------------: | ----------: |
+| AI                 |          20 |             200 |          30 |
+| STT                |          20 |             300 |          20 |
+| Live transcription |         120 |            1200 |          60 |
+| Image              |           8 |              60 |           5 |
+| Embedding          |          40 |             400 |          20 |
+
+## Environment overrides
+
+Global provider defaults:
+
+- `VOICELOG_PROVIDER_USER_QUOTA_PER_HOUR`
+- `VOICELOG_PROVIDER_WORKSPACE_QUOTA_PER_DAY`
+- `VOICELOG_PROVIDER_IP_QUOTA_PER_MINUTE`
+
+Family overrides:
+
+- `VOICELOG_STT_USER_QUOTA_PER_HOUR`
+- `VOICELOG_STT_WORKSPACE_QUOTA_PER_DAY`
+- `VOICELOG_LIVE_TRANSCRIPTION_USER_QUOTA_PER_HOUR`
+- `VOICELOG_IMAGE_USER_QUOTA_PER_HOUR`
+- `VOICELOG_EMBEDDING_USER_QUOTA_PER_HOUR`
+
+Endpoint overrides use the normalized family and endpoint name:
+
+- `VOICELOG_STT_RECORDING_TRANSCRIBE_USER_QUOTA_PER_HOUR`
+- `VOICELOG_STT_RETRY_TRANSCRIBE_USER_QUOTA_PER_HOUR`
+- `VOICELOG_IMAGE_SKETCHNOTE_USER_QUOTA_PER_HOUR`
+- `VOICELOG_AI_MEDIA_ANALYZE_WORKSPACE_QUOTA_PER_DAY`
+
+## Operator visibility
+
+Owners, admins, and operators can inspect workspace counters without raw meeting
+content:
+
+```bash
+curl -H "Authorization: Bearer <token>" \
+  "https://<api-host>/media/quota/usage?workspaceId=<workspace-id>"
+```
+
+The response contains counter keys, counts, and reset times only. It does not
+include prompts, transcripts, audio paths, provider payloads, or generated
+content.
+
+## Store selection
+
+`VOICELOG_AI_QUOTA_STORE=auto` uses the DB-backed store outside local/test when
+a DB adapter is available. Use `memory` only for local development or isolated
+tests.

--- a/server/lib/aiQuotaStore.ts
+++ b/server/lib/aiQuotaStore.ts
@@ -13,8 +13,16 @@ export type AiQuotaExceeded = {
   retryAfter: number;
 };
 
+export type AiQuotaSnapshot = {
+  key: string;
+  count: number;
+  resetAt: number;
+  updatedAt?: string;
+};
+
 export interface AiQuotaStore {
   increment(checks: AiQuotaCheck[]): Promise<AiQuotaExceeded | null>;
+  snapshot?(options?: { prefix?: string; contains?: string }): Promise<AiQuotaSnapshot[]>;
   reset?(): Promise<void> | void;
 }
 
@@ -73,6 +81,18 @@ export class MemoryAiQuotaStore implements AiQuotaStore {
 
   reset() {
     this.counters.clear();
+  }
+
+  async snapshot(options: { prefix?: string; contains?: string } = {}) {
+    return [...this.counters.entries()]
+      .filter(([key]) => !options.prefix || key.startsWith(options.prefix))
+      .filter(([key]) => !options.contains || key.includes(options.contains))
+      .map(([key, entry]) => ({
+        key,
+        count: entry.count,
+        resetAt: entry.resetAt,
+      }))
+      .sort((a, b) => a.key.localeCompare(b.key));
   }
 }
 
@@ -192,6 +212,161 @@ export class DbAiQuotaStore implements AiQuotaStore {
     await this.ensureSchema();
     await this.db._execute('DELETE FROM ai_quota_counters');
   }
+
+  async snapshot(options: { prefix?: string; contains?: string } = {}) {
+    if (this.fallbackMode) {
+      return this.fallbackStore.snapshot(options);
+    }
+    await this.ensureSchema();
+    if (typeof this.db._all !== 'function') {
+      return [];
+    }
+    const rows = await this.db._all(
+      'SELECT key, count, reset_at, updated_at FROM ai_quota_counters ORDER BY key'
+    );
+    return (Array.isArray(rows) ? rows : [])
+      .map((row: any) => ({
+        key: String(row.key || ''),
+        count: Number(row.count || 0),
+        resetAt: Number(row.reset_at || 0),
+        updatedAt: row.updated_at ? String(row.updated_at) : undefined,
+      }))
+      .filter((entry) => entry.key)
+      .filter((entry) => !options.prefix || entry.key.startsWith(options.prefix))
+      .filter((entry) => !options.contains || entry.key.includes(options.contains));
+  }
+}
+
+export type ProviderQuotaKind = 'ai' | 'stt' | 'live-transcription' | 'image' | 'embedding';
+
+export type ProviderQuotaInput = {
+  kind: ProviderQuotaKind;
+  endpoint: string;
+  userId: string;
+  workspaceId?: string;
+  ip?: string;
+  now?: number;
+  env?: NodeJS.ProcessEnv;
+};
+
+const MINUTE_MS = 60 * 1000;
+const HOUR_MS = 60 * MINUTE_MS;
+const DAY_MS = 24 * HOUR_MS;
+
+const providerQuotaDefaults: Record<
+  ProviderQuotaKind,
+  { userPerHour: number; workspacePerDay: number; ipPerMinute: number }
+> = {
+  ai: { userPerHour: 20, workspacePerDay: 200, ipPerMinute: 30 },
+  stt: { userPerHour: 20, workspacePerDay: 300, ipPerMinute: 20 },
+  'live-transcription': { userPerHour: 120, workspacePerDay: 1200, ipPerMinute: 60 },
+  image: { userPerHour: 8, workspacePerDay: 60, ipPerMinute: 5 },
+  embedding: { userPerHour: 40, workspacePerDay: 400, ipPerMinute: 20 },
+};
+
+export function readPositiveIntEnv(name: string, fallback: number, env = process.env) {
+  const value = Number(env[name]);
+  return Number.isFinite(value) && value > 0 ? Math.floor(value) : fallback;
+}
+
+function envSegment(value: string) {
+  return value
+    .replace(/[^a-zA-Z0-9]+/g, '_')
+    .replace(/^_+|_+$/g, '')
+    .toUpperCase();
+}
+
+export function buildProviderQuotaChecks(input: ProviderQuotaInput): AiQuotaCheck[] {
+  const env = input.env || process.env;
+  const now = input.now || Date.now();
+  const defaults = providerQuotaDefaults[input.kind];
+  const kindEnv = envSegment(input.kind);
+  const endpointEnv = envSegment(`${input.kind}_${input.endpoint}`);
+  const kindKey = input.kind;
+  const endpoint = input.endpoint.replace(/[^a-zA-Z0-9_-]+/g, '-');
+  const userId = String(input.userId || '').trim();
+  const workspaceId = String(input.workspaceId || '').trim();
+  const ip = String(input.ip || 'local').trim() || 'local';
+  const userPerHour = readPositiveIntEnv(
+    `VOICELOG_${kindEnv}_USER_QUOTA_PER_HOUR`,
+    readPositiveIntEnv('VOICELOG_PROVIDER_USER_QUOTA_PER_HOUR', defaults.userPerHour, env),
+    env
+  );
+  const workspacePerDay = readPositiveIntEnv(
+    `VOICELOG_${kindEnv}_WORKSPACE_QUOTA_PER_DAY`,
+    readPositiveIntEnv('VOICELOG_PROVIDER_WORKSPACE_QUOTA_PER_DAY', defaults.workspacePerDay, env),
+    env
+  );
+  const ipPerMinute = readPositiveIntEnv(
+    `VOICELOG_${kindEnv}_IP_QUOTA_PER_MINUTE`,
+    readPositiveIntEnv('VOICELOG_PROVIDER_IP_QUOTA_PER_MINUTE', defaults.ipPerMinute, env),
+    env
+  );
+  const endpointUserPerHour = readPositiveIntEnv(
+    `VOICELOG_${endpointEnv}_USER_QUOTA_PER_HOUR`,
+    userPerHour,
+    env
+  );
+  const endpointWorkspacePerDay = readPositiveIntEnv(
+    `VOICELOG_${endpointEnv}_WORKSPACE_QUOTA_PER_DAY`,
+    workspacePerDay,
+    env
+  );
+  const endpointIpPerMinute = readPositiveIntEnv(
+    `VOICELOG_${endpointEnv}_IP_QUOTA_PER_MINUTE`,
+    ipPerMinute,
+    env
+  );
+
+  return [
+    { key: `${kindKey}:user:${userId}:hour`, limit: userPerHour, windowMs: HOUR_MS, now },
+    {
+      key: `${kindKey}:user:${userId}:endpoint:${endpoint}:hour`,
+      limit: endpointUserPerHour,
+      windowMs: HOUR_MS,
+      now,
+    },
+    { key: `${kindKey}:ip:${ip}:minute`, limit: ipPerMinute, windowMs: MINUTE_MS, now },
+    {
+      key: `${kindKey}:ip:${ip}:endpoint:${endpoint}:minute`,
+      limit: endpointIpPerMinute,
+      windowMs: MINUTE_MS,
+      now,
+    },
+    ...(workspaceId
+      ? [
+          {
+            key: `${kindKey}:workspace:${workspaceId}:day`,
+            limit: workspacePerDay,
+            windowMs: DAY_MS,
+            now,
+          },
+          {
+            key: `${kindKey}:workspace:${workspaceId}:endpoint:${endpoint}:day`,
+            limit: endpointWorkspacePerDay,
+            windowMs: DAY_MS,
+            now,
+          },
+        ]
+      : []),
+  ];
+}
+
+export function buildProviderQuotaExceededBody(input: {
+  kind: ProviderQuotaKind;
+  endpoint: string;
+  exceeded: AiQuotaExceeded;
+}) {
+  const code = `${input.kind.replace(/-/g, '_')}_quota_exceeded`;
+  return {
+    code,
+    message: 'Przekroczono limit uzycia dostawcy. Sprobuj ponownie pozniej.',
+    retryAfter: input.exceeded.retryAfter,
+    limit: input.exceeded.limit,
+    quotaKey: input.exceeded.key,
+    providerFamily: input.kind,
+    endpoint: input.endpoint,
+  };
 }
 
 export function createAiQuotaStore({

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -28,6 +28,12 @@ import {
 import { getMemoryPressure } from '../lib/serverUtils.ts';
 import { createProgressToken } from '../lib/progressTokens.ts';
 import { validateJsonBody, validatePayload } from '../lib/requestValidation.ts';
+import {
+  buildProviderQuotaChecks,
+  buildProviderQuotaExceededBody,
+  createAiQuotaStore,
+  type ProviderQuotaKind,
+} from '../lib/aiQuotaStore.ts';
 import { DISK_SPACE_BLOCK_UPLOAD_BYTES } from '../lib/diskSpace.ts';
 import {
   MAX_RAW_UPLOAD_BYTES,
@@ -62,6 +68,16 @@ const AUDIO_CONTENT_TYPE_EXTENSIONS: Record<string, string[]> = {
 
 const IDEMPOTENCY_KEY_HEADER = 'Idempotency-Key';
 const ACTIVE_TRANSCRIPTION_STATUSES = new Set(['processing', 'diarization']);
+
+function getClientIp(c: any) {
+  return (
+    String(c.req.header('x-forwarded-for') || '')
+      .split(',')[0]
+      .trim() ||
+    String(c.req.header('x-real-ip') || '').trim() ||
+    'local'
+  );
+}
 
 function normalizeAnalysisPayload(result: any) {
   if (result && typeof result === 'object') {
@@ -671,6 +687,7 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
   const router = new Hono<{ Variables: { session: any; user: any; reqId: string } }>();
   const { transcriptionService, config } = services;
   const { authMiddleware, applyRateLimit, ensureWorkspaceAccess } = middlewares;
+  const quotaStore = createAiQuotaStore({ db: services.db });
   const startTranscriptionPipeline =
     typeof transcriptionService.startTranscriptionPipeline === 'function'
       ? transcriptionService.startTranscriptionPipeline.bind(transcriptionService)
@@ -680,6 +697,65 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
           return transcriptionService.getMediaAsset(recordingId);
         };
   const uploadDir = config.uploadDir || process.env.VOICELOG_UPLOAD_DIR || './server/data/uploads';
+
+  async function enforceProviderQuota(
+    c: any,
+    input: {
+      kind: ProviderQuotaKind;
+      endpoint: string;
+      workspaceId?: string;
+    }
+  ) {
+    const session = c.get('session') as any;
+    const userId = String(session?.user_id || session?.userId || '').trim();
+    if (!userId) {
+      return c.json({ message: 'Brak uzytkownika w sesji.' }, 401);
+    }
+
+    const exceeded = await quotaStore.increment(
+      buildProviderQuotaChecks({
+        kind: input.kind,
+        endpoint: input.endpoint,
+        userId,
+        workspaceId: input.workspaceId,
+        ip: getClientIp(c),
+      })
+    );
+    if (!exceeded) return null;
+
+    c.header('Retry-After', String(exceeded.retryAfter));
+    logger.warn('[provider quota] quota exceeded', {
+      requestId: c.get('reqId') || 'unknown',
+      userId,
+      workspaceId: input.workspaceId || undefined,
+      providerFamily: input.kind,
+      endpoint: input.endpoint,
+      quotaKey: exceeded.key,
+      limit: exceeded.limit,
+      retryAfter: exceeded.retryAfter,
+    });
+    return c.json(
+      buildProviderQuotaExceededBody({
+        kind: input.kind,
+        endpoint: input.endpoint,
+        exceeded,
+      }),
+      429
+    );
+  }
+
+  async function assertOperatorAccess(c: any, workspaceId: string) {
+    const session = c.get('session') as any;
+    const userId = String(session?.user_id || session?.userId || '').trim();
+    const membership =
+      typeof services.workspaceService?.getMembership === 'function'
+        ? await services.workspaceService.getMembership(workspaceId, userId)
+        : null;
+    const role = String(
+      membership?.member_role || membership?.role || session?.role || ''
+    ).toLowerCase();
+    return ['owner', 'admin', 'operator'].includes(role);
+  }
 
   async function writeAuditEvent(
     c: any,
@@ -861,6 +937,41 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
   }
 
   router.get('/upload-policy', (c) => c.json(createUploadPolicy(), 200));
+
+  router.get('/quota/usage', authMiddleware, async (c) => {
+    const session = c.get('session') as any;
+    const workspaceId = String(
+      c.req.query('workspaceId') ||
+        c.req.header('X-Workspace-Id') ||
+        session?.workspace_id ||
+        session?.workspaceId ||
+        ''
+    ).trim();
+    if (!workspaceId) {
+      return c.json({ message: 'Brakuje workspaceId.' }, 400);
+    }
+
+    const allowed = await assertOperatorAccess(c, workspaceId);
+    if (!allowed) {
+      return c.json({ message: 'Tylko owner, admin lub operator moze przegladac limity.' }, 403);
+    }
+
+    const entries = quotaStore.snapshot
+      ? await quotaStore.snapshot({ contains: `:workspace:${workspaceId}:` })
+      : [];
+    return c.json(
+      {
+        workspaceId,
+        counters: entries.map((entry) => ({
+          key: entry.key,
+          count: entry.count,
+          resetAt: new Date(entry.resetAt).toISOString(),
+          updatedAt: entry.updatedAt,
+        })),
+      },
+      200
+    );
+  });
 
   // --- Media & Processing ---
   router.use('/recordings', authMiddleware);
@@ -1370,6 +1481,13 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
         );
       }
 
+      const quotaResponse = await enforceProviderQuota(c, {
+        kind: 'stt',
+        endpoint: 'recording-transcribe',
+        workspaceId: body.workspaceId || asset.workspace_id,
+      });
+      if (quotaResponse) return quotaResponse;
+
       // Guard against OOM - reject when memory is already tight
       const memPressure = getMemoryPressure();
       if (!memPressure.ok) {
@@ -1522,6 +1640,13 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
           202
         );
       }
+
+      const quotaResponse = await enforceProviderQuota(c, {
+        kind: 'stt',
+        endpoint: 'retry-transcribe',
+        workspaceId: asset.workspace_id,
+      });
+      if (quotaResponse) return quotaResponse;
       // If the local file is gone (e.g. after Railway redeploy), try the same
       // reconstructed remote candidates as the audio download endpoint.
       if (
@@ -2020,6 +2145,13 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       );
     }
 
+    const quotaResponse = await enforceProviderQuota(c, {
+      kind: 'embedding',
+      endpoint: 'voice-profile',
+      workspaceId: asset.workspace_id,
+    });
+    if (quotaResponse) return quotaResponse;
+
     try {
       const options = overrideSegments.length > 0 ? { transcriptSegments: overrideSegments } : {};
       const profile = await transcriptionService.createVoiceProfileFromSpeaker(
@@ -2064,6 +2196,12 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
         const asset = await transcriptionService.getMediaAsset(recordingId);
         if (!asset) return c.json({ message: 'Nie znaleziono nagrania.' }, 404);
         await ensureWorkspaceAccess(c, asset.workspace_id);
+        const quotaResponse = await enforceProviderQuota(c, {
+          kind: 'ai',
+          endpoint: 'voice-coaching',
+          workspaceId: asset.workspace_id,
+        });
+        if (quotaResponse) return quotaResponse;
         const coaching = await transcriptionService.generateVoiceCoaching(
           asset,
           String(body.speakerId),
@@ -2200,6 +2338,13 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       if (!process.env.GEMINI_API_KEY) {
         return c.json({ message: 'Brak klucza GEMINI_API_KEY w konfiguracji środowiska.' }, 400);
       }
+
+      const quotaResponse = await enforceProviderQuota(c, {
+        kind: 'image',
+        endpoint: 'sketchnote',
+        workspaceId: asset.workspace_id,
+      });
+      if (quotaResponse) return quotaResponse;
 
       try {
         const { logger } = await import('../logger.ts');
@@ -2355,6 +2500,13 @@ Important:
       return c.json({ message: 'Brakuje workspaceId.' }, 400);
     }
     await ensureWorkspaceAccess(c, workspaceId);
+
+    const quotaResponse = await enforceProviderQuota(c, {
+      kind: 'ai',
+      endpoint: 'media-analyze',
+      workspaceId,
+    });
+    if (quotaResponse) return quotaResponse;
 
     const result = await transcriptionService.analyzeMeetingWithOpenAI({ ...body, workspaceId });
     const payload = normalizeAnalysisPayload(result);
@@ -2813,6 +2965,7 @@ export function createTranscribeRoutes(services: AppServices, middlewares: AppMi
   const router = new Hono<{ Variables: { session: any; user: any } }>();
   const { transcriptionService, config } = services;
   const { authMiddleware, applyRateLimit, ensureWorkspaceAccess } = middlewares;
+  const quotaStore = createAiQuotaStore({ db: services.db });
   const liveTranscribeTimeoutMs = () => {
     if (config?.transcribeLiveTimeoutMs && config.transcribeLiveTimeoutMs > 0) {
       return Number(config.transcribeLiveTimeoutMs);
@@ -2835,6 +2988,31 @@ export function createTranscribeRoutes(services: AppServices, middlewares: AppMi
       return c.json({ message: 'Brakuje workspaceId.' }, 400);
     }
     await ensureWorkspaceAccess(c, workspaceId);
+
+    const sessionUserId = String(session?.user_id || session?.userId || '').trim();
+    if (!sessionUserId) {
+      return c.json({ message: 'Brak uzytkownika w sesji.' }, 401);
+    }
+    const exceeded = await quotaStore.increment(
+      buildProviderQuotaChecks({
+        kind: 'live-transcription',
+        endpoint: 'live',
+        userId: sessionUserId,
+        workspaceId,
+        ip: getClientIp(c),
+      })
+    );
+    if (exceeded) {
+      c.header('Retry-After', String(exceeded.retryAfter));
+      return c.json(
+        buildProviderQuotaExceededBody({
+          kind: 'live-transcription',
+          endpoint: 'live',
+          exceeded,
+        }),
+        429
+      );
+    }
 
     const contentType = c.req.header('content-type') || 'audio/webm';
     const headerValidation = validatePayload(

--- a/server/tests/lib/aiQuotaStore.test.ts
+++ b/server/tests/lib/aiQuotaStore.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import {
   createAiQuotaStore,
+  buildProviderQuotaChecks,
   DbAiQuotaStore,
   MemoryAiQuotaStore,
   type AiQuotaCheck,
@@ -53,6 +54,9 @@ function createFakeDb(options: { type?: string } = {}) {
     async _get(_sql: string, params: unknown[] = []) {
       return rows.get(String(params[0])) || null;
     },
+    async _all() {
+      return [...rows.values()];
+    },
   };
 }
 
@@ -61,6 +65,8 @@ function createOverflowDb(
     repairSucceeds?: boolean;
     overflowPersists?: boolean;
     genericInsertError?: boolean;
+    genericAfterRepair?: boolean;
+    overflowAsString?: boolean;
   } = {}
 ) {
   const rows = new Map<
@@ -92,7 +98,13 @@ function createOverflowDb(
         if (options.genericInsertError) {
           throw new Error('connection lost');
         }
+        if (repaired && options.genericAfterRepair) {
+          throw new Error('post-repair connection lost');
+        }
         if (!repaired || options.overflowPersists) {
+          if (options.overflowAsString) {
+            return Promise.reject('integer out of range');
+          }
           throw new Error('value "1782975650185" is out of range for type integer');
         }
         const [key, count, resetAt, updatedAt] = params;
@@ -135,6 +147,111 @@ describe('AI quota stores', () => {
     await expect(store.increment([makeCheck({ now: 2_000 })])).resolves.toBeNull();
   });
 
+  test('MemoryAiQuotaStore snapshot filters counters for operator usage views', async () => {
+    const store = new MemoryAiQuotaStore();
+
+    await store.increment([
+      makeCheck({ key: 'stt:workspace:ws1:day', limit: 10 }),
+      makeCheck({ key: 'stt:workspace:ws2:day', limit: 10 }),
+    ]);
+
+    await expect(store.snapshot({ contains: ':workspace:ws1:' })).resolves.toEqual([
+      {
+        key: 'stt:workspace:ws1:day',
+        count: 1,
+        resetAt: 61_000,
+      },
+    ]);
+  });
+
+  test('MemoryAiQuotaStore snapshot supports prefix filters', async () => {
+    const store = new MemoryAiQuotaStore();
+
+    await store.increment([
+      makeCheck({ key: 'stt:workspace:ws1:day', limit: 10 }),
+      makeCheck({ key: 'ai:workspace:ws1:day', limit: 10 }),
+    ]);
+
+    await expect(store.snapshot({ prefix: 'ai:' })).resolves.toEqual([
+      {
+        key: 'ai:workspace:ws1:day',
+        count: 1,
+        resetAt: 61_000,
+      },
+    ]);
+  });
+
+  test('MemoryAiQuotaStore normalizes invalid timestamps to the current time', async () => {
+    const store = new MemoryAiQuotaStore();
+    const before = Date.now();
+
+    await store.increment([makeCheck({ key: 'ai:user:u1:invalid-now', now: 0 })]);
+    const [snapshot] = await store.snapshot({ contains: 'invalid-now' });
+
+    expect(snapshot.resetAt).toBeGreaterThanOrEqual(before + 60_000);
+  });
+
+  test('buildProviderQuotaChecks applies endpoint-specific env overrides', () => {
+    const checks = buildProviderQuotaChecks({
+      kind: 'image',
+      endpoint: 'sketchnote',
+      userId: 'u1',
+      workspaceId: 'ws1',
+      ip: '127.0.0.1',
+      now: 10_000,
+      env: {
+        VOICELOG_IMAGE_SKETCHNOTE_USER_QUOTA_PER_HOUR: '2',
+        VOICELOG_IMAGE_SKETCHNOTE_WORKSPACE_QUOTA_PER_DAY: '5',
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(checks).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'image:user:u1:endpoint:sketchnote:hour',
+          limit: 2,
+        }),
+        expect.objectContaining({
+          key: 'image:workspace:ws1:endpoint:sketchnote:day',
+          limit: 5,
+        }),
+      ])
+    );
+  });
+
+  test('buildProviderQuotaChecks applies provider fallback env and sanitizes optional keys', () => {
+    const checks = buildProviderQuotaChecks({
+      kind: 'stt',
+      endpoint: 'live/audio beta',
+      userId: '',
+      ip: '',
+      now: 20_000,
+      env: {
+        VOICELOG_PROVIDER_USER_QUOTA_PER_HOUR: '3',
+        VOICELOG_PROVIDER_IP_QUOTA_PER_MINUTE: '4',
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(checks).toEqual([
+      expect.objectContaining({ key: 'stt:user::hour', limit: 3 }),
+      expect.objectContaining({ key: 'stt:user::endpoint:live-audio-beta:hour', limit: 3 }),
+      expect.objectContaining({ key: 'stt:ip:local:minute', limit: 4 }),
+      expect.objectContaining({ key: 'stt:ip:local:endpoint:live-audio-beta:minute', limit: 4 }),
+    ]);
+  });
+
+  test('buildProviderQuotaChecks falls back to current time when no timestamp is provided', () => {
+    const before = Date.now();
+    const [firstCheck] = buildProviderQuotaChecks({
+      kind: 'ai',
+      endpoint: 'summary',
+      userId: 'u1',
+      env: {} as NodeJS.ProcessEnv,
+    });
+
+    expect(firstCheck.now).toBeGreaterThanOrEqual(before);
+  });
+
   test('DbAiQuotaStore shares quota counters across store instances using the same database', async () => {
     const db = createFakeDb();
     const firstInstance = new DbAiQuotaStore(db);
@@ -160,6 +277,21 @@ describe('AI quota stores', () => {
 
     expect(db.rows.get('ai:user:u1:hour')?.count).toBe(1);
     expect(db.rows.get('ai:user:u1:hour')?.reset_at).toBe(122_000);
+  });
+
+  test('DbAiQuotaStore treats invalid persisted counts as zero before incrementing', async () => {
+    const db = createFakeDb();
+    db.rows.set('ai:user:u1:hour', {
+      key: 'ai:user:u1:hour',
+      count: Number.NaN,
+      reset_at: 61_000,
+      updated_at: new Date(1_000).toISOString(),
+    });
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck()])).resolves.toBeNull();
+
+    expect(db.rows.get('ai:user:u1:hour')?.count).toBe(1);
   });
 
   test('DbAiQuotaStore creates reset windows as BIGINT for millisecond timestamps', async () => {
@@ -216,6 +348,20 @@ describe('AI quota stores', () => {
     expect(db.insertAttempts).toBe(1);
   });
 
+  test('DbAiQuotaStore snapshot reads fallback counters after overflow fallback', async () => {
+    const db = createOverflowDb();
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+
+    await expect(store.snapshot({ contains: ':user:u1:' })).resolves.toEqual([
+      expect.objectContaining({
+        key: 'ai:user:u1:hour',
+        count: 1,
+      }),
+    ]);
+  });
+
   test('DbAiQuotaStore falls back to memory when reset_at overflow persists after repair', async () => {
     const db = createOverflowDb({ repairSucceeds: true, overflowPersists: true });
     const store = new DbAiQuotaStore(db);
@@ -224,6 +370,25 @@ describe('AI quota stores', () => {
 
     expect(db.insertAttempts).toBe(2);
     expect(db.rows.size).toBe(0);
+  });
+
+  test('DbAiQuotaStore recognizes non-Error reset_at overflow failures', async () => {
+    const db = createOverflowDb({ repairSucceeds: true, overflowAsString: true });
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).resolves.toBeNull();
+
+    expect(db.insertAttempts).toBe(2);
+  });
+
+  test('DbAiQuotaStore propagates non-overflow failures after reset_at repair', async () => {
+    const db = createOverflowDb({ repairSucceeds: true, genericAfterRepair: true });
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.increment([makeCheck({ now: 1_782_975_650_185 })])).rejects.toThrow(
+      'post-repair connection lost'
+    );
+    expect(db.insertAttempts).toBe(2);
   });
 
   test('DbAiQuotaStore still propagates non-overflow DB failures', async () => {
@@ -241,6 +406,64 @@ describe('AI quota stores', () => {
     await store.reset();
 
     expect(db.rows.has('ai:user:u1:hour')).toBe(false);
+  });
+
+  test('DbAiQuotaStore snapshot returns persisted counters when adapter supports _all', async () => {
+    const db = createFakeDb();
+    const store = new DbAiQuotaStore(db);
+
+    await store.increment([makeCheck({ key: 'ai:workspace:ws1:endpoint:search:day' })]);
+
+    await expect(store.snapshot({ contains: ':workspace:ws1:' })).resolves.toEqual([
+      expect.objectContaining({
+        key: 'ai:workspace:ws1:endpoint:search:day',
+        count: 1,
+      }),
+    ]);
+  });
+
+  test('DbAiQuotaStore snapshot tolerates malformed listed rows', async () => {
+    const db = {
+      ...createFakeDb(),
+      async _all() {
+        return [
+          { key: 'ai:workspace:ws1:endpoint:search:day', count: 0, reset_at: 0 },
+          { key: '', count: 5, reset_at: 10, updated_at: '' },
+        ];
+      },
+    };
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.snapshot({ prefix: 'ai:' })).resolves.toEqual([
+      {
+        key: 'ai:workspace:ws1:endpoint:search:day',
+        count: 0,
+        resetAt: 0,
+        updatedAt: undefined,
+      },
+    ]);
+  });
+
+  test('DbAiQuotaStore snapshot treats non-array adapter results as empty', async () => {
+    const db = {
+      ...createFakeDb(),
+      async _all() {
+        return null;
+      },
+    };
+    const store = new DbAiQuotaStore(db);
+
+    await expect(store.snapshot()).resolves.toEqual([]);
+  });
+
+  test('DbAiQuotaStore snapshot returns an empty list when adapter cannot list rows', async () => {
+    const db = createFakeDb();
+    const { _all: _unused, ...dbWithoutAll } = db;
+    const store = new DbAiQuotaStore(dbWithoutAll);
+
+    await store.increment([makeCheck({ key: 'ai:workspace:ws1:endpoint:search:day' })]);
+
+    await expect(store.snapshot({ contains: ':workspace:ws1:' })).resolves.toEqual([]);
   });
 
   test('createAiQuotaStore selects DB store outside tests when a DB adapter is available', () => {
@@ -261,6 +484,30 @@ describe('AI quota stores', () => {
         NODE_ENV: 'production',
         VOICELOG_AI_QUOTA_STORE: 'memory',
         RAILWAY_ENVIRONMENT_NAME: 'production',
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(store).toBeInstanceOf(MemoryAiQuotaStore);
+  });
+
+  test('createAiQuotaStore allows explicit DB store in test mode', () => {
+    const db = createFakeDb();
+    const store = createAiQuotaStore({
+      db,
+      env: {
+        NODE_ENV: 'test',
+        VOICELOG_AI_QUOTA_STORE: 'db',
+      } as NodeJS.ProcessEnv,
+    });
+
+    expect(store).toBeInstanceOf(DbAiQuotaStore);
+  });
+
+  test('createAiQuotaStore uses memory when Vercel env has no usable DB adapter', () => {
+    const store = createAiQuotaStore({
+      env: {
+        NODE_ENV: '',
+        VERCEL: '1',
       } as NodeJS.ProcessEnv,
     });
 

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -111,6 +111,7 @@ describe('Media Routes', () => {
     sentryMocks.capturePipelineException.mockClear();
     tracingMocks.withAudioSpan.mockClear();
     tracingMocks.appendTraceContext.mockClear();
+    vi.unstubAllEnvs();
     // Reset fs state to default after each test
     setFsState();
   });
@@ -921,6 +922,89 @@ describe('Media Routes', () => {
     );
   });
 
+  it('POST /media/recordings/:recordingId/transcribe - returns stt_quota_exceeded with Retry-After', async () => {
+    vi.stubEnv('VOICELOG_STT_USER_QUOTA_PER_HOUR', '1');
+    mockTranscriptionService.getMediaAsset.mockImplementation(async (recordingId: string) => ({
+      id: recordingId,
+      workspace_id: 'ws_1',
+      meeting_id: 'meeting_1',
+      file_path: '/tmp/fake.webm',
+      content_type: 'audio/webm',
+      transcription_status: 'uploaded',
+      transcript_json: '[]',
+    }));
+
+    const first = await app.request('/media/recordings/rec_quota_first/transcribe', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer fake_token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ workspaceId: 'ws_1' }),
+    });
+    const second = await app.request('/media/recordings/rec_quota_second/transcribe', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer fake_token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ workspaceId: 'ws_1' }),
+    });
+
+    expect(first.status).toBe(202);
+    expect(second.status).toBe(429);
+    expect(second.headers.get('Retry-After')).toMatch(/^\d+$/);
+    await expect(second.json()).resolves.toMatchObject({
+      code: 'stt_quota_exceeded',
+      providerFamily: 'stt',
+      endpoint: 'recording-transcribe',
+      retryAfter: expect.any(Number),
+    });
+    expect(mockTranscriptionService.queueTranscription).toHaveBeenCalledTimes(1);
+  });
+
+  it('GET /media/quota/usage exposes workspace counters to operators without raw content', async () => {
+    vi.stubEnv('VOICELOG_STT_USER_QUOTA_PER_HOUR', '3');
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_quota_usage',
+      workspace_id: 'ws_1',
+      meeting_id: 'meeting_1',
+      file_path: '/tmp/fake.webm',
+      content_type: 'audio/webm',
+      transcription_status: 'uploaded',
+      transcript_json: '[]',
+    });
+
+    await app.request('/media/recordings/rec_quota_usage/transcribe', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer fake_token',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ workspaceId: 'ws_1' }),
+    });
+
+    const res = await app.request('/media/quota/usage?workspaceId=ws_1', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer fake_token' },
+    });
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload.workspaceId).toBe('ws_1');
+    expect(payload.counters).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          key: 'stt:workspace:ws_1:day',
+          count: 1,
+          resetAt: expect.any(String),
+        }),
+      ])
+    );
+    expect(JSON.stringify(payload)).not.toContain('fake.webm');
+    expect(JSON.stringify(payload)).not.toContain('transcript');
+  });
+
   it('POST /media/recordings/:recordingId/sketchnote - uses Gemini 3 Pro Image preview', async () => {
     mockTranscriptionService.getMediaAsset.mockResolvedValue({
       id: 'rec_sketchnote',
@@ -972,6 +1056,58 @@ describe('Media Routes', () => {
     expect(String((global.fetch as any).mock.calls[0][1].headers['x-goog-api-key'])).toBe(
       'test-key'
     );
+
+    global.fetch = originalFetch;
+    process.env.GEMINI_API_KEY = originalGeminiKey;
+  });
+
+  it('POST /media/recordings/:recordingId/sketchnote - returns image_quota_exceeded before Gemini call', async () => {
+    vi.stubEnv('VOICELOG_IMAGE_USER_QUOTA_PER_HOUR', '1');
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_sketchnote',
+      workspace_id: 'ws_1',
+      diarization_json: JSON.stringify({
+        summary: 'Spotkanie o wdrozeniu nowego procesu.',
+      }),
+    });
+    mockWorkspaceService.getMembership.mockResolvedValue({ member_role: 'owner' });
+
+    const originalFetch = global.fetch;
+    const originalGeminiKey = process.env.GEMINI_API_KEY;
+    process.env.GEMINI_API_KEY = 'test-key';
+    global.fetch = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          candidates: [
+            {
+              content: {
+                parts: [{ inlineData: { mimeType: 'image/png', data: 'dGVzdA==' } }],
+              },
+            },
+          ],
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } }
+      )
+    ) as any;
+
+    const first = await app.request('/media/recordings/rec_sketchnote/sketchnote', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token' },
+    });
+    const second = await app.request('/media/recordings/rec_sketchnote/sketchnote', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token' },
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(second.headers.get('Retry-After')).toMatch(/^\d+$/);
+    await expect(second.json()).resolves.toMatchObject({
+      code: 'image_quota_exceeded',
+      providerFamily: 'image',
+      endpoint: 'sketchnote',
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(1);
 
     global.fetch = originalFetch;
     process.env.GEMINI_API_KEY = originalGeminiKey;

--- a/server/tests/routes/transcribe.test.ts
+++ b/server/tests/routes/transcribe.test.ts
@@ -25,6 +25,7 @@ describe('Transcribe Routes', () => {
 
   afterEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     vi.useRealTimers();
   });
 
@@ -103,6 +104,39 @@ describe('Transcribe Routes', () => {
     const firstArg = mockTranscriptionService.transcribeLiveChunk.mock.calls[0][0];
     expect(firstArg).toEqual(expect.stringContaining('live_'));
     expect(path.extname(firstArg)).toBe('.wav');
+  });
+
+  it('returns live_transcription_quota_exceeded with Retry-After before provider call', async () => {
+    vi.stubEnv('VOICELOG_LIVE_TRANSCRIPTION_USER_QUOTA_PER_HOUR', '1');
+
+    const first = await app.request('/transcribe/live', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer token',
+        'Content-Type': 'audio/webm',
+        'X-Workspace-Id': 'ws1',
+      },
+      body: Buffer.alloc(2000, 1),
+    });
+    const second = await app.request('/transcribe/live', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer token',
+        'Content-Type': 'audio/webm',
+        'X-Workspace-Id': 'ws1',
+      },
+      body: Buffer.alloc(2000, 1),
+    });
+
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(429);
+    expect(second.headers.get('Retry-After')).toMatch(/^\d+$/);
+    await expect(second.json()).resolves.toMatchObject({
+      code: 'live_transcription_quota_exceeded',
+      providerFamily: 'live-transcription',
+      endpoint: 'live',
+    });
+    expect(mockTranscriptionService.transcribeLiveChunk).toHaveBeenCalledTimes(1);
   });
 
   it('responds quickly within the configured transcribe timeout budget', async () => {


### PR DESCRIPTION
## Summary
- Extends the existing AI quota store with reusable provider quota checks and operator-safe snapshots.
- Gates costly media/provider paths: STT start/retry, live transcription, sketchnote image generation, media analysis, voice coaching, and voice-profile embeddings.
- Adds `/media/quota/usage` for owner/admin/operator visibility without exposing prompts, transcripts, audio paths, or generated content.
- Documents quota defaults and env overrides in `docs/ops/PROVIDER_QUOTAS.md` and `.env.example`.

Closes #1251

## Validation
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\lib\aiQuotaStore.test.ts server\tests\routes\media.test.ts server\tests\routes\transcribe.test.ts --coverage.enabled=false` -> 3 files passed, 81 tests passed
- `node_modules\.bin\vitest.cmd run -c server\vitest.config.ts server\tests\routes\media.additional.test.ts server\tests\routes\ai.test.ts server\tests\routes\costly-endpoints-auth.test.ts --coverage.enabled=false` -> 3 files passed, 116 tests passed
- `node_modules\.bin\tsc.cmd --project server\tsconfig.server.json --noEmit` -> passed
- `node_modules\.bin\prettier.CMD --check server\lib\aiQuotaStore.ts server\routes\media.ts server\tests\lib\aiQuotaStore.test.ts server\tests\routes\media.test.ts server\tests\routes\transcribe.test.ts docs\ops\PROVIDER_QUOTAS.md docs\README.md .env.example` -> passed
- `git diff --check` -> passed, with Windows LF/CRLF warnings only
- `node scripts\audit-mojibake.mjs` -> passed

## Review
- Runtime behavior is additive: previously ungated provider calls now return a structured 429 before calling external providers when quota is exceeded.
- The DB snapshot uses `_all` when available; adapters without `_all` return an empty operator snapshot instead of leaking or failing.
- No workflow files were changed, so this PR avoids the current GitHub token `workflow` scope blocker.