### PR TITLE
feat(compliance): add audit export reporting (#1258)

### DIFF
--- a/docs/AUDIT_EXPORT_COMPLIANCE.md
+++ b/docs/AUDIT_EXPORT_COMPLIANCE.md
@@ -1,0 +1,87 @@
+# Audit Export Compliance Runbook
+
+## Purpose
+
+Workspace audit export gives enterprise operators a deterministic report of security-relevant
+workspace events without exporting raw audio or transcript content.
+
+Use it for compliance evidence, customer support investigations, and incident review.
+
+## Endpoint
+
+```http
+GET /workspaces/:workspaceId/audit-logs/export
+Authorization: Bearer <session-token>
+```
+
+Supported query parameters:
+
+| Parameter     | Description                                             |
+| ------------- | ------------------------------------------------------- |
+| `format`      | `json` by default, or `csv` for a flat report.          |
+| `from`        | Inclusive ISO timestamp lower bound for `createdAt`.    |
+| `to`          | Inclusive ISO timestamp upper bound for `createdAt`.    |
+| `eventType`   | Audit action, for example `recording.audio.downloaded`. |
+| `actorUserId` | User id that performed the audited action.              |
+| `recordingId` | Recording id when the audited entity is a recording.    |
+
+## Permissions
+
+The endpoint requires `workspace:audit:read`.
+
+Allowed roles:
+
+- `owner`
+- `admin`
+- `operator`
+- `auditor`
+
+Regular `member` and `viewer` roles cannot export audit reports.
+
+## JSON Report Shape
+
+```json
+{
+  "schemaVersion": "audit-export-v1",
+  "generatedAt": "2026-07-05T12:00:00.000Z",
+  "generatedBy": "user_123",
+  "filters": {
+    "workspaceId": "workspace_123",
+    "from": "2026-07-01T00:00:00.000Z",
+    "to": "2026-07-05T00:00:00.000Z",
+    "eventType": "recording.audio.downloaded",
+    "actorUserId": "user_123",
+    "recordingId": "recording_123"
+  },
+  "eventCount": 1,
+  "events": []
+}
+```
+
+CSV exports include:
+
+- `id`
+- `createdAt`
+- `workspaceId`
+- `actorUserId`
+- `eventType`
+- `entityType`
+- `entityId`
+- `recordingId`
+- `metadataJson`
+
+## Data Minimization
+
+Exported metadata is sanitized. Keys that can carry raw transcript, audio, prompt, file path,
+storage path, payload, or raw provider content are removed from the report metadata.
+
+The export must not be used as a replacement for full workspace data export because it is
+intentionally audit-focused and content-minimized.
+
+## Operator Checklist
+
+- Confirm the workspace id and date range before generating the report.
+- Prefer narrow filters for event type, actor, and recording when responding to a support request.
+- Store exported reports in the approved customer evidence location.
+- Do not attach raw audio, transcript text, prompts, provider payloads, API keys, or bearer tokens.
+- Re-run the export after remediation when the report is used for incident closure evidence.

--- a/server/database.ts
+++ b/server/database.ts
@@ -2506,6 +2506,123 @@ export class Database {
     };
   }
 
