### PR TITLE
fix(release): align production Railway URL for #1418

### DIFF
--- a/.github/workflows/backend-production-smoke.yml
+++ b/.github/workflows/backend-production-smoke.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       issues: write
     env:
-      VOICELOG_SMOKE_BASE_URL: ${{ secrets.VOICELOG_SMOKE_BASE_URL || 'https://audiorecorder-production.up.railway.app' }}
+      VOICELOG_SMOKE_BASE_URL: ${{ secrets.VOICELOG_SMOKE_BASE_URL || 'https://voicelog-production.up.railway.app' }}
       VOICELOG_SMOKE_TOKEN: ${{ secrets.VOICELOG_SMOKE_TOKEN }}
       VOICELOG_SMOKE_EMAIL: ${{ secrets.VOICELOG_SMOKE_EMAIL }}
       VOICELOG_SMOKE_PASSWORD: ${{ secrets.VOICELOG_SMOKE_PASSWORD }}
@@ -84,7 +84,7 @@ jobs:
           echo "Starting smoke test..."
           pnpm run test:smoke
         env:
-          SMOKE_TEST_URL: https://audiorecorder-production.up.railway.app/health
+          SMOKE_TEST_URL: https://voicelog-production.up.railway.app/health
           EXPECTED_GIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           REQUIRE_EXACT_GIT_SHA: 'true'
           SMOKE_MAX_RETRIES: '30'
@@ -132,7 +132,7 @@ jobs:
           echo "Checking Railway deployment status..."
           curl -v "$SMOKE_TEST_URL" || echo "Railway not responding"
         env:
-          SMOKE_TEST_URL: https://audiorecorder-production.up.railway.app/health
+          SMOKE_TEST_URL: https://voicelog-production.up.railway.app/health
         continue-on-error: true
 
       - name: Create GitHub issue on production crash

--- a/.github/workflows/railway-build-metadata.yml
+++ b/.github/workflows/railway-build-metadata.yml
@@ -159,7 +159,7 @@ jobs:
                 --max-time 20 \
                 -o "$body_file" \
                 -w "%{http_code}" \
-                https://audiorecorder-production.up.railway.app/health \
+                https://voicelog-production.up.railway.app/health \
                 || true
             )"
             payload="$(cat "$body_file" || true)"

--- a/.github/workflows/railway-sync-google-oauth.yml
+++ b/.github/workflows/railway-sync-google-oauth.yml
@@ -32,7 +32,7 @@ jobs:
           test -n "$GOOGLE_CALENDAR_SCOPES"
           test -n "$GOOGLE_OAUTH_REDIRECT_URI"
           case "$GOOGLE_OAUTH_REDIRECT_URI" in
-            https://audiorecorder-production.up.railway.app/integrations/google/callback) ;;
+            https://voicelog-production.up.railway.app/integrations/google/callback) ;;
             *) echo "GOOGLE_OAUTH_REDIRECT_URI must point to the Railway production callback" >&2; exit 1 ;;
           esac
 

--- a/docs/INCIDENT_RESPONSE_DR_RUNBOOK.md
+++ b/docs/INCIDENT_RESPONSE_DR_RUNBOOK.md
@@ -61,8 +61,8 @@ pnpm run test:e2e:production-system
 Useful manual checks:
 
 ```powershell
-curl https://audiorecorder-production.up.railway.app/health
-curl https://audiorecorder-production.up.railway.app/api/capabilities
+curl https://voicelog-production.up.railway.app/health
+curl https://voicelog-production.up.railway.app/api/capabilities
 gh run list --repo maniczko/audioRecorder --limit 10
 gh pr checks <PR_NUMBER> --repo maniczko/audioRecorder --watch=false
 ```
@@ -91,7 +91,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://audiorecorder-production.up.railway.app/health
+curl https://voicelog-production.up.railway.app/health
 pnpm run release:prod-smoke
 pnpm run errors:railway
 gh run list --repo maniczko/audioRecorder --workflow backend-production-smoke.yml --limit 5
@@ -115,7 +115,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://audiorecorder-production.up.railway.app/api/capabilities
+curl https://voicelog-production.up.railway.app/api/capabilities
 pnpm run release:audio-prod-smoke
 pnpm run errors:railway
 ```
@@ -140,7 +140,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://audiorecorder-production.up.railway.app/health
+curl https://voicelog-production.up.railway.app/health
 pnpm run verify:supabase:workspace
 pnpm run release:audio-prod-smoke
 ```
@@ -164,7 +164,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://audiorecorder-production.up.railway.app/health
+curl https://voicelog-production.up.railway.app/health
 pnpm run release:prod-smoke
 pnpm run verify:supabase:workspace
 ```

--- a/docs/ops/RAILWAY_CONFIG.md
+++ b/docs/ops/RAILWAY_CONFIG.md
@@ -89,7 +89,7 @@ If upload dir is not writable:
 After deployment, check:
 
 ```
