### PR TITLE
docs(security): add key rotation runbook (#1259)

### DIFF
--- a/docs/SECURITY_KEY_MANAGEMENT_RUNBOOK.md
+++ b/docs/SECURITY_KEY_MANAGEMENT_RUNBOOK.md
@@ -1,0 +1,117 @@
+# Security Key Management and Secret Rotation Runbook
+
+## Purpose
+
+This runbook defines the VoiceLog secret inventory, Rotation procedure, Encryption assumptions,
+and Emergency rotation checklist for production and enterprise readiness.
+
+Secrets must live only in approved secret stores:
+
+- GitHub Actions secrets
+- Railway service variables
+- Vercel project variables
+- Supabase dashboard or database connection secret store
+- Provider dashboards for AI, observability, and OAuth credentials
+
+Do not commit production credentials to Git, issue comments, PR descriptions, logs, screenshots, or
+customer evidence bundles.
+
+## Secret inventory
+
+| Category              | Production secrets                                                                                                         | Primary store                                 | Consumers                                                      | Rotation trigger                                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------- | -------------------------------------------------------------- | ----------------------------------------------------------------- |
+| Backend admin and ops | `VOICELOG_ADMIN_TOKEN`, production smoke tokens                                                                            | GitHub Actions, Railway                       | Admin endpoints, production smoke, ops scripts                 | Suspected exposure, staff change, quarterly review                |
+| Database              | `DATABASE_URL`, `VOICELOG_DATABASE_URL`                                                                                    | Railway, GitHub Actions, Supabase             | Backend API, migrations, production smoke                      | Supabase password rotation, incident, environment rebuild         |
+| Supabase              | `SUPABASE_URL`, `SUPABASE_SERVICE_ROLE_KEY`                                                                                | Railway, GitHub Actions, Vercel smoke secrets | Remote audio storage, workspace verification, production smoke | Any service-role exposure, bucket policy change, quarterly review |
+| OpenAI                | `OPENAI_API_KEY`, `VOICELOG_OPENAI_API_KEY`, `VOICELOG_OPENAI_BASE_URL`                                                    | Railway, GitHub Actions                       | STT, embeddings, RAG-like operations                           | Provider rotation, usage anomaly, employee/vendor access change   |
+| Groq                  | `GROQ_API_KEY`                                                                                                             | Railway, GitHub Actions                       | STT fallback or fast STT                                       | Usage anomaly, provider rotation, access change                   |
+| Anthropic             | `ANTHROPIC_API_KEY`, `ANTHROPIC_MODEL`                                                                                     | Railway, GitHub Actions                       | Meeting analysis and AI assistant features                     | Usage anomaly, model/provider access change                       |
+| Hugging Face          | `HF_TOKEN`, `HUGGINGFACE_TOKEN`                                                                                            | Railway, GitHub Actions                       | Pyannote diarization                                           | Model access change, token scope change, incident                 |
+| Google OAuth          | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_OAUTH_REDIRECT_URI`, `GOOGLE_CALENDAR_SCOPES`, `VITE_GOOGLE_CLIENT_ID` | Google Cloud, Railway, Vercel, GitHub Actions | Google Calendar and Google Tasks integrations                  | OAuth client exposure, redirect URI change, consent scope change  |
+| Vercel                | `VERCEL_TOKEN`, `VERCEL_ORG_ID`, `VERCEL_PROJECT_ID`, frontend env vars                                                    | GitHub Actions, Vercel                        | Production deploy workflow and frontend runtime                | Token owner change, failed deploy audit, incident                 |
+| Railway               | `RAILWAY_TOKEN`, `RAILWAY_SERVICE_ID`                                                                                      | GitHub Actions, Railway                       | Railway sync and deployment metadata workflows                 | Token owner change, Railway project/service change, incident      |
+| Sentry                | `SENTRY_DSN`, `VITE_SENTRY_DSN`, `SENTRY_AUTH_TOKEN`, `SENTRY_ORG`, `SENTRY_PROJECT`                                       | GitHub Actions, Railway, Vercel, Sentry       | Error reporting and release health                             | DSN leak, auth token exposure, org/project move                   |
+| Datadog               | `DD_API_KEY`, `DD_SERVICE`, `DD_ENV`, `DD_APM_ENABLED`                                                                     | Railway, Datadog                              | APM and trace ingestion                                        | API key exposure, Datadog site/account move                       |
+| New Relic             | `NEW_RELIC_LICENSE_KEY`, `NEW_RELIC_APP_NAME`, `NEW_RELIC_ENVIRONMENT`, `NEW_RELIC_ENABLED`                                | Railway, New Relic                            | APM and telemetry                                              | License key exposure, account move                                |
+| OpenTelemetry         | `VOICELOG_OTEL_ENABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_HEADERS`                                       | Railway, collector secret store               | Trace export to an approved collector                          | Collector migration, header/token exposure                        |
+| Email and digest      | `VOICELOG_SMTP_HOST`, `VOICELOG_SMTP_USER`, `VOICELOG_SMTP_PASS`                                                           | Railway or mail provider                      | Digest and notification email                                  | SMTP credential exposure, provider account change                 |
+
+## Rotation procedure
+
+Use this procedure for each production secret category.
+
+1. Identify affected environments: GitHub Actions, Railway, Vercel, Supabase, and provider
+   dashboards.
+2. Create the replacement secret in the provider dashboard with minimum required scope.
+3. Add the replacement secret to the target secret store without deleting the old secret.
+4. Deploy or restart the affected service.
+5. Verify health:
+   - `/health`
+   - `/api/capabilities`
+   - production smoke workflow relevant to the provider
+   - provider dashboard usage/ingest logs
+6. Revoke the old secret only after the new secret is confirmed active.
+7. Record the rotation in the release or incident notes with:
+   - date and time
+   - rotated category
+   - owner
+   - environments updated
+   - verification evidence links
+
+### Provider-specific notes
+
+- Supabase: rotate database password and service role separately. Verify storage bucket access
+  after service-role rotation.
+- OpenAI, Groq, Anthropic, Hugging Face: verify quota dashboards after rotation and ensure no
+  frontend bundle contains backend-only keys.
+- Google OAuth: update allowed JavaScript origins and redirect URIs before replacing client
+  secrets in Railway/Vercel.
+- Sentry, Datadog, New Relic, OpenTelemetry: verify telemetry ingestion without sending raw
+  transcript, audio, prompt, provider payload, or bearer token data.
+- Vercel and Railway: rotate deploy tokens from the owning account and update GitHub Actions
+  secrets before rerunning deployment workflows.
+
+## Encryption assumptions
+
+| Surface                | Assumption                                                                                          | Required operator check                                                                                       |
+| ---------------------- | --------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------- |
+| Database at rest       | PostgreSQL/Supabase managed storage encryption is provided by the hosting platform.                 | Confirm the Supabase project and Railway Postgres region and encryption posture before enterprise onboarding. |
+| Supabase Storage       | Object storage encryption is managed by Supabase/storage provider.                                  | Confirm bucket privacy, signed URL policy, and service-role access.                                           |
+| Backups                | Backup encryption and retention are provider-managed unless a separate backup system is configured. | Confirm backup region, retention window, restore access, and deletion policy.                                 |
+| Local development data | Local SQLite files, downloaded audio, and debug exports are not assumed encrypted.                  | Developers must keep local workstations encrypted and avoid real customer data locally.                       |
+| CI artifacts           | GitHub Actions artifacts are not a secret store.                                                    | Do not upload `.env`, audio, transcripts, provider payloads, or secret-bearing logs.                          |
+| Logs and telemetry     | Structured logging and Sentry/trace sanitizers must redact tokens and content-like payloads.        | Verify redaction tests and inspect sample production events after provider changes.                           |
+
+## Emergency rotation checklist
+
+Use this checklist when a credential may have been exposed.
+
+1. Freeze automation that could reuse the exposed credential.
+2. Identify the secret category, owner, environments, and last known good deploy.
+3. Revoke or disable the exposed credential in the provider dashboard.
+4. Create a replacement with minimum required scope.
+5. Update GitHub Actions, Railway, Vercel, Supabase, and provider secret stores as needed.
+6. Redeploy or restart affected services.
+7. Verify `/health`, `/api/capabilities`, production smoke, and provider usage dashboards.
+8. Search recent logs and audit events for unexpected use.
+9. Rotate downstream credentials if the exposed secret could access them.
+10. Open or update the incident issue with evidence, impact, and follow-up hardening tasks.
+
+## Repository guard
+
+`node scripts/validate-secret-hygiene.mjs` scans tracked text files for high-confidence secret
+literals such as OpenAI, Anthropic, Groq, Hugging Face, GitHub PAT, Google OAuth client secret, and
+Supabase service-role JWT formats.
+
+The guard allows obvious placeholders, dummy CI values, and test fixtures. It is part of
+`pnpm run audit:repo-hygiene`, so CI and local release checks can block accidental secret commits.
+
+## Documentation review checklist
+
+- Secret inventory includes backend, frontend, CI, Railway, Vercel, Supabase, AI providers, and
+  observability tools.
+- Rotation procedure exists for every production secret category.
+- Emergency rotation checklist has an owner, verification steps, and incident evidence step.
+- Encryption assumptions cover database, Supabase Storage, backups, local development, CI
+  artifacts, and telemetry.
+- Repository guard is run before release and blocks obvious secret leaks.

--- a/docs/ops/URUCHOMIENIE.md
+++ b/docs/ops/URUCHOMIENIE.md
@@ -35,7 +35,7 @@ HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 na swój prawdziwy token:
 
 ```bash
-HF_TOKEN=hf_AbCdEfGhIjKlMnOpQrStUvWxYz123456
+HF_TOKEN=hf_your_huggingface_token_here
 ```
 
 ---

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "audit:build-warnings": "node scripts/audit-build-warnings.mjs",
     "audit:lighthouse": "node scripts/run-lighthouse-audit.mjs",
     "audit:mojibake": "node scripts/audit-mojibake.mjs",
-    "audit:repo-hygiene": "node scripts/validate-repo-hygiene.mjs && node scripts/validate-critical-path-coverage.mjs && node scripts/validate-database-schema-audit.mjs",
+    "audit:repo-hygiene": "node scripts/validate-repo-hygiene.mjs && node scripts/validate-secret-hygiene.mjs && node scripts/validate-critical-path-coverage.mjs && node scripts/validate-database-schema-audit.mjs",
     "audit:tooling": "node scripts/tooling-readiness-audit.mjs --write-report",
     "audit:ui-actions": "node scripts/audit-ui-action-contracts.mjs --write-report",
     "test:ui-actions:contract": "node scripts/audit-ui-action-contracts.mjs --write-report",

--- a/scripts/validate-secret-hygiene.mjs
+++ b/scripts/validate-secret-hygiene.mjs
@@ -1,0 +1,137 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+const SECRET_PATTERNS = [
+  {
+    kind: 'openai-api-key',
+    pattern: /\bsk-(?!ant-)(?:proj-)?[A-Za-z0-9_-]{24,}\b/g,
+  },
+  {
+    kind: 'anthropic-api-key',
+    pattern: /\bsk-ant-[A-Za-z0-9_-]{24,}\b/g,
+  },
+  {
+    kind: 'groq-api-key',
+    pattern: /\bgsk_[A-Za-z0-9_-]{24,}\b/g,
+  },
+  {
+    kind: 'huggingface-token',
+    pattern: /\bhf_[A-Za-z0-9]{24,}\b/g,
+  },
+  {
+    kind: 'github-pat',
+    pattern: /\bgithub_pat_[A-Za-z0-9_]{24,}\b/g,
+  },
+  {
+    kind: 'supabase-service-role-jwt',
+    pattern: /\beyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\b/g,
+  },
+  {
+    kind: 'google-oauth-client-secret',
+    pattern: /\bGOCSPX-[A-Za-z0-9_-]{20,}\b/g,
+  },
+];
+
+const TEXT_FILE_PATTERN =
+  /\.(?:cjs|css|env|example|html|js|json|jsx|md|mjs|ps1|py|sh|sql|ts|tsx|txt|yaml|yml)$/i;
+const SKIP_PATH_PATTERN =
+  /^(?:build|coverage|dist|node_modules|playwright-report|test-results|\.git)\//i;
+const PLACEHOLDER_PATTERN =
+  /(?:dummy|example|placeholder|test|fake|mock|sample|your[_ -]?|change[-_]?this|xxx|xxxx|x4x4|secret-123|new-secret|ops-secret|validating-env)/i;
+
+export function normalizeGitPath(filePath) {
+  return String(filePath || '')
+    .replace(/\\/g, '/')
+    .replace(/^\.\//, '')
+    .trim();
+}
+
+export function isScannableTextPath(filePath) {
+  const normalized = normalizeGitPath(filePath);
+  return Boolean(
+    normalized && !SKIP_PATH_PATTERN.test(normalized) && TEXT_FILE_PATTERN.test(normalized)
+  );
+}
+
+function isAllowedPlaceholder({ path: filePath, line }) {
+  const normalizedPath = normalizeGitPath(filePath).toLowerCase();
+  const normalizedLine = String(line || '').toLowerCase();
+  return (
+    PLACEHOLDER_PATTERN.test(normalizedLine) || /(^|\/)(tests?|fixtures?)\//.test(normalizedPath)
+  );
+}
+
+export function findForbiddenSecretLiterals(files = []) {
+  const violations = [];
+  for (const file of files) {
+    const filePath = normalizeGitPath(file.path);
+    const content = String(file.content || '');
+    const lines = content.split(/\r?\n/);
+    lines.forEach((line, index) => {
+      if (isAllowedPlaceholder({ path: filePath, line })) {
+        return;
+      }
+      for (const rule of SECRET_PATTERNS) {
+        rule.pattern.lastIndex = 0;
+        if (rule.pattern.test(line)) {
+          violations.push({
+            path: filePath,
+            line: index + 1,
+            kind: rule.kind,
+          });
+        }
+      }
+    });
+  }
+  return violations;
+}
+
+export function readTrackedTextFiles({ cwd = process.cwd(), maxBytes = 1024 * 1024 } = {}) {
+  const output = execFileSync('git', ['ls-files'], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+
+  return output
+    .split(/\r?\n/)
+    .filter(isScannableTextPath)
+    .map((filePath) => {
+      const absolutePath = path.join(cwd, filePath);
+      const content = readFileSync(absolutePath, 'utf8');
+      return {
+        path: filePath,
+        content: content.length > maxBytes ? content.slice(0, maxBytes) : content,
+      };
+    });
+}
+
+export function validateSecretHygiene(options = {}) {
+  const files = options.files || readTrackedTextFiles(options);
+  const violations = findForbiddenSecretLiterals(files);
+  if (violations.length > 0) {
+    const preview = violations
+      .slice(0, 40)
+      .map((violation) => `- ${violation.path}:${violation.line} (${violation.kind})`)
+      .join('\n');
+    const suffix =
+      violations.length > 40
+        ? `\n...and ${violations.length - 40} more secret-looking literal(s).`
+        : '';
+    throw new Error(
+      `Potential committed secrets detected:\n${preview}${suffix}\nMove real credentials to GitHub, Railway, Vercel, or provider secret stores.`
+    );
+  }
+
+  return true;
+}
+
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const isMainModule =
+  entrypointPath === path.resolve(process.cwd(), 'scripts/validate-secret-hygiene.mjs');
+
+if (isMainModule) {
+  validateSecretHygiene();
+  console.log('Secret hygiene validation passed.');
+}

--- a/scripts/validate-secret-hygiene.test.ts
+++ b/scripts/validate-secret-hygiene.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+import { findForbiddenSecretLiterals, validateSecretHygiene } from './validate-secret-hygiene.mjs';
+
+const repoRoot = process.cwd();
+const runbookPath = join(repoRoot, 'docs', 'SECURITY_KEY_MANAGEMENT_RUNBOOK.md');
+
+describe('secret hygiene validation', () => {
+  it('blocks obvious production-looking secret literals', () => {
+    const violations = findForbiddenSecretLiterals([
+      {
+        path: 'server/config.ts',
+        content: 'const leaked = "sk-proj-live_1234567890abcdefghijklmnopqrstuvwxyz";',
+      },
+      {
+        path: 'docs/example.md',
+        content: 'SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real.payload',
+      },
+      {
+        path: 'scripts/example.mjs',
+        content: 'const token = "github_pat_1234567890abcdefghijklmnopqrstuvwxyz";',
+      },
+    ]);
+
+    expect(violations.map((violation) => violation.kind)).toEqual([
+      'openai-api-key',
+      'supabase-service-role-jwt',
+      'github-pat',
+    ]);
+  });
+
+  it('allows placeholders, dummy CI values, and test fixtures', () => {
+    const violations = findForbiddenSecretLiterals([
+      { path: '.env.example', content: '# OPENAI_API_KEY=sk-...' },
+      {
+        path: '.github/workflows/ci.yml',
+        content: 'OPENAI_API_KEY: sk-proj-dummy-ci-key-for-validating-env-123456789',
+      },
+      {
+        path: 'server/tests/setup.ts',
+        content: "process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-key';",
+      },
+    ]);
+
+    expect(violations).toEqual([]);
+  });
+
+  it('keeps the current tracked repository free of obvious secret literals', () => {
+    expect(() => validateSecretHygiene()).not.toThrow();
+  });
+
+  it('documents secret inventory, rotation, encryption assumptions, and emergency response', () => {
+    const markdown = readFileSync(runbookPath, 'utf8');
+
+    for (const requiredText of [
+      'Secret inventory',
+      'Rotation procedure',
+      'Emergency rotation checklist',
+      'Encryption assumptions',
+      'Railway',
+      'Vercel',
+      'Supabase',
+      'OpenAI',
+      'Groq',
+      'Anthropic',
+      'Hugging Face',
+      'Google OAuth',
+      'Sentry',
+      'Datadog',
+      'New Relic',
+    ]) {
+      expect(markdown).toContain(requiredText);
+    }
+  });
+});

--- a/scripts/validate-secret-hygiene.test.ts
+++ b/scripts/validate-secret-hygiene.test.ts
@@ -7,20 +7,36 @@ import { findForbiddenSecretLiterals, validateSecretHygiene } from './validate-s
 const repoRoot = process.cwd();
 const runbookPath = join(repoRoot, 'docs', 'SECURITY_KEY_MANAGEMENT_RUNBOOK.md');
 
+const secretLikeFixture = (...parts: string[]) => parts.join('');
+
 describe('secret hygiene validation', () => {
   it('blocks obvious production-looking secret literals', () => {
+    const openAiKey = secretLikeFixture(
+      'sk-',
+      'proj-',
+      'live_1234567890abcdefghijklmnopqrstuvwxyz'
+    );
+    const supabaseServiceRoleJwt = secretLikeFixture(
+      'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9',
+      '.',
+      'real',
+      '.',
+      'payload'
+    );
+    const githubPat = secretLikeFixture('github_', 'pat_', '1234567890abcdefghijklmnopqrstuvwxyz');
+
     const violations = findForbiddenSecretLiterals([
       {
         path: 'server/config.ts',
-        content: 'const leaked = "sk-proj-live_1234567890abcdefghijklmnopqrstuvwxyz";',
+        content: `const leaked = "${openAiKey}";`,
       },
       {
         path: 'docs/example.md',
-        content: 'SUPABASE_SERVICE_ROLE_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.real.payload',
+        content: `SUPABASE_SERVICE_ROLE_KEY=${supabaseServiceRoleJwt}`,
       },
       {
         path: 'scripts/example.mjs',
-        content: 'const token = "github_pat_1234567890abcdefghijklmnopqrstuvwxyz";',
+        content: `const token = "${githubPat}";`,
       },
     ]);
 


### PR DESCRIPTION
﻿## Summary
- Closes #1259
- Adds `docs/SECURITY_KEY_MANAGEMENT_RUNBOOK.md` with secret inventory, rotation procedure, encryption assumptions, and emergency rotation checklist.
- Adds `scripts/validate-secret-hygiene.mjs` to block obvious committed secret literals.
- Wires secret hygiene into `pnpm run audit:repo-hygiene`.
- Replaces an HF token-shaped documentation sample with a clear placeholder.

## Validation
- RED confirmed: `corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/validate-secret-hygiene.test.ts --coverage.enabled=false` failed before the scanner module existed.
- GREEN: `corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/validate-secret-hygiene.test.ts scripts/validate-repo-hygiene.test.ts --coverage.enabled=false` - passed, 7 tests.
- `node scripts/validate-secret-hygiene.mjs` - passed.
- `corepack pnpm run audit:repo-hygiene` - passed, including the new secret hygiene guard.
- `corepack pnpm run audit:mojibake` - passed.
- `git diff --check` - passed.
- Pre-push `pnpm run test:release:guard` through Node 22 toolchain - passed: server retry 1446 passed / 82 skipped, targeted frontend/script 81 passed, build warning audit and Vite build passed.

## Notes / Risks
- The scanner intentionally targets high-confidence secret formats and allows obvious dummy/test/example values to avoid blocking existing CI fixtures.
- Legal/security owners still need to confirm provider-specific encryption and retention statements for regulated customer commitments.