+  sanitizeAuditExportMetadata(value: unknown): unknown {
+    const blockedKeyPattern = /transcript|audio|prompt|payload|file[_-]?path|storage[_-]?path|raw/i;
+    if (Array.isArray(value)) {
+      return value.map((item) => this.sanitizeAuditExportMetadata(item));
+    }
+    if (!value || typeof value !== 'object') {
+      return value;
+    }
+
+    const sanitized: Record<string, unknown> = {};
+    for (const [key, nestedValue] of Object.entries(value as Record<string, unknown>)) {
+      if (blockedKeyPattern.test(key)) {
+        continue;
+      }
+      sanitized[key] = this.sanitizeAuditExportMetadata(nestedValue);
+    }
+    return sanitized;
+  }
+
+  async exportAuditLogs(
+    workspaceId: string,
+    options: {
+      generatedBy?: string;
+      actorUserId?: string;
+      targetActorUserId?: string;
+      eventType?: string;
+      recordingId?: string;
+      from?: string;
+      to?: string;
+      nowIso?: string;
+      limit?: number;
+    } = {}
+  ): Promise<any> {
+    const safeWorkspaceId = String(workspaceId || '').trim();
+    if (!safeWorkspaceId) throw new Error('Brakuje workspaceId.');
+
+    const generatedAt = String(options.nowIso || this.nowIso());
+    const generatedBy = String(options.generatedBy || '').trim();
+    const actorUserId = String(options.actorUserId || options.targetActorUserId || '').trim();
+    const eventType = String(options.eventType || '').trim();
+    const recordingId = String(options.recordingId || '').trim();
+    const from = String(options.from || '').trim();
+    const to = String(options.to || '').trim();
+    const limitInput = Number(options.limit ?? 5000);
+    const limit = Math.max(
+      1,
+      Math.min(5000, Math.floor(Number.isFinite(limitInput) ? limitInput : 5000))
+    );
+
+    const params: any[] = [safeWorkspaceId];
+    const filters = ['workspace_id = ?'];
+    if (from) {
+      filters.push('created_at >= ?');
+      params.push(from);
+    }
+    if (to) {
+      filters.push('created_at <= ?');
+      params.push(to);
+    }
+    if (eventType) {
+      filters.push('action = ?');
+      params.push(eventType);
+    }
+    if (actorUserId) {
+      filters.push('actor_user_id = ?');
+      params.push(actorUserId);
+    }
+    if (recordingId) {
+      filters.push('entity_type = ?', 'entity_id = ?');
+      params.push('recording', recordingId);
+    }
+
+    params.push(limit);
+    const rows = await this._query(
+      `SELECT id, workspace_id, actor_user_id, action, entity_type, entity_id, metadata_json, created_at
+       FROM audit_logs
+       WHERE ${filters.join(' AND ')}
+       ORDER BY created_at ASC, id ASC
+       LIMIT ?`,
+      params
+    );
+    const events = rows.map((entry: any) => {
+      const metadata = this.sanitizeAuditExportMetadata(
+        this._safeJsonParse(entry.metadata_json, {})
+      );
+      return {
+        id: String(entry.id || ''),
+        workspaceId: String(entry.workspace_id || ''),
+        actorUserId: String(entry.actor_user_id || ''),
+        action: String(entry.action || ''),
+        eventType: String(entry.action || ''),
+        entityType: String(entry.entity_type || ''),
+        entityId: String(entry.entity_id || ''),
+        recordingId:
+          String(entry.entity_type || '') === 'recording' ? String(entry.entity_id || '') : '',
+        metadata,
+        createdAt: String(entry.created_at || ''),
+      };
+    });
+
+    return {
+      schemaVersion: 'audit-export-v1',
+      generatedAt,
+      generatedBy,
+      filters: {
+        workspaceId: safeWorkspaceId,
+        from,
+        to,
+        eventType,
+        actorUserId,
+        recordingId,
+      },
+      eventCount: events.length,
+      events,
+    };
+  }
+
   async deleteMediaAsset(
     recordingId: string,
     workspaceId: string,

--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -164,6 +164,47 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
     return workspaceMembershipCan(membership, 'workspace:audit:read');
   }
 
+  function csvEscape(value: unknown) {
+    const text = String(value ?? '');
+    if (/[",\r\n]/.test(text)) {
+      return `"${text.replace(/"/g, '""')}"`;
+    }
+    return text;
+  }
+
+  function auditExportToCsv(report: any) {
+    const columns = [
+      'id',
+      'createdAt',
+      'workspaceId',
+      'actorUserId',
+      'eventType',
+      'entityType',
+      'entityId',
+      'recordingId',
+      'metadataJson',
+    ];
+    const rows = Array.isArray(report?.events) ? report.events : [];
+    return [
+      columns.join(','),
+      ...rows.map((event: any) =>
+        [
+          event.id,
+          event.createdAt,
+          event.workspaceId,
+          event.actorUserId,
+          event.eventType,
+          event.entityType,
+          event.entityId,
+          event.recordingId,
+          JSON.stringify(event.metadata || {}),
+        ]
+          .map(csvEscape)
+          .join(',')
+      ),
+    ].join('\n');
+  }
+
   router.put('/workspaces/:workspaceId/retention', async (c) => {
     const workspaceId = c.req.param('workspaceId');
     const membership = await ensureWorkspaceAccess(c, workspaceId);
@@ -225,6 +266,39 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
       }),
       200
     );