-https://audiorecorder-production.up.railway.app/health
+https://voicelog-production.up.railway.app/health
 ```
 
 Expected response:
@@ -181,7 +181,7 @@ df -h /app/server/data
 ### API Health
 
 ```bash
-curl https://audiorecorder-production.up.railway.app/api/health
+curl https://voicelog-production.up.railway.app/api/health
 ```
 
 ### Logs

--- a/scripts/fetch-railway-errors.js
+++ b/scripts/fetch-railway-errors.js
@@ -183,7 +183,7 @@ ${deploymentInfo}
 
   // Add health check
   try {
-    const healthUrl = 'https://audiorecorder-production.up.railway.app/health';
+    const healthUrl = 'https://voicelog-production.up.railway.app/health';
     const healthCmd = `curl -s ${healthUrl}`;
     const health = execSync(healthCmd, { encoding: 'utf-8' });
     report += `\`\`\`json\n${health}\n\`\`\`\n`;

--- a/scripts/monitor-external-services.js
+++ b/scripts/monitor-external-services.js
@@ -288,7 +288,7 @@ async function getRailwayStatus() {
         const res = await fetch(`https://backboard.railway.app/graphql/v2`, {
           method: 'POST',
           headers,
-          body: JSON.stringify({ query, variables })
+          body: JSON.stringify({ query, variables }),
         });
         if (!res.ok) throw new Error(`Railway API: ${res.status}`);
         return res.json();
@@ -321,7 +321,7 @@ async function getRailwayStatus() {
 
     // Fallback: check Railway backend health endpoint
     // Always use production Railway URL for monitoring (not local dev server)
-    const RAILWAY_URL = 'https://audiorecorder-production.up.railway.app/health';
+    const RAILWAY_URL = 'https://voicelog-production.up.railway.app/health';
 
     let healthStatus = null;
     try {
@@ -334,7 +334,7 @@ async function getRailwayStatus() {
     }
 
     return {
-      status: healthStatus ? 'connected' : (hasConfig ? 'config-only' : 'not-configured'),
+      status: healthStatus ? 'connected' : hasConfig ? 'config-only' : 'not-configured',
       configured: hasConfig || !!process.env.RAILWAY_TOKEN,
       has_token: hasRailwayEnv,
       deployments: [],
@@ -342,9 +342,9 @@ async function getRailwayStatus() {
       health: healthStatus,
       note: healthStatus
         ? `Backend healthy: ${healthStatus.status || 'ok'}`
-        : (hasRailwayEnv
+        : hasRailwayEnv
           ? `Railway API token is not authorized. Run \`railway link\` or get a new token at https://railway.app/dashboard/account/tokens`
-          : 'Railway config files exist. Add RAILWAY_TOKEN for full deployment status.'),
+          : 'Railway config files exist. Add RAILWAY_TOKEN for full deployment status.',
       api_error: healthStatus ? null : 'Railway API not authorized — using health fallback',
     };
   } catch (error) {

--- a/scripts/release-readiness.test.ts
+++ b/scripts/release-readiness.test.ts
@@ -786,6 +786,15 @@ describe('release readiness gates', () => {
     ]) {
       expect(rewriteSources).toContain(source);
     }
+
+    for (const rewrite of vercelConfig.rewrites || []) {
+      expect(String(rewrite.destination || '')).toContain(
+        'https://voicelog-production.up.railway.app'
+      );
+      expect(String(rewrite.destination || '')).not.toContain(
+        'https://audiorecorder-production.up.railway.app'
+      );
+    }
   });
 
   it('keeps the error monitor issue-driven instead of committing root TASK_QUEUE.md', () => {

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -116,7 +116,7 @@ describe('GitHub workflows validation', () => {
     const content = readFileSync(workflowPath, 'utf8');
 
     expect(existsSync(workflowPath)).toBe(true);
-    expect(content).toContain('uses: actions/checkout@v6');
+    expect(content).toContain('uses: actions/checkout@v7');
     expect(content).toContain('uses: github/codeql-action/init@v4');
     expect(content).toContain('uses: github/codeql-action/analyze@v4');
     expect(content).toContain('queries: +security-and-quality');
@@ -272,7 +272,7 @@ describe('GitHub workflows validation', () => {
     expect(installStep?.run).toContain('pnpm install --frozen-lockfile --ignore-scripts');
     expect(debugStep?.if).toBe("failure() && steps.smoke.outcome == 'failure'");
     expect(debugStep?.env?.SMOKE_TEST_URL).toBe(
-      'https://audiorecorder-production.up.railway.app/health'
+      'https://voicelog-production.up.railway.app/health'
     );
   });
 
@@ -402,7 +402,7 @@ describe('GitHub workflows validation', () => {
       'GOOGLE_OAUTH_REDIRECT_URI: ${{ secrets.GOOGLE_OAUTH_REDIRECT_URI }}'
     );
     expect(content).toContain(
-      'https://audiorecorder-production.up.railway.app/integrations/google/callback'
+      'https://voicelog-production.up.railway.app/integrations/google/callback'
     );
     expect(content).toContain('--skip-deploys');
     expect(content).toContain('--stdin');
@@ -411,11 +411,30 @@ describe('GitHub workflows validation', () => {
     expect(content).not.toContain('localhost');
   });
 
+  it('keeps production Railway health checks on the current backend domain', () => {
+    const checkedFiles = [
+      '.github/workflows/railway-build-metadata.yml',
+      '.github/workflows/backend-production-smoke.yml',
+      '.github/workflows/railway-sync-google-oauth.yml',
+      'scripts/fetch-railway-errors.js',
+      'scripts/monitor-external-services.js',
+      'src/services/config.ts',
+      'vercel.json',
+    ];
+
+    for (const fileName of checkedFiles) {
+      const content = readFileSync(path.resolve(fileName), 'utf8');
+
+      expect(content, fileName).toContain('https://voicelog-production.up.railway.app');
+      expect(content, fileName).not.toContain('https://audiorecorder-production.up.railway.app');
+    }
+  });
+
   it('checks out the error monitor workflow with the built-in GitHub token', () => {
     const workflowPath = path.join(workflowDir, 'error-monitor-and-task-creator.yml');
     const content = readFileSync(workflowPath, 'utf8');
 
-    expect(content).toContain('actions/checkout@v6');
+    expect(content).toContain('actions/checkout@v7');
     expect(content).toContain('github.token');
     expect(content).not.toContain('secrets.GH_PAT');
     expect(content).not.toContain('secrets.GITHUB_TOKEN');
@@ -425,7 +444,7 @@ describe('GitHub workflows validation', () => {
     const workflowPath = path.join(workflowDir, 'task-queue-auto-assign.yml');
     const content = readFileSync(workflowPath, 'utf8');
 
-    expect(content).toContain('actions/checkout@v6');
+    expect(content).toContain('actions/checkout@v7');
     expect(content).toContain("git push origin HEAD:${{ github.ref_name || 'main' }}");
     expect(content).not.toContain('secrets.GH_PAT');
     expect(content).not.toContain('secrets.GITHUB_TOKEN');

--- a/src/service-worker.test.ts
+++ b/src/service-worker.test.ts
@@ -91,7 +91,7 @@ describe('service-worker', () => {
     listeners.fetch({
       request: {
         method: 'GET',
-        url: 'https://audiorecorder-production.up.railway.app/voice-profiles',
+        url: 'https://voicelog-production.up.railway.app/voice-profiles',
         mode: 'cors',
       },
       respondWith,

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -31,14 +31,14 @@ describe('services/config resolveApiBaseUrl', () => {
   });
 
   it('uses configured API URL directly on Vercel preview runtime', async () => {
-    process.env.VITE_API_BASE_URL = 'https://audiorecorder-production.up.railway.app';
+    process.env.VITE_API_BASE_URL = 'https://voicelog-production.up.railway.app';
     delete process.env.REACT_APP_API_BASE_URL;
     setWindowOrigin('https://audiorecorder-preview.vercel.app');
 
     const config = await import('./config');
 
-    expect(config.API_BASE_URL).toBe('https://audiorecorder-production.up.railway.app');
-    expect(config.MEDIA_API_BASE_URL).toBe('https://audiorecorder-production.up.railway.app');
+    expect(config.API_BASE_URL).toBe('https://voicelog-production.up.railway.app');
+    expect(config.MEDIA_API_BASE_URL).toBe('https://voicelog-production.up.railway.app');
   });
 
   it('falls back to Railway directly on hosted Vercel when API URL is missing', async () => {
@@ -48,7 +48,7 @@ describe('services/config resolveApiBaseUrl', () => {
 
     const config = await import('./config');
 
-    expect(config.API_BASE_URL).toBe('https://audiorecorder-production.up.railway.app');
+    expect(config.API_BASE_URL).toBe('https://voicelog-production.up.railway.app');
   });
 
   it('allows overriding the direct media API base URL', async () => {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -31,7 +31,7 @@ function readEnv(key: string, fallback = '') {
   return fallback;
 }
 
-const RAILWAY_API_BASE_URL = 'https://audiorecorder-production.up.railway.app';
+const RAILWAY_API_BASE_URL = 'https://voicelog-production.up.railway.app';
 
 function readMode(value, fallback = 'local') {
   const normalized = String(value || '')

--- a/src/services/httpClient.test.ts
+++ b/src/services/httpClient.test.ts
@@ -76,13 +76,13 @@ describe('httpClient retry logic', () => {
     global.fetch = mockFetch as any;
 
     const result = await apiRequest('/media/upload-policy', {
-      baseUrl: 'https://audiorecorder-production.up.railway.app/',
+      baseUrl: 'https://voicelog-production.up.railway.app/',
       retries: 0,
     });
 
     expect(result).toEqual({ ok: true });
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://audiorecorder-production.up.railway.app/media/upload-policy',
+      'https://voicelog-production.up.railway.app/media/upload-policy',
       expect.any(Object)
     );
   });

--- a/vercel.json
+++ b/vercel.json
@@ -6,47 +6,47 @@
   "rewrites": [
     {
       "source": "/health",
-      "destination": "https://audiorecorder-production.up.railway.app/health"
+      "destination": "https://voicelog-production.up.railway.app/health"
     },
     {
       "source": "/api/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/api/:path*"
+      "destination": "https://voicelog-production.up.railway.app/api/:path*"
     },
     {
       "source": "/auth/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/auth/:path*"
+      "destination": "https://voicelog-production.up.railway.app/auth/:path*"
     },
     {
       "source": "/users/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/users/:path*"
+      "destination": "https://voicelog-production.up.railway.app/users/:path*"
     },
     {
       "source": "/workspaces/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/workspaces/:path*"
+      "destination": "https://voicelog-production.up.railway.app/workspaces/:path*"
     },
     {
       "source": "/state/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/state/:path*"
+      "destination": "https://voicelog-production.up.railway.app/state/:path*"
     },
     {
       "source": "/voice-profiles",
-      "destination": "https://audiorecorder-production.up.railway.app/voice-profiles"
+      "destination": "https://voicelog-production.up.railway.app/voice-profiles"
     },
     {
       "source": "/voice-profiles/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/voice-profiles/:path*"
+      "destination": "https://voicelog-production.up.railway.app/voice-profiles/:path*"
     },
     {
       "source": "/media/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/media/:path*"
+      "destination": "https://voicelog-production.up.railway.app/media/:path*"
     },
     {
       "source": "/transcribe",
-      "destination": "https://audiorecorder-production.up.railway.app/transcribe"
+      "destination": "https://voicelog-production.up.railway.app/transcribe"
     },
     {
       "source": "/ai/:path*",
-      "destination": "https://audiorecorder-production.up.railway.app/ai/:path*"
+      "destination": "https://voicelog-production.up.railway.app/ai/:path*"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- Aligns the canonical production Railway backend URL to `https://voicelog-production.up.railway.app` across Vercel rewrites, frontend hosted-preview fallback config, Railway metadata/smoke workflows, monitoring scripts, and ops runbooks.
- Adds regression coverage so release/readiness workflow tests fail if operational configs drift back to the old `https://audiorecorder-production.up.railway.app` host.
- Updates workflow validation expectations to match the already-merged `actions/checkout@v7` upgrade on `main`.

## Root Cause / Before
- Active monitoring issues #1418/#1436 were still exercising `https://audiorecorder-production.up.railway.app/health`.
- Manual evidence on 2026-07-06: old host returns HTTP 502, current `https://voicelog-production.up.railway.app/health` returns HTTP 200.
- `vercel.json` also proxied production frontend API routes to the old Railway host, so deployed frontend traffic could hit the stale backend URL.

## After
- Railway Build Metadata, Backend Production Smoke, Google OAuth Railway sync, Vercel rewrites, hosted-preview fallback config, monitoring scripts, and relevant tests now use the current `voicelog-production` Railway domain.

## Validation
- `node scripts/validate-github-workflows.mjs` passed.
- `CI=true corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/validate-github-workflows.test.ts scripts/release-readiness.test.ts --coverage.enabled=false` passed: 2 files / 62 tests.
- `CI=true corepack pnpm exec vitest run src/services/config.test.ts src/services/httpClient.test.ts src/service-worker.test.ts tests/build-output.test.ts --coverage.enabled=false` passed: 3 files / 49 tests.
- `CI=true corepack pnpm run typecheck` passed.
- `CI=true corepack pnpm exec prettier --check ...` passed for changed files.
- Pre-push release guard passed locally: server suite 101 files, 1466 tests passed; targeted guard tests 3 files, 81 tests passed; build warning audit passed.
- Production probe evidence: `https://voicelog-production.up.railway.app/health` returned HTTP 200; `https://audiorecorder-production.up.railway.app/health` returned HTTP 502.

## Risks
- The currently running Railway Build Metadata workflow on `main` still uses the old URL and may fail before this PR lands. After merge, rerun/next CI should exercise the corrected endpoint.

Closes #1418
Refs #1436
Refs #1307