### PR TITLE
feat(config): add workspace feature flags (#1262)

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -10,7 +10,11 @@ import { config } from './config.ts';
 import { resolveBuildMetadata } from './runtime.ts';
 import { isCreatedAtExpiredByRetention } from './lib/retentionPolicy.ts';
 import { requireVoiceProfileEmbedding } from './lib/voiceProfileEmbedding.ts';
-import type { SessionPayload, WorkspaceStatePayload } from '../src/shared/contracts.ts';
+import {
+  normalizeWorkspaceFeatureFlags,
+  type SessionPayload,
+  type WorkspaceStatePayload,
+} from '../src/shared/contracts.ts';
 import {
   STORAGE_CONTENT_TYPE,
   buildManifestStoragePath,
@@ -1246,6 +1250,17 @@ export class Database {
         throw error;
       }
     }
+    try {
+      await this._execute(
+        "ALTER TABLE workspace_state ADD COLUMN feature_flags_json TEXT NOT NULL DEFAULT '{}'"
+      );
+    } catch (error) {
+      if (
+        !isAddColumnAlreadyAppliedMigrationError('ALTER TABLE workspace_state ADD COLUMN', error)
+      ) {
+        throw error;
+      }
+    }
 
     const existing = await this._get(
       'SELECT workspace_id FROM workspace_state WHERE workspace_id = ?',
@@ -1266,9 +1281,10 @@ export class Database {
           calendar_meta_json,
           vocabulary_json,
           retention_days,
+          feature_flags_json,
           updated_at
         )
-        VALUES (?, '[]', '[]', '[]', '{}', '{}', '{}', '[]', ?, ?)
+        VALUES (?, '[]', '[]', '[]', '{}', '{}', '{}', '[]', ?, '{}', ?)
       `,
       [workspaceId, DEFAULT_RETENTION_DAYS, timestamp]
     );
@@ -1444,6 +1460,7 @@ export class Database {
       calendarMeta,
       vocabulary: this._safeJsonParse(row.vocabulary_json, []),
       retentionDays: _normalizeRetentionDays(row.retention_days),
+      featureFlags: normalizeWorkspaceFeatureFlags(this._safeJsonParse(row.feature_flags_json, {})),
       updatedAt: row.updated_at,
     };
   }
@@ -1459,6 +1476,7 @@ export class Database {
       calendarMeta: {},
       vocabulary: [],
       retentionDays: DEFAULT_RETENTION_DAYS,
+      featureFlags: normalizeWorkspaceFeatureFlags(),
     }
   ): Promise<WorkspaceState> {
     await this.ensureWorkspaceState(workspaceId);
@@ -1503,6 +1521,7 @@ export class Database {
             calendar_meta_json = ?,
             vocabulary_json = ?,
             retention_days = ?,
+            feature_flags_json = ?,
             updated_at = ?
         WHERE workspace_id = ?
       `,
@@ -1521,6 +1540,11 @@ export class Database {
         JSON.stringify(calendarMeta),
         JSON.stringify(Array.isArray(payload.vocabulary) ? payload.vocabulary : []),
         _normalizeRetentionDays((payload as any).retentionDays, currentRow?.retention_days),
+        JSON.stringify(
+          normalizeWorkspaceFeatureFlags(
+            (payload as any).featureFlags || this._safeJsonParse(currentRow?.feature_flags_json, {})
+          )
+        ),
         timestamp,
         workspaceId,
       ]
@@ -1531,6 +1555,44 @@ export class Database {
       workspaceId,
     ]);
     return this.getWorkspaceState(workspaceId);
+  }
+
+  async updateWorkspaceFeatureFlags(
+    workspaceId: string,
+    featureFlags: unknown,
+    options: { actorUserId?: string; requestId?: string; source?: string } = {}
+  ): Promise<any> {
+    const safeWorkspaceId = String(workspaceId || '').trim();
+    if (!safeWorkspaceId) throw new Error('Brakuje workspaceId.');
+    await this.ensureWorkspaceState(safeWorkspaceId);
+    const current = await this.getWorkspaceState(safeWorkspaceId);
+    const nextFeatureFlags = normalizeWorkspaceFeatureFlags({
+      ...current.featureFlags,
+      ...(featureFlags && typeof featureFlags === 'object' ? featureFlags : {}),
+    });
+    const timestamp = this.nowIso();
+    await this._execute(
+      'UPDATE workspace_state SET feature_flags_json = ?, updated_at = ? WHERE workspace_id = ?',
+      [JSON.stringify(nextFeatureFlags), timestamp, safeWorkspaceId]
+    );
+    await this._execute('UPDATE workspaces SET updated_at = ? WHERE id = ?', [
+      timestamp,
+      safeWorkspaceId,
+    ]);
+    await this.writeAuditLogBestEffort({
+      workspaceId: safeWorkspaceId,
+      actorUserId: String(options.actorUserId || ''),
+      action: 'workspace.feature_flags.updated',
+      entityType: 'workspace',
+      entityId: safeWorkspaceId,
+      metadata: {
+        previousFeatureFlags: current.featureFlags,
+        featureFlags: nextFeatureFlags,
+        source: String(options.source || 'api'),
+        requestId: String(options.requestId || ''),
+      },
+    });
+    return { featureFlags: nextFeatureFlags, state: await this.getWorkspaceState(safeWorkspaceId) };
   }
 
   async tombstoneWorkspaceRecording(workspaceId: string, recordingId: string): Promise<void> {

--- a/server/http/capabilities.ts
+++ b/server/http/capabilities.ts
@@ -2,6 +2,8 @@ import type { Hono } from 'hono';
 import { config } from '../config.ts';
 import { resolveSttRuntimePolicy } from '../stt/policy.ts';
 import { MetricsService } from '../services/MetricsService.ts';
+import { normalizeWorkspaceFeatureFlags } from '../../src/shared/contracts.ts';
+import type { WorkspaceFeatureFlags, WorkspaceSttProvider } from '../../src/shared/types.ts';
 
 export type CapabilityStatus = 'available' | 'degraded' | 'unavailable';
 export type ProductionStatus = 'ready' | 'degraded';
@@ -14,7 +16,9 @@ export interface CapabilityFlag {
     | 'supabaseStorage'
     | 'liveTranscription'
     | 'embeddings'
-    | 'imageGeneration';
+    | 'imageGeneration'
+    | 'retentionFeatures'
+    | 'experimentalUi';
   label: string;
   enabled: boolean;
   status: CapabilityStatus;
@@ -36,6 +40,7 @@ export interface ProductionCapabilitiesPayload {
   status: ProductionStatus;
   generatedAt: string;
   capabilities: Record<CapabilityFlag['id'], CapabilityFlag>;
+  workspaceFeatureFlags: WorkspaceFeatureFlags;
   degradedCapabilities: CapabilityFlag[];
   telemetry: {
     fallbackModeUsed: boolean;
@@ -46,6 +51,7 @@ export interface ProductionCapabilitiesPayload {
 interface ResolveOptions {
   env?: NodeJS.ProcessEnv;
   storageReadiness?: StorageReadiness;
+  workspaceFeatureFlags?: Partial<WorkspaceFeatureFlags>;
   now?: Date;
 }
 
@@ -91,11 +97,72 @@ function sanitizeReason(value?: string) {
   return String(value || '').replace(/(sk|gsk|hf|key|secret|token)[-_a-z0-9]+/gi, '[redacted]');
 }
 
+function capabilityDisabledByWorkspace(
+  capability: CapabilityFlag,
+  enabled: boolean
+): CapabilityFlag {
+  if (enabled) return capability;
+  return {
+    ...capability,
+    enabled: false,
+    status: 'unavailable',
+    provider: 'none',
+    reason: 'Disabled by workspace feature flags.',
+    fallbackMode: false,
+  };
+}
+
+function resolveForcedSttProvider(
+  sttProvider: WorkspaceSttProvider,
+  availability: { hasOpenAi: boolean; hasGroq: boolean; hasLocalWhisper: boolean }
+): CapabilityFlag | null {
+  if (sttProvider === 'auto') return null;
+  if (sttProvider === 'disabled') {
+    return {
+      id: 'stt',
+      label: 'Transkrypcja STT',
+      enabled: false,
+      status: 'unavailable',
+      provider: 'none',
+      reason: 'Disabled by workspace feature flags.',
+      fallbackMode: false,
+    };
+  }
+  if (sttProvider === 'local-whisper') {
+    return {
+      id: 'stt',
+      label: 'Transkrypcja STT',
+      enabled: false,
+      status: 'unavailable',
+      provider: 'none',
+      reason: 'Workspace local-whisper provider is not wired into the STT pipeline yet.',
+      fallbackMode: false,
+    };
+  }
+
+  const providerConfigured =
+    (sttProvider === 'openai' && availability.hasOpenAi) ||
+    (sttProvider === 'groq' && availability.hasGroq);
+
+  return {
+    id: 'stt',
+    label: 'Transkrypcja STT',
+    enabled: providerConfigured,
+    status: providerConfigured ? 'available' : 'unavailable',
+    provider: providerConfigured ? sttProvider : 'none',
+    reason: providerConfigured
+      ? undefined
+      : `Workspace STT provider ${sttProvider} is not configured.`,
+    fallbackMode: false,
+  };
+}
+
 export function resolveProductionCapabilities(
   options: ResolveOptions = {}
 ): ProductionCapabilitiesPayload {
   const env = options.env || process.env;
   const storageReadiness = options.storageReadiness || DEFAULT_STORAGE_READINESS;
+  const workspaceFeatureFlags = normalizeWorkspaceFeatureFlags(options.workspaceFeatureFlags);
   const hasOpenAi = hasValue(env, 'OPENAI_API_KEY') || hasValue(env, 'VOICELOG_OPENAI_API_KEY');
   const hasGroq = hasValue(env, 'GROQ_API_KEY');
   const hasLocalWhisper = isEnabled(env.USE_LOCAL_WHISPER) && hasValue(env, 'WHISPER_CPP_PATH');
@@ -133,29 +200,41 @@ export function resolveProductionCapabilities(
       reason: 'No STT provider is configured.',
     };
   }
+  stt =
+    resolveForcedSttProvider(workspaceFeatureFlags.sttProvider, {
+      hasOpenAi,
+      hasGroq,
+      hasLocalWhisper,
+    }) || stt;
 
   const capabilities: ProductionCapabilitiesPayload['capabilities'] = {
-    stt,
-    diarization: {
-      id: 'diarization',
-      label: 'Diarization',
-      enabled: hasHfToken,
-      status: hasHfToken ? 'available' : 'unavailable',
-      provider: hasHfToken ? 'pyannote' : 'none',
-      reason: hasHfToken ? undefined : 'HF_TOKEN or HUGGINGFACE_TOKEN is missing.',
-    },
-    meetingAnalysis: {
-      id: 'meetingAnalysis',
-      label: 'Analiza spotkan',
-      enabled: meetingAnalysisFlag && hasAnthropic,
-      status: meetingAnalysisFlag && hasAnthropic ? 'available' : 'degraded',
-      provider: meetingAnalysisFlag && hasAnthropic ? 'anthropic' : 'local-fallback',
-      reason:
-        meetingAnalysisFlag && hasAnthropic
-          ? undefined
-          : 'Anthropic analysis is disabled or missing; local fallback is active.',
-      fallbackMode: !(meetingAnalysisFlag && hasAnthropic),
-    },
+    stt: capabilityDisabledByWorkspace(stt, workspaceFeatureFlags.sttProvider !== 'disabled'),
+    diarization: capabilityDisabledByWorkspace(
+      {
+        id: 'diarization',
+        label: 'Diarization',
+        enabled: hasHfToken,
+        status: hasHfToken ? 'available' : 'unavailable',
+        provider: hasHfToken ? 'pyannote' : 'none',
+        reason: hasHfToken ? undefined : 'HF_TOKEN or HUGGINGFACE_TOKEN is missing.',
+      },
+      workspaceFeatureFlags.diarization
+    ),
+    meetingAnalysis: capabilityDisabledByWorkspace(
+      {
+        id: 'meetingAnalysis',
+        label: 'Analiza spotkan',
+        enabled: meetingAnalysisFlag && hasAnthropic,
+        status: meetingAnalysisFlag && hasAnthropic ? 'available' : 'degraded',
+        provider: meetingAnalysisFlag && hasAnthropic ? 'anthropic' : 'local-fallback',
+        reason:
+          meetingAnalysisFlag && hasAnthropic
+            ? undefined
+            : 'Anthropic analysis is disabled or missing; local fallback is active.',
+        fallbackMode: !(meetingAnalysisFlag && hasAnthropic),
+      },
+      workspaceFeatureFlags.meetingAnalysis
+    ),
     supabaseStorage: {
       id: 'supabaseStorage',
       label: 'Magazyn audio',
@@ -173,29 +252,55 @@ export function resolveProductionCapabilities(
             ),
       fallbackMode: storageReadiness.ready !== true,
     },
-    liveTranscription: {
-      id: 'liveTranscription',
-      label: 'Transkrypcja live',
-      enabled: true,
+    liveTranscription: capabilityDisabledByWorkspace(
+      {
+        id: 'liveTranscription',
+        label: 'Transkrypcja live',
+        enabled: true,
+        status: 'available',
+        provider: 'browser-speech-recognition',
+        reason: 'Availability depends on browser support and microphone permission.',
+      },
+      workspaceFeatureFlags.liveTranscription
+    ),
+    embeddings: capabilityDisabledByWorkspace(
+      {
+        id: 'embeddings',
+        label: 'Embeddingi',
+        enabled: hasOpenAi,
+        status: hasOpenAi ? 'available' : 'unavailable',
+        provider: hasOpenAi ? 'openai' : 'none',
+        reason: hasOpenAi ? undefined : 'OPENAI_API_KEY or VOICELOG_OPENAI_API_KEY is missing.',
+      },
+      workspaceFeatureFlags.embeddings
+    ),
+    imageGeneration: capabilityDisabledByWorkspace(
+      {
+        id: 'imageGeneration',
+        label: 'Generowanie obrazow',
+        enabled: hasGemini,
+        status: hasGemini ? 'available' : 'unavailable',
+        provider: hasGemini ? 'gemini' : 'none',
+        reason: hasGemini ? undefined : 'GEMINI_API_KEY is missing.',
+      },
+      workspaceFeatureFlags.imageGeneration
+    ),
+    retentionFeatures: {
+      id: 'retentionFeatures',
+      label: 'Retencja i legal hold',
+      enabled: workspaceFeatureFlags.retentionFeatures,
+      status: workspaceFeatureFlags.retentionFeatures ? 'available' : 'unavailable',
+      provider: workspaceFeatureFlags.retentionFeatures ? 'internal' : 'none',
+      reason: workspaceFeatureFlags.retentionFeatures
+        ? undefined
+        : 'Disabled by workspace feature flags.',
+    },
+    experimentalUi: {
+      id: 'experimentalUi',
+      label: 'Eksperymentalny UI',
+      enabled: workspaceFeatureFlags.experimentalUi,
       status: 'available',
-      provider: 'browser-speech-recognition',
-      reason: 'Availability depends on browser support and microphone permission.',
-    },
-    embeddings: {
-      id: 'embeddings',
-      label: 'Embeddingi',
-      enabled: hasOpenAi,
-      status: hasOpenAi ? 'available' : 'unavailable',
-      provider: hasOpenAi ? 'openai' : 'none',
-      reason: hasOpenAi ? undefined : 'OPENAI_API_KEY or VOICELOG_OPENAI_API_KEY is missing.',
-    },
-    imageGeneration: {
-      id: 'imageGeneration',
-      label: 'Generowanie obrazow',
-      enabled: hasGemini,
-      status: hasGemini ? 'available' : 'unavailable',
-      provider: hasGemini ? 'gemini' : 'none',
-      reason: hasGemini ? undefined : 'GEMINI_API_KEY is missing.',
+      provider: 'internal',
     },
   };
 
@@ -211,6 +316,7 @@ export function resolveProductionCapabilities(
     status: degradedCapabilities.length === 0 ? 'ready' : 'degraded',
     generatedAt: (options.now || new Date()).toISOString(),
     capabilities,
+    workspaceFeatureFlags,
     degradedCapabilities,
     telemetry: {
       fallbackModeUsed: fallbackModeCapabilities.length > 0,

--- a/server/lib/types.ts
+++ b/server/lib/types.ts
@@ -182,6 +182,19 @@ export interface TranscriptionResult {
   reviewSummary?: string | null;
 }
 
+export type WorkspaceSttProvider = 'auto' | 'openai' | 'groq' | 'local-whisper' | 'disabled';
+
+export interface WorkspaceFeatureFlags {
+  sttProvider: WorkspaceSttProvider;
+  diarization: boolean;
+  meetingAnalysis: boolean;
+  embeddings: boolean;
+  imageGeneration: boolean;
+  liveTranscription: boolean;
+  retentionFeatures: boolean;
+  experimentalUi: boolean;
+}
+
 export interface WorkspaceState {
   meetings: any[];
   manualTasks: any[];
@@ -191,5 +204,6 @@ export interface WorkspaceState {
   calendarMeta: any;
   vocabulary: string[];
   retentionDays: number;
+  featureFlags: WorkspaceFeatureFlags;
   updatedAt: string;
 }

--- a/server/migrations/001_initial_schema.sql
+++ b/server/migrations/001_initial_schema.sql
@@ -39,6 +39,7 @@ CREATE TABLE IF NOT EXISTS workspace_state (
   calendar_meta_json TEXT NOT NULL DEFAULT '{}',
   vocabulary_json TEXT NOT NULL DEFAULT '[]',
   retention_days INTEGER NOT NULL DEFAULT 365,
+  feature_flags_json TEXT NOT NULL DEFAULT '{}',
   updated_at TEXT NOT NULL
 );
 

--- a/server/migrations/20260705_workspace_feature_flags.sql
+++ b/server/migrations/20260705_workspace_feature_flags.sql
@@ -1,0 +1,2 @@
+ALTER TABLE workspace_state
+  ADD COLUMN feature_flags_json TEXT NOT NULL DEFAULT '{}';

--- a/server/pipeline.ts
+++ b/server/pipeline.ts
@@ -473,6 +473,9 @@ async function runTranscriptionAttempt(
                   contentType: transcribeContentType,
                   fields,
                   signal: options.signal,
+                  preferredProvider: options.sttPreferredProvider,
+                  apiKey: options.sttApiKey,
+                  baseUrl: options.sttBaseUrl,
                 })
             );
             const finalSttResult = await maybeRetryPoorQualityWithOpenAi({
@@ -550,7 +553,7 @@ async function runTranscriptionAttempt(
       }
 
       // Provider-level fallback: Groq primary failed → retry with OpenAI
-      if (!whisperPayload && _sttUseGroq && OPENAI_API_KEY) {
+      if (!whisperPayload && _sttUseGroq && OPENAI_API_KEY && !options.sttPreferredProvider) {
         const openaiModels =
           config.VOICELOG_STT_MODEL_FULL !== 'whisper-1'
             ? [...new Set([config.VOICELOG_STT_MODEL_FULL, config.VERIFICATION_MODEL, 'whisper-1'])]
@@ -690,7 +693,7 @@ async function runTranscriptionAttempt(
         }
       }
 
-      if (!diarization) {
+      if (!diarization && !options.skipSemanticDiarization) {
         if (DEBUG)
           console.log(
             '[pipeline] Pyannote unavailable — using GPT-4o-mini transcript diarization.'

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -106,6 +106,14 @@ function normalizeAnalysisPayload(result: any, segments: any[] = []) {
   };
 }
 
+async function getWorkspaceFeatureFlags(workspaceService: any, workspaceId: string) {
+  if (typeof workspaceService?.getWorkspaceState !== 'function') {
+    return {};
+  }
+  const state = await workspaceService.getWorkspaceState(workspaceId);
+  return state?.featureFlags || {};
+}
+
 function getIdempotencyKey(c: any): string | undefined {
   const key = String(c.req.header(IDEMPOTENCY_KEY_HEADER) || '').trim();
   return key ? key.slice(0, 160) : undefined;
@@ -688,7 +696,7 @@ async function cleanupOldChunks(
 
 export function createMediaRoutes(services: AppServices, middlewares: AppMiddlewares) {
   const router = new Hono<{ Variables: { session: any; user: any; reqId: string } }>();
-  const { transcriptionService, config } = services;
+  const { transcriptionService, workspaceService, config } = services;
   const { authMiddleware, applyRateLimit, ensureWorkspaceAccess } = middlewares;
   const quotaStore = createAiQuotaStore({ db: services.db });
   const startTranscriptionPipeline =
@@ -1480,6 +1488,17 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       if (!workspaceMembershipCan(membership, 'recordings:process')) {
         return c.json({ message: 'Nie masz uprawnien do przetwarzania nagran.' }, 403);
       }
+      const featureFlags = await getWorkspaceFeatureFlags(workspaceService, workspaceId);
+      if (featureFlags.sttProvider === 'disabled') {
+        return c.json(
+          {
+            message: 'Transkrypcja STT jest wylaczona dla tego workspace.',
+            code: 'workspace_stt_disabled',
+            recordingId,
+          },
+          403
+        );
+      }
 
       const runtimeActive =
         typeof transcriptionService.isTranscriptionJobActive === 'function'
@@ -1584,6 +1603,17 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       const asset = await transcriptionService.getMediaAsset(recordingId);
       if (!asset) return c.json({ message: 'Nie znaleziono nagrania.' }, 404);
       await ensureWorkspaceAccess(c, asset.workspace_id);
+      const featureFlags = await getWorkspaceFeatureFlags(workspaceService, asset.workspace_id);
+      if (featureFlags.sttProvider === 'disabled') {
+        return c.json(
+          {
+            message: 'Transkrypcja STT jest wylaczona dla tego workspace.',
+            code: 'workspace_stt_disabled',
+            recordingId,
+          },
+          403
+        );
+      }
 
       if (
         asset.transcription_status === 'completed' &&
@@ -2156,6 +2186,21 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       );
     }
 
+    const featureFlags = await getWorkspaceFeatureFlags(workspaceService, asset.workspace_id);
+    if (featureFlags.embeddings === false) {
+      return c.json(
+        {
+          code: 'workspace_embeddings_disabled',
+          message: 'Embeddingi sa wylaczone dla tego workspace.',
+          stage: 'embedding',
+          recordingId,
+          speakerId,
+          speakerName,
+        },
+        403
+      );
+    }
+
     const quotaResponse = await enforceProviderQuota(c, {
       kind: 'embedding',
       endpoint: 'voice-profile',
@@ -2326,6 +2371,17 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
         body?.summary || diarization?.reviewSummary?.summary || diarization?.summary;
       if (!summaryText)
         return c.json({ message: 'Brak podsumowania do wygenerowania sketchnotki.' }, 400);
+
+      const featureFlags = await getWorkspaceFeatureFlags(workspaceService, asset.workspace_id);
+      if (featureFlags.imageGeneration === false) {
+        return c.json(
+          {
+            message: 'Generowanie obrazow jest wylaczone dla tego workspace.',
+            code: 'workspace_image_generation_disabled',
+          },
+          403
+        );
+      }
 
       const asList = (value: any) =>
         (Array.isArray(value) ? value : [])
@@ -2513,6 +2569,19 @@ Important:
     const membership = await ensureWorkspaceAccess(c, workspaceId);
     if (!workspaceMembershipCan(membership, 'ai:analyze')) {
       return c.json({ message: 'Nie masz uprawnien do analizy AI.' }, 403);
+    }
+
+    const featureFlags = await getWorkspaceFeatureFlags(workspaceService, workspaceId);
+    if (featureFlags.meetingAnalysis === false) {
+      return c.json(
+        {
+          mode: 'disabled-feature-flag',
+          analysisSource: 'fallback',
+          fallbackReason: 'disabled-feature-flag',
+          generatedBy: 'server',
+        },
+        200
+      );
     }
 
     const quotaResponse = await enforceProviderQuota(c, {
@@ -2980,7 +3049,7 @@ Important:
 
 export function createTranscribeRoutes(services: AppServices, middlewares: AppMiddlewares) {
   const router = new Hono<{ Variables: { session: any; user: any } }>();
-  const { transcriptionService, config } = services;
+  const { transcriptionService, workspaceService, config } = services;
   const { authMiddleware, applyRateLimit, ensureWorkspaceAccess } = middlewares;
   const quotaStore = createAiQuotaStore({ db: services.db });
   const liveTranscribeTimeoutMs = () => {
@@ -3005,6 +3074,16 @@ export function createTranscribeRoutes(services: AppServices, middlewares: AppMi
       return c.json({ message: 'Brakuje workspaceId.' }, 400);
     }
     await ensureWorkspaceAccess(c, workspaceId);
+    const featureFlags = await getWorkspaceFeatureFlags(workspaceService, workspaceId);
+    if (featureFlags.liveTranscription === false) {
+      return c.json(
+        {
+          message: 'Transkrypcja live jest wylaczona dla tego workspace.',
+          code: 'workspace_live_transcription_disabled',
+        },
+        403
+      );
+    }
 
     const sessionUserId = String(session?.user_id || session?.userId || '').trim();
     if (!sessionUserId) {

--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -6,6 +6,7 @@ import { AppServices, AppMiddlewares } from './middleware.ts';
 import { applyWorkspaceStateDelta, normalizeWorkspaceState } from '../../src/shared/contracts.ts';
 import { workspaceMembershipCan } from '../../src/shared/workspacePermissions.ts';
 import type { VoiceProfileSummary, VoiceProfilesListPayload } from '../../src/shared/types.ts';
+import { resolveProductionCapabilities } from '../http/capabilities.ts';
 import { buildFallbackRagAnswer, generateRagAnswer } from '../lib/ragAnswer.ts';
 import {
   createVoiceProfileEmbeddingFailure,
@@ -204,6 +205,45 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
       ),
     ].join('\n');
   }
+
+  router.get('/workspaces/:workspaceId/feature-flags', async (c) => {
+    const workspaceId = c.req.param('workspaceId');
+    await ensureWorkspaceAccess(c, workspaceId);
+    const state = await workspaceService.getWorkspaceState(workspaceId);
+    return c.json({ workspaceId, featureFlags: state.featureFlags }, 200);
+  });
+
+  router.put('/workspaces/:workspaceId/feature-flags', async (c) => {
+    const workspaceId = c.req.param('workspaceId');
+    const membership = await ensureWorkspaceAccess(c, workspaceId);
+    if (!requireWorkspaceAdmin(membership)) {
+      return c.json({ message: 'Tylko owner lub admin moze zmieniac feature flagi.' }, 403);
+    }
+
+    const body = await c.req.json().catch(() => ({}));
+    const session = c.get('session') as any;
+    return c.json(
+      await workspaceService.updateWorkspaceFeatureFlags(
+        workspaceId,
+        body.featureFlags || body,
+        String(session?.user_id || ''),
+        String(c.get('reqId') || '')
+      ),
+      200
+    );
+  });
+
+  router.get('/workspaces/:workspaceId/capabilities', async (c) => {
+    const workspaceId = c.req.param('workspaceId');
+    await ensureWorkspaceAccess(c, workspaceId);
+    const state = await workspaceService.getWorkspaceState(workspaceId);
+    return c.json(
+      resolveProductionCapabilities({
+        workspaceFeatureFlags: state.featureFlags,
+      }),
+      200
+    );
+  });
 
   router.put('/workspaces/:workspaceId/retention', async (c) => {
     const workspaceId = c.req.param('workspaceId');

--- a/server/services/TranscriptionService.ts
+++ b/server/services/TranscriptionService.ts
@@ -841,6 +841,24 @@ export default class TranscriptionService extends EventEmitter {
             ]);
             await markProcessingPromise;
 
+            const featureFlags = wsState?.featureFlags || {};
+            if (featureFlags.sttProvider === 'disabled') {
+              const disabledError: any = new Error(
+                'Transkrypcja STT jest wylaczona dla tego workspace.'
+              );
+              disabledError.code = 'workspace_stt_disabled';
+              disabledError.retryable = false;
+              throw disabledError;
+            }
+            if (featureFlags.sttProvider === 'local-whisper') {
+              const unsupportedError: any = new Error(
+                'Provider local-whisper nie jest jeszcze podpiety do pipeline STT.'
+              );
+              unsupportedError.code = 'workspace_stt_provider_unsupported';
+              unsupportedError.retryable = false;
+              throw unsupportedError;
+            }
+
             const segmentedManifest =
               asset.storage_mode === 'segmented'
                 ? parseMediaManifest(asset.media_manifest_json)
@@ -879,6 +897,13 @@ export default class TranscriptionService extends EventEmitter {
                 ...(options.vocabulary ? [options.vocabulary] : []),
                 ...(wsState.vocabulary || []),
               ].join(', '),
+              sttPreferredProvider:
+                featureFlags.sttProvider && featureFlags.sttProvider !== 'auto'
+                  ? featureFlags.sttProvider
+                  : options.sttPreferredProvider,
+              skipEarlyPyannote: processingMode !== 'full' || featureFlags.diarization === false,
+              skipSemanticDiarization: featureFlags.diarization === false,
+              skipVoiceProfileMatch: processingMode !== 'full' || featureFlags.embeddings === false,
               voiceProfiles,
               onProgress: (payload: any) => {
                 this.emit(`progress-${recordingId}`, payload);
@@ -908,9 +933,12 @@ export default class TranscriptionService extends EventEmitter {
                     )
                   : this.pipeline.transcribeRecording(asset, {
                       ...sharedOptions,
-                      skipEarlyPyannote: processingMode !== 'full',
+                      skipEarlyPyannote:
+                        processingMode !== 'full' || featureFlags.diarization === false,
+                      skipSemanticDiarization: featureFlags.diarization === false,
                       skipChunkVAD: processingMode !== 'full' || !config.VOICELOG_ENABLE_CHUNK_VAD,
-                      skipVoiceProfileMatch: processingMode !== 'full',
+                      skipVoiceProfileMatch:
+                        processingMode !== 'full' || featureFlags.embeddings === false,
                     })
             );
             addPipelineBreadcrumb('STT pipeline completed.', {

--- a/server/services/WorkspaceService.ts
+++ b/server/services/WorkspaceService.ts
@@ -15,6 +15,19 @@ export default class WorkspaceService {
     return await this.db.saveWorkspaceState(workspaceId, payload);
   }
 
+  async updateWorkspaceFeatureFlags(
+    workspaceId: string,
+    featureFlags: unknown,
+    actorUserId = '',
+    requestId = ''
+  ) {
+    return await this.db.updateWorkspaceFeatureFlags(workspaceId, featureFlags, {
+      actorUserId,
+      requestId,
+      source: 'api',
+    });
+  }
+
   async updateRetentionPolicy(
     workspaceId: string,
     retentionDays: number,

--- a/server/tests/database.test.ts
+++ b/server/tests/database.test.ts
@@ -854,6 +854,68 @@ describe('Database (Async Worker SQLite)', () => {
     });
   });
 
+  test('Issue #1262 - workspace feature flag updates are persisted and audited', async () => {
+    const workspaceId = 'ws_feature_flags';
+    const now = new Date().toISOString();
+    await db._execute(
+      `INSERT INTO workspaces (id, name, owner_user_id, invite_code, created_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?)`,
+      [workspaceId, 'Feature Flags', 'owner_flags', 'FLAGS42', now, now]
+    );
+    await db.ensureWorkspaceState(workspaceId);
+
+    const result = await db.updateWorkspaceFeatureFlags(
+      workspaceId,
+      {
+        sttProvider: 'groq',
+        meetingAnalysis: false,
+        embeddings: 'off',
+      },
+      {
+        actorUserId: 'admin_flags',
+        requestId: 'req_flags',
+        source: 'test',
+      }
+    );
+
+    expect(result.featureFlags).toMatchObject({
+      sttProvider: 'groq',
+      meetingAnalysis: false,
+      embeddings: false,
+      diarization: true,
+    });
+    await expect(db.getWorkspaceState(workspaceId)).resolves.toMatchObject({
+      featureFlags: {
+        sttProvider: 'groq',
+        meetingAnalysis: false,
+        embeddings: false,
+      },
+    });
+
+    const auditRow = await db._get(
+      'SELECT * FROM audit_logs WHERE workspace_id = ? AND action = ?',
+      [workspaceId, 'workspace.feature_flags.updated']
+    );
+    expect(auditRow).toMatchObject({
+      actor_user_id: 'admin_flags',
+      entity_type: 'workspace',
+      entity_id: workspaceId,
+    });
+    expect(JSON.parse(auditRow.metadata_json)).toMatchObject({
+      requestId: 'req_flags',
+      source: 'test',
+      featureFlags: {
+        sttProvider: 'groq',
+        meetingAnalysis: false,
+        embeddings: false,
+      },
+      previousFeatureFlags: {
+        sttProvider: 'auto',
+        meetingAnalysis: true,
+      },
+    });
+  });
+
   test('Issue #1261 - workspace-level retention hold skips all expired workspace recordings', async () => {
     await db.ensureWorkspaceState('ws_retention_workspace_hold');
     await db.saveWorkspaceState('ws_retention_workspace_hold', {

--- a/server/tests/database/migration-contract.test.ts
+++ b/server/tests/database/migration-contract.test.ts
@@ -148,4 +148,17 @@ describe('Database migration contracts', () => {
     }
     expect(migration).toContain('where released_at is null');
   });
+
+  test('Issue #1262 - workspace feature flag migration preserves fresh and upgraded databases', () => {
+    const migration = readMigration('20260705_workspace_feature_flags.sql')
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+    const initialSchema = readMigration('001_initial_schema.sql')
+      .replace(/\s+/g, ' ')
+      .toLowerCase();
+
+    expect(migration).toContain('alter table workspace_state');
+    expect(migration).toContain('add column feature_flags_json text not null default');
+    expect(initialSchema).toContain('feature_flags_json text not null default');
+  });
 });

--- a/server/tests/routes/capabilities.test.ts
+++ b/server/tests/routes/capabilities.test.ts
@@ -186,6 +186,61 @@ describe('http/capabilities.ts', () => {
     restore();
   });
 
+  test('Issue #1262 - applies workspace provider and disabled capability flags', () => {
+    const restore = withCleanCapabilityEnv();
+    process.env.OPENAI_API_KEY = 'sk-test-secret';
+    process.env.GROQ_API_KEY = 'gsk-test-secret';
+    process.env.HF_TOKEN = 'hf-test-secret';
+    process.env.ANTHROPIC_API_KEY = 'anthropic-secret';
+    process.env.VOICELOG_ENABLE_MEETING_ANALYSIS = 'true';
+
+    const payload = resolveProductionCapabilities({
+      workspaceFeatureFlags: {
+        sttProvider: 'groq',
+        meetingAnalysis: false,
+        embeddings: false,
+        retentionFeatures: false,
+      },
+      storageReadiness: {
+        configured: true,
+        ready: true,
+        bucket: 'recordings',
+        status: 'ready',
+      },
+    });
+
+    expect(payload.workspaceFeatureFlags).toMatchObject({
+      sttProvider: 'groq',
+      meetingAnalysis: false,
+      embeddings: false,
+      retentionFeatures: false,
+    });
+    expect(payload.capabilities.stt).toMatchObject({
+      enabled: true,
+      status: 'available',
+      provider: 'groq',
+    });
+    expect(payload.capabilities.meetingAnalysis).toMatchObject({
+      enabled: false,
+      status: 'unavailable',
+      provider: 'none',
+      reason: 'Disabled by workspace feature flags.',
+    });
+    expect(payload.capabilities.embeddings).toMatchObject({
+      enabled: false,
+      status: 'unavailable',
+      provider: 'none',
+    });
+    expect(payload.capabilities.retentionFeatures).toMatchObject({
+      enabled: false,
+      status: 'unavailable',
+      provider: 'none',
+    });
+    expect(JSON.stringify(payload)).not.toContain('sk-test-secret');
+    expect(JSON.stringify(payload)).not.toContain('gsk-test-secret');
+    restore();
+  });
+
   test('reports local whisper as a configured offline STT fallback', () => {
     const restore = withCleanCapabilityEnv();
     process.env.USE_LOCAL_WHISPER = 'true';
@@ -200,6 +255,26 @@ describe('http/capabilities.ts', () => {
       fallbackMode: true,
     });
     expect(payload.telemetry.fallbackModeCapabilities).toContain('stt');
+    restore();
+  });
+
+  test('Issue #1262 - does not silently remap forced local whisper to a cloud provider', () => {
+    const restore = withCleanCapabilityEnv();
+    process.env.OPENAI_API_KEY = 'sk-test-secret';
+    process.env.USE_LOCAL_WHISPER = 'true';
+    process.env.WHISPER_CPP_PATH = 'C:/tools/whisper/main.exe';
+
+    const payload = resolveProductionCapabilities({
+      workspaceFeatureFlags: { sttProvider: 'local-whisper' },
+    });
+
+    expect(payload.capabilities.stt).toMatchObject({
+      enabled: false,
+      status: 'unavailable',
+      provider: 'none',
+      reason: 'Workspace local-whisper provider is not wired into the STT pipeline yet.',
+    });
+    expect(JSON.stringify(payload)).not.toContain('sk-test-secret');
     restore();
   });
 

--- a/server/tests/routes/costly-endpoints-auth.test.ts
+++ b/server/tests/routes/costly-endpoints-auth.test.ts
@@ -37,6 +37,7 @@ describe('Costly endpoint auth contract', () => {
   let authService: { getSession: ReturnType<typeof vi.fn> };
   let workspaceService: {
     getMembership: ReturnType<typeof vi.fn>;
+    getWorkspaceState: ReturnType<typeof vi.fn>;
     upsertVoiceProfile: ReturnType<typeof vi.fn>;
   };
 
@@ -76,6 +77,18 @@ describe('Costly endpoint auth contract', () => {
     authService = { getSession: vi.fn().mockResolvedValue(null) };
     workspaceService = {
       getMembership: vi.fn(),
+      getWorkspaceState: vi.fn().mockResolvedValue({
+        featureFlags: {
+          sttProvider: 'auto',
+          diarization: true,
+          meetingAnalysis: true,
+          embeddings: true,
+          imageGeneration: true,
+          liveTranscription: true,
+          retentionFeatures: true,
+          experimentalUi: false,
+        },
+      }),
       upsertVoiceProfile: vi.fn(),
     };
 

--- a/server/tests/routes/media.additional.test.ts
+++ b/server/tests/routes/media.additional.test.ts
@@ -9,10 +9,28 @@ import { SINGLE_OBJECT_MAX_BYTES } from '../../lib/mediaStoragePolicy.ts';
 describe('Media Routes - Additional Coverage', () => {
   let app: ReturnType<typeof createApp>;
   let mockTranscriptionService: Record<string, ReturnType<typeof vi.fn>>;
-  let mockWorkspaceService: { getMembership: ReturnType<typeof vi.fn> };
+  let mockWorkspaceService: ReturnType<typeof makeWorkspaceServiceMock>;
   let mockAuthService: { getSession: ReturnType<typeof vi.fn> };
   let testUploadDir: string;
   let actualFs: typeof import('node:fs');
+
+  function makeWorkspaceServiceMock(membership: unknown = { member_role: 'owner' }) {
+    return {
+      getMembership: vi.fn().mockResolvedValue(membership),
+      getWorkspaceState: vi.fn().mockResolvedValue({
+        featureFlags: {
+          sttProvider: 'auto',
+          diarization: true,
+          meetingAnalysis: true,
+          embeddings: true,
+          imageGeneration: true,
+          liveTranscription: true,
+          retentionFeatures: true,
+          experimentalUi: false,
+        },
+      }),
+    };
+  }
 
   beforeEach(async () => {
     actualFs = await vi.importActual<typeof import('node:fs')>('node:fs');
@@ -62,9 +80,7 @@ describe('Media Routes - Additional Coverage', () => {
       removeListener: vi.fn(),
       _execute: vi.fn(),
     };
-    mockWorkspaceService = {
-      getMembership: vi.fn().mockResolvedValue({ member_role: 'owner' }),
-    };
+    mockWorkspaceService = makeWorkspaceServiceMock();
 
     mockAuthService = {
       getSession: vi
@@ -408,7 +424,7 @@ describe('Media Routes - Additional Coverage', () => {
       // Create app with the mock
       const testApp = createApp({
         authService: { getSession: vi.fn().mockResolvedValue({ user_id: 'user_1' }) },
-        workspaceService: { getMembership: vi.fn().mockResolvedValue({ member_role: 'owner' }) },
+        workspaceService: makeWorkspaceServiceMock(),
         transcriptionService: {
           ...mockTranscriptionService,
           analyzeMeetingWithOpenAI: mockAnalyzeMeetingWithOpenAI,
@@ -443,7 +459,7 @@ describe('Media Routes - Additional Coverage', () => {
 
       const testApp = createApp({
         authService: { getSession: vi.fn().mockResolvedValue({ user_id: 'user_1' }) },
-        workspaceService: { getMembership: vi.fn().mockResolvedValue({ member_role: 'owner' }) },
+        workspaceService: makeWorkspaceServiceMock(),
         transcriptionService: {
           ...mockTranscriptionService,
           analyzeMeetingWithOpenAI: mockAnalyzeMeetingWithOpenAI,
@@ -492,7 +508,7 @@ describe('Media Routes - Additional Coverage', () => {
 
       const testApp = createApp({
         authService: { getSession: vi.fn().mockResolvedValue({ user_id: 'user_1' }) },
-        workspaceService: { getMembership: vi.fn().mockResolvedValue({ member_role: 'owner' }) },
+        workspaceService: makeWorkspaceServiceMock(),
         transcriptionService: {
           ...mockTranscriptionService,
           analyzeMeetingWithOpenAI: mockAnalyzeMeetingWithOpenAI,
@@ -520,7 +536,7 @@ describe('Media Routes - Additional Coverage', () => {
       });
       const testApp = createApp({
         authService: { getSession: vi.fn().mockResolvedValue(null) },
-        workspaceService: { getMembership: vi.fn().mockResolvedValue({ member_role: 'owner' }) },
+        workspaceService: makeWorkspaceServiceMock(),
         transcriptionService: {
           ...mockTranscriptionService,
           analyzeMeetingWithOpenAI: mockAnalyzeMeetingWithOpenAI,
@@ -544,7 +560,7 @@ describe('Media Routes - Additional Coverage', () => {
       });
       const testApp = createApp({
         authService: { getSession: vi.fn().mockResolvedValue({ user_id: 'user_1' }) },
-        workspaceService: { getMembership: vi.fn().mockResolvedValue({ member_role: 'owner' }) },
+        workspaceService: makeWorkspaceServiceMock(),
         transcriptionService: {
           ...mockTranscriptionService,
           analyzeMeetingWithOpenAI: mockAnalyzeMeetingWithOpenAI,
@@ -568,7 +584,7 @@ describe('Media Routes - Additional Coverage', () => {
       });
       const testApp = createApp({
         authService: { getSession: vi.fn().mockResolvedValue({ user_id: 'user_1' }) },
-        workspaceService: { getMembership: vi.fn().mockResolvedValue(null) },
+        workspaceService: makeWorkspaceServiceMock(null),
         transcriptionService: {
           ...mockTranscriptionService,
           analyzeMeetingWithOpenAI: mockAnalyzeMeetingWithOpenAI,

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -86,6 +86,18 @@ describe('Media Routes', () => {
     };
     mockWorkspaceService = {
       getMembership: vi.fn().mockResolvedValue({ member_role: 'owner' }),
+      getWorkspaceState: vi.fn().mockResolvedValue({
+        featureFlags: {
+          sttProvider: 'auto',
+          diarization: true,
+          meetingAnalysis: true,
+          embeddings: true,
+          imageGeneration: true,
+          liveTranscription: true,
+          retentionFeatures: true,
+          experimentalUi: false,
+        },
+      }),
     };
 
     const mockAuthService = {
@@ -390,6 +402,43 @@ describe('Media Routes', () => {
       'rec_1',
       expect.objectContaining({ processingMode: 'fast' })
     );
+  });
+
+  it('Issue #1262 - blocks STT start before provider quota when workspace STT is disabled', async () => {
+    mockWorkspaceService.getWorkspaceState.mockResolvedValueOnce({
+      featureFlags: {
+        sttProvider: 'disabled',
+        diarization: true,
+        meetingAnalysis: true,
+        embeddings: true,
+        imageGeneration: true,
+        liveTranscription: true,
+        retentionFeatures: true,
+        experimentalUi: false,
+      },
+    });
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_stt_disabled',
+      workspace_id: 'ws_1',
+      file_path: '/tmp/fake.webm',
+      content_type: 'audio/webm',
+      size_bytes: 1024,
+      transcription_status: 'failed',
+    });
+
+    const res = await app.request('/media/recordings/rec_stt_disabled/transcribe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspaceId: 'ws_1' }),
+    });
+
+    expect(res.status).toBe(403);
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'workspace_stt_disabled',
+      recordingId: 'rec_stt_disabled',
+    });
+    expect(mockTranscriptionService.queueTranscription).not.toHaveBeenCalled();
+    expect(mockTranscriptionService.ensureTranscriptionJob).not.toHaveBeenCalled();
   });
 
   it('POST /media/recordings/:recordingId/transcribe - validates body before asset lookup', async () => {
@@ -1786,6 +1835,38 @@ describe('Media Routes', () => {
         fallbackReason: 'no-key',
       })
     );
+  });
+
+  it('Issue #1262 - returns local fallback when meeting analysis is disabled', async () => {
+    mockWorkspaceService.getWorkspaceState.mockResolvedValueOnce({
+      featureFlags: {
+        sttProvider: 'auto',
+        diarization: true,
+        meetingAnalysis: false,
+        embeddings: true,
+        imageGeneration: true,
+        liveTranscription: true,
+        retentionFeatures: true,
+        experimentalUi: false,
+      },
+    });
+    mockTranscriptionService.analyzeMeetingWithOpenAI = vi.fn().mockResolvedValue({
+      summary: 'Should not run',
+    });
+
+    const res = await app.request('/media/analyze', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspaceId: 'ws_1', meeting: {}, segments: [] }),
+    });
+
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({
+      mode: 'disabled-feature-flag',
+      analysisSource: 'fallback',
+      fallbackReason: 'disabled-feature-flag',
+    });
+    expect(mockTranscriptionService.analyzeMeetingWithOpenAI).not.toHaveBeenCalled();
   });
 
   it('POST /media/analyze records fallback metrics and sanitized warning context', async () => {

--- a/server/tests/routes/transcribe.test.ts
+++ b/server/tests/routes/transcribe.test.ts
@@ -17,7 +17,15 @@ describe('Transcribe Routes', () => {
 
     app = createApp({
       authService: testAuthService as any,
-      workspaceService: { getMembership: vi.fn().mockResolvedValue({ role: 'owner' }) } as any,
+      workspaceService: {
+        getMembership: vi.fn().mockResolvedValue({ role: 'owner' }),
+        getWorkspaceState: vi.fn().mockResolvedValue({
+          featureFlags: {
+            sttProvider: 'auto',
+            liveTranscription: true,
+          },
+        }),
+      } as any,
       transcriptionService: mockTranscriptionService,
       config: { allowedOrigins: '*', trustProxy: false, uploadDir: process.cwd() },
     });
@@ -77,6 +85,12 @@ describe('Transcribe Routes', () => {
 
     const testWorkspaceService = {
       getMembership: vi.fn().mockResolvedValue({ role: 'owner' }),
+      getWorkspaceState: vi.fn().mockResolvedValue({
+        featureFlags: {
+          sttProvider: 'auto',
+          liveTranscription: true,
+        },
+      }),
     };
 
     app = createApp({
@@ -146,6 +160,12 @@ describe('Transcribe Routes', () => {
 
     const testWorkspaceService = {
       getMembership: vi.fn().mockResolvedValue({ role: 'owner' }),
+      getWorkspaceState: vi.fn().mockResolvedValue({
+        featureFlags: {
+          sttProvider: 'auto',
+          liveTranscription: true,
+        },
+      }),
     };
 
     app = createApp({
@@ -191,6 +211,12 @@ describe('Transcribe Routes', () => {
 
     const testWorkspaceService = {
       getMembership: vi.fn().mockResolvedValue({ role: 'owner' }),
+      getWorkspaceState: vi.fn().mockResolvedValue({
+        featureFlags: {
+          sttProvider: 'auto',
+          liveTranscription: true,
+        },
+      }),
     };
 
     app = createApp({

--- a/server/tests/routes/workspaces.test.ts
+++ b/server/tests/routes/workspaces.test.ts
@@ -46,7 +46,20 @@ describe('Workspace Routes', () => {
       getSession: vi.fn(),
     };
     mockWorkspaceService = {
+      getWorkspaceState: vi.fn().mockResolvedValue({
+        featureFlags: {
+          sttProvider: 'auto',
+          diarization: true,
+          meetingAnalysis: true,
+          embeddings: true,
+          imageGeneration: true,
+          liveTranscription: true,
+          retentionFeatures: true,
+          experimentalUi: false,
+        },
+      }),
       saveWorkspaceState: vi.fn(),
+      updateWorkspaceFeatureFlags: vi.fn(),
       updateRetentionPolicy: vi.fn(),
       cleanupExpiredRecordingsByRetention: vi.fn(),
       setRecordingRetentionHold: vi.fn(),
@@ -227,6 +240,84 @@ describe('Workspace Routes', () => {
     expect(mockWorkspaceService.updateRetentionPolicy).toHaveBeenCalledWith(
       'ws1',
       45,
+      'u1',
+      expect.any(String)
+    );
+  });
+
+  it('Issue #1262 - exposes workspace capabilities and protects feature flag updates', async () => {
+    mockWorkspaceService.getWorkspaceState.mockResolvedValue({
+      featureFlags: {
+        sttProvider: 'groq',
+        diarization: true,
+        meetingAnalysis: false,
+        embeddings: true,
+        imageGeneration: true,
+        liveTranscription: true,
+        retentionFeatures: true,
+        experimentalUi: false,
+      },
+    });
+    mockWorkspaceService.updateWorkspaceFeatureFlags.mockResolvedValue({
+      featureFlags: { sttProvider: 'disabled', meetingAnalysis: false },
+    });
+
+    app = createApp(
+      {
+        authService: mockAuthService,
+        workspaceService: mockWorkspaceService,
+        transcriptionService: mockTranscriptionService,
+        config: { allowedOrigins: '*', trustProxy: false, uploadDir: '/tmp', OPENAI_API_KEY: '' },
+      },
+      buildMiddlewares('member')
+    );
+
+    const capabilitiesRes = await app.request('/workspaces/ws1/capabilities', {
+      method: 'GET',
+      headers: { Authorization: 'Bearer token' },
+    });
+    const forbiddenUpdateRes = await app.request('/workspaces/ws1/feature-flags', {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featureFlags: { sttProvider: 'disabled' } }),
+    });
+
+    expect(capabilitiesRes.status).toBe(200);
+    expect(await capabilitiesRes.json()).toMatchObject({
+      workspaceFeatureFlags: {
+        sttProvider: 'groq',
+        meetingAnalysis: false,
+      },
+      capabilities: {
+        meetingAnalysis: {
+          enabled: false,
+          status: 'unavailable',
+        },
+      },
+    });
+    expect(forbiddenUpdateRes.status).toBe(403);
+    expect(mockWorkspaceService.updateWorkspaceFeatureFlags).not.toHaveBeenCalled();
+
+    app = createApp(
+      {
+        authService: mockAuthService,
+        workspaceService: mockWorkspaceService,
+        transcriptionService: mockTranscriptionService,
+        config: { allowedOrigins: '*', trustProxy: false, uploadDir: '/tmp', OPENAI_API_KEY: '' },
+      },
+      buildMiddlewares('admin')
+    );
+
+    const updateRes = await app.request('/workspaces/ws1/feature-flags', {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ featureFlags: { sttProvider: 'disabled' } }),
+    });
+
+    expect(updateRes.status).toBe(200);
+    expect(mockWorkspaceService.updateWorkspaceFeatureFlags).toHaveBeenCalledWith(
+      'ws1',
+      { sttProvider: 'disabled' },
       'u1',
       expect.any(String)
     );

--- a/src/components/app-shell/ProductionReadinessBanner.test.tsx
+++ b/src/components/app-shell/ProductionReadinessBanner.test.tsx
@@ -1,15 +1,29 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import ProductionReadinessBanner from './ProductionReadinessBanner';
-import { fetchProductionCapabilities } from '../../services/capabilitiesService';
+import {
+  fetchProductionCapabilities,
+  fetchWorkspaceCapabilities,
+} from '../../services/capabilitiesService';
 
 vi.mock('../../services/capabilitiesService', () => ({
   fetchProductionCapabilities: vi.fn(),
+  fetchWorkspaceCapabilities: vi.fn(),
+}));
+
+const workspaceSelectorsMock = vi.hoisted(() => ({
+  currentWorkspaceId: null as string | null,
+}));
+
+vi.mock('../../store/workspaceStore', () => ({
+  useWorkspaceSelectors: () => workspaceSelectorsMock,
 }));
 
 describe('ProductionReadinessBanner', () => {
   afterEach(() => {
     vi.mocked(fetchProductionCapabilities).mockReset();
+    vi.mocked(fetchWorkspaceCapabilities).mockReset();
+    workspaceSelectorsMock.currentWorkspaceId = null;
   });
 
   test('shows degraded production mode with user-facing reasons', async () => {
@@ -69,6 +83,36 @@ describe('ProductionReadinessBanner', () => {
 
     await waitFor(() => expect(fetchProductionCapabilities).toHaveBeenCalled());
     expect(screen.queryByRole('status')).not.toBeInTheDocument();
+  });
+
+  test('loads workspace capabilities when a workspace is selected', async () => {
+    workspaceSelectorsMock.currentWorkspaceId = 'workspace_1';
+    vi.mocked(fetchWorkspaceCapabilities).mockResolvedValueOnce({
+      ok: false,
+      status: 'degraded',
+      generatedAt: '2026-06-28T00:00:00.000Z',
+      degradedCapabilities: [
+        {
+          id: 'liveTranscription',
+          label: 'Transkrypcja live',
+          enabled: false,
+          status: 'unavailable',
+          provider: 'none',
+          reason: 'Disabled by workspace feature flags.',
+        },
+      ],
+      capabilities: {},
+      telemetry: {
+        fallbackModeUsed: false,
+        fallbackModeCapabilities: [],
+      },
+    } as any);
+
+    render(<ProductionReadinessBanner />);
+
+    expect(await screen.findByRole('status')).toHaveTextContent('Transkrypcja live');
+    expect(fetchWorkspaceCapabilities).toHaveBeenCalledWith('workspace_1');
+    expect(fetchProductionCapabilities).not.toHaveBeenCalled();
   });
 
   test('does not block the app shell when capability fetch fails', async () => {

--- a/src/components/app-shell/ProductionReadinessBanner.tsx
+++ b/src/components/app-shell/ProductionReadinessBanner.tsx
@@ -2,20 +2,27 @@ import { AlertTriangle } from 'lucide-react';
 import { useEffect, useState } from 'react';
 import {
   fetchProductionCapabilities,
+  fetchWorkspaceCapabilities,
   type CapabilityFlag,
   type ProductionCapabilities,
 } from '../../services/capabilitiesService';
+import { useWorkspaceSelectors } from '../../store/workspaceStore';
 
 function reasonLabel(capability: CapabilityFlag) {
   return capability.reason || `${capability.label}: ${capability.status}`;
 }
 
 export default function ProductionReadinessBanner() {
+  const { currentWorkspaceId } = useWorkspaceSelectors();
   const [capabilities, setCapabilities] = useState<ProductionCapabilities | null>(null);
 
   useEffect(() => {
     let mounted = true;
-    fetchProductionCapabilities()
+    const capabilityRequest = currentWorkspaceId
+      ? fetchWorkspaceCapabilities(currentWorkspaceId)
+      : fetchProductionCapabilities();
+
+    capabilityRequest
       .then((payload) => {
         if (mounted) setCapabilities(payload);
       })
@@ -27,7 +34,7 @@ export default function ProductionReadinessBanner() {
     return () => {
       mounted = false;
     };
-  }, []);
+  }, [currentWorkspaceId]);
 
   if (!capabilities || capabilities.ok || capabilities.degradedCapabilities.length === 0) {
     return null;

--- a/src/services/capabilitiesService.test.ts
+++ b/src/services/capabilitiesService.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it, vi, afterEach } from 'vitest';
-import { fetchProductionCapabilities } from './capabilitiesService';
+import {
+  fetchProductionCapabilities,
+  fetchWorkspaceCapabilities,
+  fetchWorkspaceFeatureFlags,
+  updateWorkspaceFeatureFlags,
+} from './capabilitiesService';
 import { apiRequest } from './httpClient';
 
 vi.mock('./httpClient', () => ({
@@ -21,6 +26,38 @@ describe('capabilitiesService', () => {
     expect(apiRequest).toHaveBeenCalledWith('/api/capabilities', {
       method: 'GET',
       retries: 1,
+    });
+  });
+
+  it('Issue #1262 - fetches and updates workspace capability controls', async () => {
+    vi.mocked(apiRequest)
+      .mockResolvedValueOnce({ ok: true, workspaceFeatureFlags: { sttProvider: 'groq' } })
+      .mockResolvedValueOnce({ workspaceId: 'ws 1', featureFlags: { sttProvider: 'auto' } })
+      .mockResolvedValueOnce({ featureFlags: { sttProvider: 'disabled' } });
+
+    await expect(fetchWorkspaceCapabilities('ws 1')).resolves.toMatchObject({
+      workspaceFeatureFlags: { sttProvider: 'groq' },
+    });
+    await expect(fetchWorkspaceFeatureFlags('ws 1')).resolves.toMatchObject({
+      featureFlags: { sttProvider: 'auto' },
+    });
+    await expect(
+      updateWorkspaceFeatureFlags('ws 1', { sttProvider: 'disabled' })
+    ).resolves.toMatchObject({
+      featureFlags: { sttProvider: 'disabled' },
+    });
+
+    expect(apiRequest).toHaveBeenNthCalledWith(1, '/workspaces/ws%201/capabilities', {
+      method: 'GET',
+      retries: 1,
+    });
+    expect(apiRequest).toHaveBeenNthCalledWith(2, '/workspaces/ws%201/feature-flags', {
+      method: 'GET',
+      retries: 1,
+    });
+    expect(apiRequest).toHaveBeenNthCalledWith(3, '/workspaces/ws%201/feature-flags', {
+      method: 'PUT',
+      body: { featureFlags: { sttProvider: 'disabled' } },
     });
   });
 });

--- a/src/services/capabilitiesService.ts
+++ b/src/services/capabilitiesService.ts
@@ -1,4 +1,5 @@
 import { apiRequest } from './httpClient';
+import type { WorkspaceFeatureFlags } from '../shared/types';
 
 export type CapabilityStatus = 'available' | 'degraded' | 'unavailable';
 export type ProductionStatus = 'ready' | 'degraded';
@@ -18,6 +19,7 @@ export interface ProductionCapabilities {
   status: ProductionStatus;
   generatedAt?: string;
   capabilities: Record<string, CapabilityFlag>;
+  workspaceFeatureFlags?: WorkspaceFeatureFlags;
   degradedCapabilities: CapabilityFlag[];
   telemetry: {
     fallbackModeUsed: boolean;
@@ -29,5 +31,31 @@ export function fetchProductionCapabilities(): Promise<ProductionCapabilities> {
   return apiRequest('/api/capabilities', {
     method: 'GET',
     retries: 1,
+  });
+}
+
+export function fetchWorkspaceCapabilities(workspaceId: string): Promise<ProductionCapabilities> {
+  return apiRequest(`/workspaces/${encodeURIComponent(workspaceId)}/capabilities`, {
+    method: 'GET',
+    retries: 1,
+  });
+}
+
+export function fetchWorkspaceFeatureFlags(
+  workspaceId: string
+): Promise<{ workspaceId: string; featureFlags: WorkspaceFeatureFlags }> {
+  return apiRequest(`/workspaces/${encodeURIComponent(workspaceId)}/feature-flags`, {
+    method: 'GET',
+    retries: 1,
+  });
+}
+
+export function updateWorkspaceFeatureFlags(
+  workspaceId: string,
+  featureFlags: Partial<WorkspaceFeatureFlags>
+): Promise<{ featureFlags: WorkspaceFeatureFlags; state: unknown }> {
+  return apiRequest(`/workspaces/${encodeURIComponent(workspaceId)}/feature-flags`, {
+    method: 'PUT',
+    body: { featureFlags },
   });
 }

--- a/src/shared/contracts.test.ts
+++ b/src/shared/contracts.test.ts
@@ -6,6 +6,7 @@ import {
   applyWorkspaceStateDelta,
   normalizeMediaTranscriptionResponse,
   normalizeTranscriptionStatusPayload,
+  normalizeWorkspaceFeatureFlags,
   normalizeWorkspaceState,
   serializeWorkspaceState,
 } from './contracts';
@@ -27,6 +28,16 @@ describe('shared contracts', () => {
       calendarMeta: {},
       vocabulary: ['crm'],
       retentionDays: 365,
+      featureFlags: {
+        sttProvider: 'auto',
+        diarization: true,
+        meetingAnalysis: true,
+        embeddings: true,
+        imageGeneration: true,
+        liveTranscription: true,
+        retentionFeatures: true,
+        experimentalUi: false,
+      },
       updatedAt: '2026-03-23T10:00:00.000Z',
     });
   });
@@ -117,9 +128,45 @@ describe('shared contracts', () => {
         calendarMeta: {},
         vocabulary: [],
         retentionDays: 365,
+        featureFlags: {
+          sttProvider: 'auto',
+          diarization: true,
+          meetingAnalysis: true,
+          embeddings: true,
+          imageGeneration: true,
+          liveTranscription: true,
+          retentionFeatures: true,
+          experimentalUi: false,
+        },
         updatedAt: '',
       })
     );
+  });
+
+  test('Issue #1262 - normalizes workspace feature flags with safe defaults', () => {
+    expect(
+      normalizeWorkspaceFeatureFlags({
+        sttProvider: 'GROQ',
+        diarization: 'false',
+        meetingAnalysis: false,
+        embeddings: 'off',
+        imageGeneration: true,
+        liveTranscription: 'yes',
+        retentionFeatures: true,
+        experimentalUi: 'true',
+      })
+    ).toEqual({
+      sttProvider: 'groq',
+      diarization: false,
+      meetingAnalysis: false,
+      embeddings: false,
+      imageGeneration: true,
+      liveTranscription: true,
+      retentionFeatures: true,
+      experimentalUi: true,
+    });
+
+    expect(normalizeWorkspaceFeatureFlags({ sttProvider: 'unknown' }).sttProvider).toBe('auto');
   });
 
   test('normalizes workspace retention days as a non-negative integer', () => {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -7,7 +7,9 @@ import type {
   TranscriptionDiagnostics,
   TranscriptionStatusPayload,
   VoiceProfileLabelingDiagnostics,
+  WorkspaceFeatureFlags,
   WorkspaceState,
+  WorkspaceSttProvider,
 } from './types.js';
 
 export interface WorkspaceStatePayload {
@@ -19,6 +21,7 @@ export interface WorkspaceStatePayload {
   calendarMeta: Record<string, unknown>;
   vocabulary: string[];
   retentionDays?: number;
+  featureFlags?: Partial<WorkspaceFeatureFlags>;
 }
 
 export interface WorkspaceCollectionDelta {
@@ -35,6 +38,7 @@ export interface WorkspaceStateDeltaPayload {
   calendarMeta?: Record<string, unknown>;
   vocabulary?: string[];
   retentionDays?: number;
+  featureFlags?: Partial<WorkspaceFeatureFlags>;
 }
 
 export interface SessionPayload<TState = WorkspaceState> {
@@ -356,6 +360,67 @@ function normalizeRetentionDays(value: unknown, fallback = 365): number {
   return fallback;
 }
 
+const WORKSPACE_STT_PROVIDERS = ['auto', 'openai', 'groq', 'local-whisper', 'disabled'] as const;
+
+export const DEFAULT_WORKSPACE_FEATURE_FLAGS: WorkspaceFeatureFlags = {
+  sttProvider: 'auto',
+  diarization: true,
+  meetingAnalysis: true,
+  embeddings: true,
+  imageGeneration: true,
+  liveTranscription: true,
+  retentionFeatures: true,
+  experimentalUi: false,
+};
+
+function normalizeBooleanFlag(value: unknown, fallback: boolean): boolean {
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase();
+    if (['1', 'true', 'yes', 'on'].includes(normalized)) return true;
+    if (['0', 'false', 'no', 'off'].includes(normalized)) return false;
+  }
+  return fallback;
+}
+
+export function normalizeWorkspaceFeatureFlags(input: unknown = {}): WorkspaceFeatureFlags {
+  const source = asRecord(input);
+  const sttProvider = String(source.sttProvider || DEFAULT_WORKSPACE_FEATURE_FLAGS.sttProvider)
+    .trim()
+    .toLowerCase();
+
+  return {
+    sttProvider: WORKSPACE_STT_PROVIDERS.includes(sttProvider as WorkspaceSttProvider)
+      ? (sttProvider as WorkspaceSttProvider)
+      : DEFAULT_WORKSPACE_FEATURE_FLAGS.sttProvider,
+    diarization: normalizeBooleanFlag(
+      source.diarization,
+      DEFAULT_WORKSPACE_FEATURE_FLAGS.diarization
+    ),
+    meetingAnalysis: normalizeBooleanFlag(
+      source.meetingAnalysis,
+      DEFAULT_WORKSPACE_FEATURE_FLAGS.meetingAnalysis
+    ),
+    embeddings: normalizeBooleanFlag(source.embeddings, DEFAULT_WORKSPACE_FEATURE_FLAGS.embeddings),
+    imageGeneration: normalizeBooleanFlag(
+      source.imageGeneration,
+      DEFAULT_WORKSPACE_FEATURE_FLAGS.imageGeneration
+    ),
+    liveTranscription: normalizeBooleanFlag(
+      source.liveTranscription,
+      DEFAULT_WORKSPACE_FEATURE_FLAGS.liveTranscription
+    ),
+    retentionFeatures: normalizeBooleanFlag(
+      source.retentionFeatures,
+      DEFAULT_WORKSPACE_FEATURE_FLAGS.retentionFeatures
+    ),
+    experimentalUi: normalizeBooleanFlag(
+      source.experimentalUi,
+      DEFAULT_WORKSPACE_FEATURE_FLAGS.experimentalUi
+    ),
+  };
+}
+
 export function normalizeWorkspaceState(input: unknown = {}): WorkspaceState {
   const source = asRecord(input);
   const calendarMeta = isRecord(source.calendarMeta) ? source.calendarMeta : {};
@@ -371,6 +436,7 @@ export function normalizeWorkspaceState(input: unknown = {}): WorkspaceState {
     calendarMeta,
     vocabulary: Array.isArray(source.vocabulary) ? source.vocabulary : [],
     retentionDays: normalizeRetentionDays(source.retentionDays),
+    featureFlags: normalizeWorkspaceFeatureFlags(source.featureFlags),
     updatedAt: String(source.updatedAt || ''),
   };
 
@@ -502,6 +568,9 @@ export function buildWorkspaceStateDelta(
 
   if (prevState.retentionDays !== nextState.retentionDays) {
     delta.retentionDays = nextState.retentionDays;
+  }
+  if (stableJson(prevState.featureFlags) !== stableJson(nextState.featureFlags)) {
+    delta.featureFlags = nextState.featureFlags;
   }
 
   return delta;
@@ -673,6 +742,7 @@ export function applyWorkspaceStateDelta(
     vocabulary: Array.isArray(delta.vocabulary) ? delta.vocabulary : current.vocabulary,
     retentionDays:
       typeof delta.retentionDays === 'number' ? delta.retentionDays : current.retentionDays,
+    featureFlags: normalizeWorkspaceFeatureFlags(delta.featureFlags || current.featureFlags),
     updatedAt: current.updatedAt,
   });
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -388,5 +388,19 @@ export interface WorkspaceState {
   calendarMeta: Record<string, unknown>;
   vocabulary: string[];
   retentionDays: number;
+  featureFlags: WorkspaceFeatureFlags;
   updatedAt?: string;
+}
+
+export type WorkspaceSttProvider = 'auto' | 'openai' | 'groq' | 'local-whisper' | 'disabled';
+
+export interface WorkspaceFeatureFlags {
+  sttProvider: WorkspaceSttProvider;
+  diarization: boolean;
+  meetingAnalysis: boolean;
+  embeddings: boolean;
+  imageGeneration: boolean;
+  liveTranscription: boolean;
+  retentionFeatures: boolean;
+  experimentalUi: boolean;
 }


### PR DESCRIPTION
## Summary
- Adds workspace-level feature flag contracts with safe defaults for STT provider, diarization, meeting analysis, embeddings, image generation, live transcription, retention features, and experimental UI.
- Persists feature flags in workspace state with a migration and audited updates.
- Resolves production capabilities per workspace and gates provider-backed endpoints before quota/provider calls when features are disabled.
- Lets the production readiness banner read workspace capabilities when a workspace is active, falling back to global capabilities otherwise.

Closes #1262

## Validation
- `node_modules\\.bin\\vitest.cmd run src/components/app-shell/ProductionReadinessBanner.test.tsx src/shared/contracts.test.ts src/services/capabilitiesService.test.ts --coverage.enabled=false` — 3 files, 22 tests passed
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/routes/capabilities.test.ts server/tests/routes/workspaces.test.ts server/tests/routes/media.test.ts server/tests/routes/transcribe.test.ts server/tests/routes/costly-endpoints-auth.test.ts server/tests/routes/media.additional.test.ts server/tests/database/migration-contract.test.ts server/tests/database.test.ts --coverage.enabled=false` — 8 files, 210 tests passed
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/flow/audio-pipeline.test.ts --coverage.enabled=false` — 1 file, 1 test passed
- `node_modules\\.bin\\tsc.cmd --noEmit` — passed
- `node_modules\\.bin\\tsc.cmd --project server\\tsconfig.server.json --noEmit` — passed
- `node scripts/audit-mojibake.mjs` — passed
- `node scripts/validate-repo-hygiene.mjs` — passed
- `node scripts/validate-database-schema-audit.mjs` — passed
- `git diff --check` — passed, only LF/CRLF warnings
- Push release guard — passed: server suite 100 files passed / 1464 tests passed / 82 skipped, follow-up frontend/script tests 3 files passed / 81 tests passed, `audit:build-warnings` build passed

## Notes / residual risks
- The workspace config surface is exposed as protected API endpoints and consumed by the existing readiness banner; this PR does not add a full admin settings UI.
- Forced workspace `local-whisper` is reported unavailable instead of being silently remapped, because the current STT worker path is wired for OpenAI/Groq. Global auto local-whisper fallback behavior is left unchanged.
- Retention and experimental UI flags are present in the capability contract; deeper product-specific behavior can be added in follow-up issues.