+  });
+
+  router.get('/workspaces/:workspaceId/audit-logs/export', async (c) => {
+    const workspaceId = c.req.param('workspaceId');
+    const membership = await ensureWorkspaceAccess(c, workspaceId);
+    if (!requireAuditReader(membership)) {
+      return c.json(
+        { message: 'Tylko owner, admin, operator lub auditor moze eksportowac audyt.' },
+        403
+      );
+    }
+
+    const session = c.get('session') as any;
+    const format = String(c.req.query('format') || 'json')
+      .trim()
+      .toLowerCase();
+    const report = await workspaceService.exportAuditLogs(workspaceId, {
+      generatedBy: String(session?.user_id || ''),
+      actorUserId: String(c.req.query('actorUserId') || '').trim(),
+      targetActorUserId: String(c.req.query('actorUserId') || '').trim(),
+      eventType: String(c.req.query('eventType') || '').trim(),
+      recordingId: String(c.req.query('recordingId') || '').trim(),
+      from: String(c.req.query('from') || '').trim(),
+      to: String(c.req.query('to') || '').trim(),
+    });
+
+    if (format === 'csv') {
+      c.header('Content-Type', 'text/csv; charset=utf-8');
+      c.header('Content-Disposition', `attachment; filename="voicelog-audit-${workspaceId}.csv"`);
+      return c.body(auditExportToCsv(report), 200);
+    }
+
+    return c.json(report, 200);
   });
 
   router.get('/workspaces/:workspaceId/audit-logs', async (c) => {

--- a/server/services/WorkspaceService.ts
+++ b/server/services/WorkspaceService.ts
@@ -63,6 +63,10 @@ export default class WorkspaceService {
     return await this.db.listAuditLogs(workspaceId, options);
   }
 
+  async exportAuditLogs(workspaceId: string, options: any = {}) {
+    return await this.db.exportAuditLogs(workspaceId, options);
+  }
+
   async updateWorkspaceMemberRole(workspaceId: string, targetUserId: string, memberRole: string) {
     return await this.db.updateWorkspaceMemberRole(workspaceId, targetUserId, memberRole);
   }

--- a/server/tests/database.test.ts
+++ b/server/tests/database.test.ts
@@ -395,6 +395,90 @@ describe('Database (Async Worker SQLite)', () => {
     expect(JSON.stringify(firstPage)).not.toContain('rec_other');
   });
 
+  test('Issue #1258 - exportAuditLogs filters events and strips raw content metadata', async () => {
+    await db._execute(
+      `INSERT INTO audit_logs (
+        id, workspace_id, actor_user_id, action, entity_type, entity_id, metadata_json, created_at
+      ) VALUES
+        (?, ?, ?, ?, ?, ?, ?, ?),
+        (?, ?, ?, ?, ?, ?, ?, ?),
+        (?, ?, ?, ?, ?, ?, ?, ?)`,
+      [
+        'audit_export_match',
+        'ws_audit_export',
+        'user_export',
+        'recording.audio.downloaded',
+        'recording',
+        'rec_export',
+        JSON.stringify({
+          requestId: 'req_export',
+          source: 'api',
+          transcriptText: 'RAW TRANSCRIPT SECRET',
+          audioPath: '/tmp/raw-audio.webm',
+          prompt: 'RAW PROMPT SECRET',
+        }),
+        '2026-07-03T10:00:00.000Z',
+        'audit_export_wrong_actor',
+        'ws_audit_export',
+        'user_other',
+        'recording.audio.downloaded',
+        'recording',
+        'rec_export',
+        JSON.stringify({ requestId: 'req_other_actor' }),
+        '2026-07-03T11:00:00.000Z',
+        'audit_export_wrong_recording',
+        'ws_audit_export',
+        'user_export',
+        'recording.deleted',
+        'recording',
+        'rec_other_export',
+        JSON.stringify({ requestId: 'req_other_recording' }),
+        '2026-07-03T12:00:00.000Z',
+      ]
+    );
+
+    const report = await db.exportAuditLogs('ws_audit_export', {
+      generatedBy: 'operator_1',
+      from: '2026-07-03T00:00:00.000Z',
+      to: '2026-07-04T00:00:00.000Z',
+      eventType: 'recording.audio.downloaded',
+      actorUserId: 'user_export',
+      recordingId: 'rec_export',
+      nowIso: '2026-07-05T12:00:00.000Z',
+    });
+
+    expect(report).toMatchObject({
+      schemaVersion: 'audit-export-v1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+      generatedBy: 'operator_1',
+      filters: {
+        workspaceId: 'ws_audit_export',
+        from: '2026-07-03T00:00:00.000Z',
+        to: '2026-07-04T00:00:00.000Z',
+        eventType: 'recording.audio.downloaded',
+        actorUserId: 'user_export',
+        recordingId: 'rec_export',
+      },
+      eventCount: 1,
+    });
+    expect(report.events).toEqual([
+      expect.objectContaining({
+        id: 'audit_export_match',
+        workspaceId: 'ws_audit_export',
+        actorUserId: 'user_export',
+        eventType: 'recording.audio.downloaded',
+        recordingId: 'rec_export',
+        metadata: { requestId: 'req_export', source: 'api' },
+        createdAt: '2026-07-03T10:00:00.000Z',
+      }),
+    ]);
+    expect(JSON.stringify(report)).not.toContain('RAW TRANSCRIPT SECRET');
+    expect(JSON.stringify(report)).not.toContain('/tmp/raw-audio.webm');
+    expect(JSON.stringify(report)).not.toContain('RAW PROMPT SECRET');
+    expect(JSON.stringify(report)).not.toContain('audit_export_wrong_actor');
+    expect(JSON.stringify(report)).not.toContain('audit_export_wrong_recording');
+  });
+
   test('Issue #1230 - deleteMediaAsset succeeds when audit storage is unavailable', async () => {
     const storageModule = await import('../lib/supabaseStorage.ts');
     const deleteAudioFromStorageSpy = vi

--- a/server/tests/routes/workspaces.test.ts
+++ b/server/tests/routes/workspaces.test.ts
@@ -51,6 +51,7 @@ describe('Workspace Routes', () => {
       cleanupExpiredRecordingsByRetention: vi.fn(),
       exportWorkspaceData: vi.fn(),
       listAuditLogs: vi.fn(),
+      exportAuditLogs: vi.fn(),
       updateWorkspaceMemberRole: vi.fn(),
       getMembership: vi.fn(),
     };
@@ -395,6 +396,131 @@ describe('Workspace Routes', () => {
       cursor: '',
     });
     expect(mockWorkspaceService.exportWorkspaceData).not.toHaveBeenCalled();
+  });
+
+  it('GET /workspaces/:workspaceId/audit-logs/export returns deterministic JSON report', async () => {
+    mockWorkspaceService.exportAuditLogs.mockResolvedValue({
+      schemaVersion: 'audit-export-v1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+      generatedBy: 'u1',
+      filters: {
+        workspaceId: 'ws1',
+        from: '2026-07-01T00:00:00.000Z',
+        to: '2026-07-05T00:00:00.000Z',
+        eventType: 'recording.audio.downloaded',
+        actorUserId: 'u1',
+        recordingId: 'rec1',
+      },
+      eventCount: 1,
+      events: [
+        {
+          id: 'audit_export_1',
+          workspaceId: 'ws1',
+          actorUserId: 'u1',
+          action: 'recording.audio.downloaded',
+          eventType: 'recording.audio.downloaded',
+          entityType: 'recording',
+          entityId: 'rec1',
+          recordingId: 'rec1',
+          metadata: { requestId: 'req_1' },
+          createdAt: '2026-07-03T10:00:00.000Z',
+        },
+      ],
+    });
+    app = createApp(
+      {
+        authService: mockAuthService,
+        workspaceService: mockWorkspaceService,
+        transcriptionService: mockTranscriptionService,
+        config: { allowedOrigins: '*', trustProxy: false, uploadDir: '/tmp', OPENAI_API_KEY: '' },
+      },
+      buildMiddlewares('operator')
+    );
+
+    const res = await app.request(
+      '/workspaces/ws1/audit-logs/export?from=2026-07-01T00:00:00.000Z&to=2026-07-05T00:00:00.000Z&eventType=recording.audio.downloaded&actorUserId=u1&recordingId=rec1',
+      {
+        method: 'GET',
+        headers: { Authorization: 'Bearer token' },
+      }
+    );
+
+    expect(res.status).toBe(200);
+    const payload = await res.json();
+    expect(payload).toMatchObject({
+      schemaVersion: 'audit-export-v1',
+      generatedBy: 'u1',
+      eventCount: 1,
+      events: [{ id: 'audit_export_1', recordingId: 'rec1' }],
+    });
+    expect(mockWorkspaceService.exportAuditLogs).toHaveBeenCalledWith('ws1', {
+      actorUserId: 'u1',
+      generatedBy: 'u1',
+      from: '2026-07-01T00:00:00.000Z',
+      to: '2026-07-05T00:00:00.000Z',
+      eventType: 'recording.audio.downloaded',
+      recordingId: 'rec1',
+      targetActorUserId: 'u1',
+    });
+  });
+
+  it('GET /workspaces/:workspaceId/audit-logs/export supports CSV and blocks members', async () => {
+    mockWorkspaceService.exportAuditLogs.mockResolvedValue({
+      schemaVersion: 'audit-export-v1',
+      generatedAt: '2026-07-05T12:00:00.000Z',
+      generatedBy: 'u1',
+      filters: { workspaceId: 'ws1' },
+      eventCount: 1,
+      events: [
+        {
+          id: 'audit_export_1',
+          workspaceId: 'ws1',
+          actorUserId: 'u1',
+          action: 'recording.deleted',
+          eventType: 'recording.deleted',
+          entityType: 'recording',
+          entityId: 'rec1',
+          recordingId: 'rec1',
+          metadata: { source: 'api' },
+          createdAt: '2026-07-03T10:00:00.000Z',
+        },
+      ],
+    });
+    app = createApp(
+      {
+        authService: mockAuthService,
+        workspaceService: mockWorkspaceService,
+        transcriptionService: mockTranscriptionService,
+        config: { allowedOrigins: '*', trustProxy: false, uploadDir: '/tmp', OPENAI_API_KEY: '' },
+      },
+      buildMiddlewares('auditor')
+    );
+
+    const csvRes = await app.request('/workspaces/ws1/audit-logs/export?format=csv', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(csvRes.status).toBe(200);
+    expect(csvRes.headers.get('content-type')).toContain('text/csv');
+    expect(await csvRes.text()).toContain('id,createdAt,workspaceId,actorUserId,eventType');
+
+    app = createApp(
+      {
+        authService: mockAuthService,
+        workspaceService: mockWorkspaceService,
+        transcriptionService: mockTranscriptionService,
+        config: { allowedOrigins: '*', trustProxy: false, uploadDir: '/tmp', OPENAI_API_KEY: '' },
+      },
+      buildMiddlewares('member')
+    );
+
+    const forbiddenRes = await app.request('/workspaces/ws1/audit-logs/export', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+
+    expect(forbiddenRes.status).toBe(403);
   });
 
   it('blocks viewers from mutating workspace state', async () => {


### PR DESCRIPTION
﻿## Summary
- Closes #1258
- Adds deterministic audit export reporting for workspace audit events.
- Supports JSON and CSV at `GET /workspaces/:workspaceId/audit-logs/export`.
- Supports filters for date range, event type, actor user id, and recording id.
- Includes integrity metadata: schema version, generated at, generated by, filters, and event count.
- Sanitizes exported audit metadata so raw transcript/audio/prompt/path/provider payload fields are not exported.
- Documents compliance usage in `docs/AUDIT_EXPORT_COMPLIANCE.md`.

## Validation
- RED confirmed: `corepack pnpm exec vitest run -c server/vitest.config.ts server/tests/database.test.ts server/tests/routes/workspaces.test.ts --coverage.enabled=false` failed before implementation on missing `exportAuditLogs` and 404 endpoint.
- GREEN: `corepack pnpm exec vitest run -c server/vitest.config.ts server/tests/database.test.ts server/tests/routes/workspaces.test.ts --coverage.enabled=false` - passed, 30 tests.
- `corepack pnpm run typecheck` - passed.
- `corepack pnpm run lint` - passed.
- `corepack pnpm run audit:mojibake` - passed.
- `corepack pnpm exec prettier --check server/database.ts server/routes/workspaces.ts server/services/WorkspaceService.ts server/tests/database.test.ts server/tests/routes/workspaces.test.ts docs/AUDIT_EXPORT_COMPLIANCE.md` - passed.
- `git diff --check` - passed.
- Pre-push `pnpm run test:release:guard` through Node 22 toolchain - passed: server retry 1449 passed / 82 skipped, targeted frontend/script 81 passed, build warning audit and Vite build passed.
- GitHub Actions on `d52f8f1`: Backend Vitest, Build, Docker, E2E, Frontend Vitest, Quality Gates, Remote API E2E, Security Audit, Visual Baselines, coverage-check, eslint-review, security-scan, bundle-size, and Vercel all passed.

## Notes / Risks
- Export is intentionally audit-only and content-minimized; full transcript/audio remains available only through existing authorized workspace export/media flows.
- The export caps returned rows at 5000 to avoid unbounded compliance downloads from a single request.
