### PR TITLE
fix(monitoring): downgrade expected auth errors (#1404)

### DIFF
--- a/server/http/app-security.ts
+++ b/server/http/app-security.ts
@@ -87,6 +87,30 @@ function getRequestLogTarget(c: any) {
   return redactSensitiveRequestUrl(String(c.req?.path || ''));
 }
 
+function resolveAppErrorStatus(err: any) {
+  if (err.name === 'ContextError' || err instanceof z.ZodError || err?.statusCode === 422) {
+    return 422;
+  }
+  return Number(err?.statusCode || err?.status || 500) || 500;
+}
+
+function logHandledAppError(err: any, c: any, statusCode: number) {
+  if (statusCode >= 500) {
+    logger.error('APP ERROR STACK', err, { sentry: false });
+    return;
+  }
+
+  logger.warn(
+    'APP CLIENT ERROR',
+    {
+      statusCode,
+      route: getRequestLogTarget(c),
+      message: err?.message || 'Client request failed.',
+    },
+    { sentry: false }
+  );
+}
+
 export function applyAppCors(app: Hono<any>, _allowedOrigins: string) {
   app.use('*', async (c, next) => {
     const requestOrigin = c.req.header('origin') || '';
@@ -222,7 +246,8 @@ export function registerNotFoundHandler(app: Hono<any>, allowedOrigins = 'http:/
 export function registerAppErrorHandler(app: Hono<any>, allowedOrigins = 'http://localhost:3000') {
   app.onError((err: any, c) => {
     setSecurityHeaders(c);
-    logger.error('APP ERROR STACK', err, { sentry: false });
+    const statusCode = resolveAppErrorStatus(err);
+    logHandledAppError(err, c, statusCode);
 
     // Ensure CORS headers are always present on error responses.
     // app.onError creates a new response that may bypass the cors middleware's
@@ -235,7 +260,6 @@ export function registerAppErrorHandler(app: Hono<any>, allowedOrigins = 'http:/
     if (err.name === 'ContextError' || err instanceof z.ZodError || err?.statusCode === 422) {
       return c.json({ message: 'Invalid payload.', errors: err?.errors || err.message }, 422);
     }
-    const statusCode = err?.statusCode || err?.status || 500;
     if (statusCode === 429 && err?.retryAfter) {
       c.header('Retry-After', String(err.retryAfter));
     }

--- a/server/tests/app-security.test.ts
+++ b/server/tests/app-security.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { createApp } from '../app.ts';
+import { logger } from '../logger.ts';
 
 function createServices(allowedOrigins: string) {
   return {
@@ -116,6 +117,35 @@ describe('app security CORS contract', () => {
     expect(error.status).toBe(503);
     expect(error.headers.get('Access-Control-Allow-Origin')).toBe('https://app.example.test');
     expectHardenedHeaders(error);
+  });
+
+  it('logs expected client auth failures below error level', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => undefined);
+    const warnSpy = vi.spyOn(logger, 'warn').mockImplementation(() => undefined);
+    const app = createApp(createServices('https://app.example.test'));
+    app.get('/expected-auth-error', () => {
+      throw Object.assign(new Error('Niepoprawny email lub haslo.'), { statusCode: 401 });
+    });
+
+    const res = await app.request('/expected-auth-error', {
+      headers: { Origin: 'https://app.example.test' },
+    });
+
+    expect(res.status).toBe(401);
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      'APP ERROR STACK',
+      expect.anything(),
+      expect.anything()
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      'APP CLIENT ERROR',
+      expect.objectContaining({
+        statusCode: 401,
+        route: '/expected-auth-error',
+        message: 'Niepoprawny email lub haslo.',
+      }),
+      { sentry: false }
+    );
   });
 
   function expectCredentialedCors(res: Response, origin = productionOrigin) {

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -1149,6 +1149,7 @@ describe('Media Routes', () => {
     it('returns 429 when Gemini responds with 429 quota exceeded', async () => {
       const ctx = setupSketchnoteTest();
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       global.fetch = vi.fn().mockResolvedValue(
         new Response(
           JSON.stringify({
@@ -2296,6 +2297,7 @@ describe('Media Routes', () => {
 
     it('zwraca 403, gdy użytkownik nie ma dostępu do workspace', async () => {
       const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+      const consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
       mockWorkspaceService.getMembership.mockResolvedValue(null);
       mockTranscriptionService.getMediaAsset.mockResolvedValue({
         id: 'rec_forbidden',
@@ -2309,11 +2311,16 @@ describe('Media Routes', () => {
 
       expect(res.status).toBe(403);
       expect(mockTranscriptionService.deleteMediaAsset).not.toHaveBeenCalled();
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(consoleErrorSpy).not.toHaveBeenCalledWith(
         '[ERROR] APP ERROR STACK',
+        expect.anything()
+      );
+      expect(consoleWarnSpy).toHaveBeenCalledWith(
+        '[WARN] APP CLIENT ERROR',
         expect.objectContaining({
           message: 'Nie masz dostepu do tego workspace.',
           statusCode: 403,
+          route: '/media/recordings/rec_forbidden',
         })
       );
     });


### PR DESCRIPTION
## Summary
- Downgrades handled 4xx application errors from `APP ERROR STACK` / error-level logging to `APP CLIENT ERROR` / warn-level logging.
- Keeps 5xx errors on `APP ERROR STACK`, so genuine runtime failures remain visible to Railway/Sentry monitoring.
- Updates media route regression coverage that previously expected a 403 to be logged as a server error.

Closes #1404

## Root cause
The global Hono `onError` handler logged every thrown error as `logger.error('APP ERROR STACK', ...)` before resolving the HTTP status. Expected client/auth failures such as invalid login credentials (`401`) therefore appeared in Railway `@level:error` logs and were grouped as runtime incidents.

## Validation
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/app-security.test.ts --coverage.enabled=false` — 1 file, 5 tests passed
- `node_modules\\.bin\\vitest.cmd run -c server/vitest.config.ts server/tests/app-security.test.ts server/tests/routes/media.test.ts --coverage.enabled=false` — 2 files, 62 tests passed
- `node_modules\\.bin\\tsc.cmd --project server\\tsconfig.server.json --noEmit` — passed
- `node scripts/audit-mojibake.mjs` — passed
- `node scripts/validate-repo-hygiene.mjs` — passed
- `node_modules\\.bin\\prettier.cmd --check <touched files>` — passed
- `git diff --check` — passed, only LF/CRLF warnings
- Push release guard — passed: server suite 100 files passed / 1458 tests passed / 82 skipped, follow-up frontend/script tests 3 files passed / 81 tests passed, `audit:build-warnings` build passed

## Residual risk
- This reduces false-positive Railway error reports for expected 4xx paths; it does not change response status or authentication behavior.