### PR TITLE
fix(db): keep auth workspace creation in one transaction (#1403)

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -39,6 +39,12 @@ const DEFAULT_RETENTION_DAYS = 365;
 const DEFAULT_REMOTE_AUDIO_AVAILABILITY_TIMEOUT_MS = 2500;
 const WORKSPACE_RETENTION_HOLD_RECORDING_ID = '__workspace__';
 
+type QueryExecutor = {
+  _query(sql: string, params?: any[]): Promise<any[]>;
+  _get(sql: string, params?: any[]): Promise<any | null>;
+  _execute(sql: string, params?: any[]): Promise<void>;
+};
+
 function _resolvePositiveTimeoutMs(value: unknown, fallback: number): number {
   const numeric = Number(value);
   if (Number.isFinite(numeric) && numeric > 0) {
@@ -448,11 +454,58 @@ export class Database {
     });
   }
 
+  _toPostgresSql(sql: string): string {
+    let i = 0;
+    return sql.replace(/\?/g, () => `$${++i}`);
+  }
+
+  _createPostgresExecutor(client: { query: (sql: string, params?: any[]) => Promise<any> }) {
+    return {
+      _query: async (sql: string, params: any[] = []) => {
+        const res = await client.query(this._toPostgresSql(sql), params);
+        return res.rows;
+      },
+      _get: async (sql: string, params: any[] = []) => {
+        const res = await client.query(this._toPostgresSql(sql), params);
+        return res.rows[0] || null;
+      },
+      _execute: async (sql: string, params: any[] = []) => {
+        await client.query(this._toPostgresSql(sql), params);
+      },
+    };
+  }
+
+  async _withTransaction<T>(operation: (tx: QueryExecutor) => Promise<T>): Promise<T> {
+    if (this.type === 'postgres') {
+      const client = await this.pool.connect();
+      const tx = this._createPostgresExecutor(client);
+      try {
+        await tx._execute('BEGIN');
+        const result = await operation(tx);
+        await tx._execute('COMMIT');
+        return result;
+      } catch (error) {
+        await tx._execute('ROLLBACK');
+        throw error;
+      } finally {
+        client.release();
+      }
+    }
+
+    await this._execute('BEGIN');
+    try {
+      const result = await operation(this);
+      await this._execute('COMMIT');
+      return result;
+    } catch (error) {
+      await this._execute('ROLLBACK');
+      throw error;
+    }
+  }
+
   async _query(sql: string, params: any[] = []) {
     if (this.type === 'postgres') {
-      let i = 0;
-      const pgSql = sql.replace(/\?/g, () => `$${++i}`);
-      const res = await this.pool.query(pgSql, params);
+      const res = await this.pool.query(this._toPostgresSql(sql), params);
       return res.rows;
     } else {
       return this._sendToWorker('query', sql, params);
@@ -461,9 +514,7 @@ export class Database {
 
   async _get(sql: string, params: any[] = []) {
     if (this.type === 'postgres') {
-      let i = 0;
-      const pgSql = sql.replace(/\?/g, () => `$${++i}`);
-      const res = await this.pool.query(pgSql, params);
+      const res = await this.pool.query(this._toPostgresSql(sql), params);
       return res.rows[0] || null;
     } else {
       const result = await this._sendToWorker('get', sql, params);
@@ -473,9 +524,7 @@ export class Database {
 
   async _execute(sql: string, params: any[] = []) {
     if (this.type === 'postgres') {
-      let i = 0;
-      const pgSql = sql.replace(/\?/g, () => `$${++i}`);
-      await this.pool.query(pgSql, params);
+      await this.pool.query(this._toPostgresSql(sql), params);
     } else {
       await this._sendToWorker('execute', sql, params);
     }
@@ -1223,9 +1272,9 @@ export class Database {
     return Promise.all(rows.map((row) => this._buildWorkspaceFromRow(row, userId)));
   }
 
-  async ensureWorkspaceState(workspaceId: string): Promise<void> {
+  async ensureWorkspaceState(workspaceId: string, executor: QueryExecutor = this): Promise<void> {
     try {
-      await this._execute(
+      await executor._execute(
         "ALTER TABLE workspace_state ADD COLUMN manual_people_json TEXT NOT NULL DEFAULT '[]'"
       );
     } catch (error) {
@@ -1236,7 +1285,7 @@ export class Database {
       }
     }
     try {
-      await this._execute(
+      await executor._execute(
         `ALTER TABLE workspace_state ADD COLUMN retention_days INTEGER NOT NULL DEFAULT ${DEFAULT_RETENTION_DAYS}`
       );
     } catch (error) {
@@ -1247,14 +1296,14 @@ export class Database {
       }
     }
 
-    const existing = await this._get(
+    const existing = await executor._get(
       'SELECT workspace_id FROM workspace_state WHERE workspace_id = ?',
       [workspaceId]
     );
     if (existing) return;
 
     const timestamp = this.nowIso();
-    await this._execute(
+    await executor._execute(
       `
         INSERT INTO workspace_state (
           workspace_id,
@@ -1660,9 +1709,8 @@ export class Database {
     let workspaceId = '';
     let memberRole = 'member';
 
-    await this._execute('BEGIN');
-    try {
-      await this._execute(
+    await this._withTransaction(async (tx) => {
+      await tx._execute(
         `
           INSERT INTO users (
             id, email, password_hash, name, provider, google_sub, google_email,
@@ -1684,20 +1732,20 @@ export class Database {
 
       if (workspaceMode === 'join') {
         if (!inviteCode) throw errorWithStatus('Podaj kod workspace, aby dolaczyc.', 400);
-        const workspace = await this._get('SELECT * FROM workspaces WHERE invite_code = ?', [
+        const workspace = await tx._get('SELECT * FROM workspaces WHERE invite_code = ?', [
           inviteCode,
         ]);
         if (!workspace) throw errorWithStatus('Nie znaleziono workspace o takim kodzie.', 404);
 
         workspaceId = workspace.id;
-        await this._execute(
+        await tx._execute(
           "INSERT INTO workspace_members (workspace_id, user_id, member_role, joined_at) VALUES (?, ?, 'member', ?)",
           [workspaceId, userId, timestamp]
         );
       } else {
         workspaceId = this._generateId('workspace');
         memberRole = 'owner';
-        await this._execute(
+        await tx._execute(
           'INSERT INTO workspaces (id, name, owner_user_id, invite_code, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
           [
             workspaceId,
@@ -1708,19 +1756,15 @@ export class Database {
             timestamp,
           ]
         );
-        await this._execute(
+        await tx._execute(
           "INSERT INTO workspace_members (workspace_id, user_id, member_role, joined_at) VALUES (?, ?, 'owner', ?)",
           [workspaceId, userId, timestamp]
         );
-        await this.ensureWorkspaceState(workspaceId);
+        await this.ensureWorkspaceState(workspaceId, tx);
       }
 
-      if (workspaceMode === 'join') await this.ensureWorkspaceState(workspaceId);
-      await this._execute('COMMIT');
-    } catch (error) {
-      await this._execute('ROLLBACK');
-      throw error;
-    }
+      if (workspaceMode === 'join') await this.ensureWorkspaceState(workspaceId, tx);
+    });
 
     const session = await this.createSession(userId, workspaceId);
     const payload: any = await this.buildSessionPayload(userId, workspaceId);
@@ -1824,8 +1868,7 @@ export class Database {
     ]);
     let workspaceId = '';
 
-    await this._execute('BEGIN');
-    try {
+    await this._withTransaction(async (tx) => {
       if (row) {
         const currentProfile = this._safeJsonParse(row.profile_json, {});
         const nextProfile = {
@@ -1833,7 +1876,7 @@ export class Database {
           avatarUrl: this._clean(profile.picture) || currentProfile.avatarUrl || '',
           googleEmail: email,
         };
-        await this._execute(
+        await tx._execute(
           "UPDATE users SET email = ?, name = ?, provider = 'google', google_sub = ?, google_email = ?, profile_json = ?, updated_at = ? WHERE id = ?",
           [
             email,
@@ -1849,7 +1892,7 @@ export class Database {
       } else {
         const userId = this._generateId('user');
         workspaceId = this._generateId('workspace');
-        await this._execute(
+        await tx._execute(
           `
           INSERT INTO users (
             id, email, password_hash, name, provider, google_sub, google_email,
@@ -1872,7 +1915,7 @@ export class Database {
             timestamp,
           ]
         );
-        await this._execute(
+        await tx._execute(
           'INSERT INTO workspaces (id, name, owner_user_id, invite_code, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)',
           [
             workspaceId,
@@ -1883,18 +1926,14 @@ export class Database {
             timestamp,
           ]
         );
-        await this._execute(
+        await tx._execute(
           "INSERT INTO workspace_members (workspace_id, user_id, member_role, joined_at) VALUES (?, ?, 'owner', ?)",
           [workspaceId, userId, timestamp]
         );
-        await this.ensureWorkspaceState(workspaceId);
-        row = await this._get('SELECT * FROM users WHERE id = ?', [userId]);
+        await this.ensureWorkspaceState(workspaceId, tx);
+        row = await tx._get('SELECT * FROM users WHERE id = ?', [userId]);
       }
-      await this._execute('COMMIT');
-    } catch (error) {
-      await this._execute('ROLLBACK');
-      throw error;
-    }
+    });
 
     const actualUserId =
       row?.id || (await this._get('SELECT id FROM users WHERE email = ?', [email]))?.id;

--- a/server/tests/database.postgres-transaction.test.ts
+++ b/server/tests/database.postgres-transaction.test.ts
@@ -1,0 +1,83 @@
+import path from 'node:path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+describe('Database Postgres transactions', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('pg');
+  });
+
+  test('Regression: Issue #1403 - registerUser keeps workspace and workspace_state inserts on one Postgres client', async () => {
+    const realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const realOs = await vi.importActual<typeof import('node:os')>('node:os');
+    const uploadDir = realFs.mkdtempSync(path.join(realOs.tmpdir(), 'voicelog-pg-tx-'));
+    const poolQueries: Array<{ sql: string; params?: unknown[] }> = [];
+    const clientQueries: Array<{ sql: string; params?: unknown[] }> = [];
+    const client = {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        clientQueries.push({ sql, params });
+        return { rows: [] };
+      }),
+      release: vi.fn(),
+    };
+    const pool = {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        poolQueries.push({ sql, params });
+        return { rows: [] };
+      }),
+      connect: vi.fn(async () => client),
+      end: vi.fn(),
+    };
+
+    const PoolMock = vi.fn(function Pool() {
+      return pool;
+    });
+
+    vi.doMock('pg', () => ({
+      Pool: PoolMock,
+    }));
+
+    const { initDatabase } = await import('../database.ts');
+    const db = initDatabase({
+      connectionString: 'postgres://unit-test',
+      uploadDir,
+    }) as any;
+    db.createSession = vi.fn(async () => ({
+      token: 'token',
+      expiresAt: '2026-07-05T00:00:00.000Z',
+    }));
+    db.buildSessionPayload = vi.fn(async (userId: string, workspaceId: string) => ({
+      user: { id: userId, email: 'new@example.test', name: 'New User' },
+      users: [],
+      workspaces: [{ id: workspaceId, name: 'Workspace' }],
+      workspaceId,
+      state: {},
+    }));
+
+    try {
+      const result = await db.registerUser({
+        email: 'new@example.test',
+        password: 'password123',
+        name: 'New User',
+        workspaceName: 'Workspace',
+        workspaceMode: 'create',
+      });
+
+      expect(result.workspaceId).toMatch(/^workspace_/);
+      expect(pool.connect).toHaveBeenCalledTimes(1);
+      expect(client.release).toHaveBeenCalledTimes(1);
+
+      const clientSql = clientQueries.map((entry) => entry.sql);
+      expect(clientSql[0]).toBe('BEGIN');
+      expect(clientSql).toContain('COMMIT');
+      expect(clientSql.some((sql) => /INSERT INTO workspaces/i.test(sql))).toBe(true);
+      expect(clientSql.some((sql) => /INSERT INTO workspace_state/i.test(sql))).toBe(true);
+      expect(poolQueries.some((entry) => /INSERT INTO workspace_state/i.test(entry.sql))).toBe(
+        false
+      );
+    } finally {
+      await db.shutdown();
+      realFs.rmSync(uploadDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes the Railway runtime FK failure from #1403 by keeping auth workspace creation and workspace_state initialization on the same Postgres client/transaction.
- Adds a transaction executor for Postgres while preserving the existing SQLite transaction path.
- Applies the same safe transaction path to first-time Google auth workspace creation.
- Adds a regression test with a mocked Postgres pool proving `registerUser()` uses `pool.connect()` and keeps `workspaces` + `workspace_state` inserts on the same client.

Closes #1403

## Root cause
`Database.registerUser()` used `BEGIN`, but in Postgres mode `_execute()` called `pool.query()` for every statement. That can lease different connections per statement, so `ensureWorkspaceState()` could attempt to insert `workspace_state` on a connection that could not see the uncommitted `workspaces` row, triggering `workspace_state_workspace_id_fkey` / code `23503` during `POST /auth/register`.

## Validation
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/database.postgres-transaction.test.ts --coverage.enabled=false` — 1 file, 1 test passed
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/database.postgres-transaction.test.ts server/tests/auth.test.ts server/tests/routes/auth.test.ts server/tests/routes/auth-extended.test.ts server/tests/database.test.ts --coverage.enabled=false` — 5 files, 47 tests passed
- `node_modules\\.bin\\tsc.cmd --project server\\tsconfig.server.json --noEmit` — passed
- `node scripts/audit-mojibake.mjs` — passed
- `node scripts/validate-repo-hygiene.mjs` — passed
- `node_modules\\.bin\\prettier.cmd --check <touched files>` — passed
- `git diff --check` — passed, only LF/CRLF warnings
- Push release guard — passed: server suite 101 files passed / 1458 tests passed / 82 skipped, follow-up frontend/script tests 3 files passed / 81 tests passed, `audit:build-warnings` build passed

## Residual risk
- This PR fixes the auth registration transaction class of the FK error. Existing orphaned rows, if any were created by older deploys, still need data cleanup through the existing repair/admin tooling.