### PR TITLE
fix(health): split Railway liveness from readiness for #1436

### DIFF
--- a/server/http/health.ts
+++ b/server/http/health.ts
@@ -5,7 +5,7 @@ import { resolveSttRuntimePolicy } from '../stt/policy.ts';
 import { createUploadPolicy } from '../lib/mediaStoragePolicy.ts';
 
 export function registerHealthRoute(app: Hono<any>, db?: any) {
-  app.get('/health', async (c) => {
+  const buildHealthPayload = async () => {
     const build = resolveBuildMetadata(process.env, '0.1.0');
     let dbStatus: any = { ok: false, status: 'unreachable' };
 
@@ -53,15 +53,21 @@ export function registerHealthRoute(app: Hono<any>, db?: any) {
       process.env.NODE_ENV === 'production' ||
       Boolean(process.env.RAILWAY_ENVIRONMENT_NAME || process.env.RAILWAY_PROJECT_ID);
     const storageOk = !storageRequired || Boolean((supabaseStorage as any).ready);
-    const status = dbStatus.ok && storageOk ? 'ok' : 'degraded';
 
-    return c.json(
-      {
-        ok: dbStatus.ok && storageOk,
-        status,
+    return {
+      livenessOk: Boolean(dbStatus.ok),
+      readinessOk: Boolean(dbStatus.ok && storageOk),
+      payload: {
+        ok: Boolean(dbStatus.ok),
+        status: dbStatus.ok ? 'ok' : 'degraded',
         db: dbStatus.status,
         supabaseRemote: Boolean((supabaseStorage as any).ready),
         supabaseStorage,
+        readiness: {
+          ok: Boolean(dbStatus.ok && storageOk),
+          status: dbStatus.ok && storageOk ? 'ready' : 'degraded',
+          storageRequired,
+        },
         mediaUpload: {
           ...createUploadPolicy(),
           storageModeSupport: ['single', 'segmented'],
@@ -95,7 +101,23 @@ export function registerHealthRoute(app: Hono<any>, db?: any) {
           rss: `${(memory.rss / 1024 / 1024).toFixed(2)} MB`,
         },
       },
-      dbStatus.ok && storageOk ? 200 : 503
+    };
+  };
+
+  app.get('/health', async (c) => {
+    const health = await buildHealthPayload();
+    return c.json(health.payload, health.livenessOk ? 200 : 503);
+  });
+
+  app.get('/ready', async (c) => {
+    const health = await buildHealthPayload();
+    return c.json(
+      {
+        ...health.payload,
+        ok: health.readinessOk,
+        status: health.readinessOk ? 'ok' : 'degraded',
+      },
+      health.readinessOk ? 200 : 503
     );
   });
 }

--- a/server/tests/routes/health.test.ts
+++ b/server/tests/routes/health.test.ts
@@ -25,6 +25,14 @@ describe('http/health.ts', () => {
     expect(route.method).toBe('get');
   });
 
+  test('registers /ready GET route', () => {
+    const app = makeHonoLike();
+    registerHealthRoute(app);
+    const route = app._routes.find((r: any) => r.path === '/ready');
+    expect(route).toBeDefined();
+    expect(route.method).toBe('get');
+  });
+
   test('returns ok status with db fallback', async () => {
     const app = makeHonoLike();
     registerHealthRoute(app, undefined);
@@ -160,6 +168,83 @@ describe('http/health.ts', () => {
       bucket: 'recordings',
     });
 
+    if (savedUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = savedUrl;
+    if (savedKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    else process.env.SUPABASE_SERVICE_ROLE_KEY = savedKey;
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Issue #1436 — Railway deploy health blocked by storage readiness
+  // Date: 2026-07-06
+  // Bug: /health returned 503 when Supabase Storage was degraded, so
+  //      Railway marked otherwise booted backend containers as failed.
+  // Fix: /health is liveness; /ready remains strict dependency readiness.
+  // ─────────────────────────────────────────────────────────────────
+  test('Regression: #1436 keeps Railway liveness healthy when storage readiness is degraded', async () => {
+    const storageModule = await import('../../lib/supabaseStorage.ts');
+    const storageSpy = vi.spyOn(storageModule, 'checkSupabaseStorageReadiness').mockResolvedValue({
+      configured: true,
+      ready: false,
+      bucket: 'recordings',
+      status: 'bucket_unavailable',
+      error: 'exceed_egress_quota',
+    });
+    const savedNodeEnv = process.env.NODE_ENV;
+    const savedRailwayEnv = process.env.RAILWAY_ENVIRONMENT_NAME;
+    const savedUrl = process.env.SUPABASE_URL;
+    const savedKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    process.env.NODE_ENV = 'production';
+    process.env.RAILWAY_ENVIRONMENT_NAME = 'production';
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'key';
+
+    const app = makeHonoLike();
+    registerHealthRoute(app, {
+      checkHealth: vi.fn().mockResolvedValue({ ok: true, status: 'healthy' }),
+    });
+    const healthRoute = app._routes.find((r: any) => r.path === '/health');
+    const readyRoute = app._routes.find((r: any) => r.path === '/ready');
+
+    let healthResponse: any;
+    let readyResponse: any;
+    await healthRoute.handler(
+      makeCtxLike((data: any, status: number) => {
+        healthResponse = { data, status };
+      })
+    );
+    await readyRoute.handler(
+      makeCtxLike((data: any, status: number) => {
+        readyResponse = { data, status };
+      })
+    );
+
+    expect(healthResponse.status).toBe(200);
+    expect(healthResponse.data).toMatchObject({
+      ok: true,
+      status: 'ok',
+      supabaseRemote: false,
+      supabaseStorage: {
+        ready: false,
+        status: 'bucket_unavailable',
+      },
+      readiness: {
+        ok: false,
+        status: 'degraded',
+        storageRequired: true,
+      },
+    });
+    expect(readyResponse.status).toBe(503);
+    expect(readyResponse.data).toMatchObject({
+      ok: false,
+      status: 'degraded',
+    });
+
+    storageSpy.mockRestore();
+    if (savedNodeEnv === undefined) delete process.env.NODE_ENV;
+    else process.env.NODE_ENV = savedNodeEnv;
+    if (savedRailwayEnv === undefined) delete process.env.RAILWAY_ENVIRONMENT_NAME;
+    else process.env.RAILWAY_ENVIRONMENT_NAME = savedRailwayEnv;
     if (savedUrl === undefined) delete process.env.SUPABASE_URL;
     else process.env.SUPABASE_URL = savedUrl;
     if (savedKey === undefined) delete process.env.SUPABASE_SERVICE_ROLE_KEY;


### PR DESCRIPTION
## Summary
- split backend `/health` liveness from dependency readiness so Railway does not reject a booted container when Supabase Storage is degraded
- add `/ready` for strict readiness/dependency checks
- keep Supabase Storage readiness visible in `/health` payload so production smoke still reports quota/config degradation

## Root Cause
Railway deploys were failing because `/health` returned 503 when Supabase Storage readiness failed with `exceed_egress_quota`. That made Railway treat the new backend container as unhealthy even though the process, DB connection, and app startup were working. The old production host then kept serving a minimal stale health response, so `Railway Build Metadata` could not verify `gitSha`.

## Validation
- `corepack pnpm exec vitest run -c server/vitest.config.ts server/tests/routes/health.test.ts server/tests/integration/api-critical.test.ts server/tests/smoke-test.test.ts --coverage.enabled=false`
- `corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/release-readiness.test.ts scripts/validate-github-workflows.test.ts --coverage.enabled=false`
- `corepack pnpm run typecheck:server`
- `corepack pnpm exec prettier --check server/http/health.ts server/tests/routes/health.test.ts`
- pre-push `test:release:guard` passed: server tests 1468 passed, guard tests 81 passed, build warning audit passed

## Residual Risk
Supabase Storage still reports an external quota/readiness problem. This PR lets Railway deploy the backend and exposes the degraded dependency in health payload/readiness instead of hiding it.

Closes #1436