### PR TITLE
fix: clarify API base URL strategy for #1307

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -26,6 +26,16 @@ VOICELOG_ENABLE_HEAPDUMP=false
 # Production should keep this false unless preview domains are intentionally trusted
 VOICELOG_ALLOW_VERCEL_PREVIEWS=false
 
+# Frontend API routing model:
+# - Localhost defaults to http://localhost:4000 or http://127.0.0.1:4000.
+# - Stable production Vercel (https://voicelog-audiorecorder.vercel.app) uses
+#   same-origin API paths and relies on vercel.json rewrites to Railway.
+# - Vercel preview deployments must set VITE_API_BASE_URL explicitly when they
+#   should talk to a backend. They do not silently inherit production Railway.
+# VITE_API_BASE_URL=https://voicelog-production.up.railway.app
+# Optional separate media API override:
+# VITE_MEDIA_API_BASE_URL=https://voicelog-production.up.railway.app
+
 # ─────────────────────────────────────────────────────────────────────────────
 # Database
 # ─────────────────────────────────────────────────────────────────────────────

--- a/docs/ops/DEPLOYMENT.md
+++ b/docs/ops/DEPLOYMENT.md
@@ -104,6 +104,18 @@ vercel login
 vercel --prod
 ```
 
+#### API routing model
+
+VoiceLog uses one frontend/backend routing model for production:
+
+- `https://voicelog-audiorecorder.vercel.app` calls API paths on the same origin.
+- `vercel.json` rewrites those same-origin paths to the Railway backend.
+- Preview deployments do not silently inherit the production Railway URL. Set
+  `VITE_API_BASE_URL` explicitly in the preview environment when a preview should
+  talk to Railway or another backend.
+- A manually configured `VITE_API_BASE_URL` or `REACT_APP_API_BASE_URL` always
+  wins over runtime defaults.
+
 ### Heroku
 
 ```bash

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -41,14 +41,21 @@ describe('services/config resolveApiBaseUrl', () => {
     expect(config.MEDIA_API_BASE_URL).toBe('https://voicelog-production.up.railway.app');
   });
 
-  it('falls back to Railway directly on hosted Vercel when API URL is missing', async () => {
+  it('does not silently point Vercel previews at production Railway when API URL is missing', async () => {
     vi.stubEnv('VITE_API_BASE_URL', '');
     vi.stubEnv('REACT_APP_API_BASE_URL', '');
+    vi.stubEnv('VITE_MEDIA_API_BASE_URL', '');
+    vi.stubEnv('REACT_APP_MEDIA_API_BASE_URL', '');
+    vi.stubEnv('VITE_DATA_PROVIDER', '');
+    vi.stubEnv('REACT_APP_DATA_PROVIDER', '');
     setWindowOrigin('https://audiorecorder-preview.vercel.app');
 
     const config = await import('./config');
 
-    expect(config.API_BASE_URL).toBe('https://voicelog-production.up.railway.app');
+    expect(config.API_BASE_URL).toBe('');
+    expect(config.MEDIA_API_BASE_URL).toBe('');
+    expect(config.APP_DATA_PROVIDER).toBe('local');
+    expect(config.remoteApiEnabled()).toBe(false);
   });
 
   it('allows overriding the direct media API base URL', async () => {
@@ -70,13 +77,19 @@ describe('services/config resolveApiBaseUrl', () => {
     expect(config.API_BASE_URL).toBe('http://127.0.0.1:4000');
   });
 
-  it('forces remote data provider on hosted HTTPS runtime so new accounts use Supabase-backed API', async () => {
+  it('uses same-origin API routing on the stable production Vercel domain', async () => {
     vi.stubEnv('VITE_DATA_PROVIDER', 'local');
     vi.stubEnv('REACT_APP_DATA_PROVIDER', 'local');
+    vi.stubEnv('VITE_API_BASE_URL', '');
+    vi.stubEnv('REACT_APP_API_BASE_URL', '');
+    vi.stubEnv('VITE_MEDIA_API_BASE_URL', '');
+    vi.stubEnv('REACT_APP_MEDIA_API_BASE_URL', '');
     setWindowOrigin('https://voicelog-audiorecorder.vercel.app');
 
     const config = await import('./config');
 
+    expect(config.API_BASE_URL).toBe('https://voicelog-audiorecorder.vercel.app');
+    expect(config.MEDIA_API_BASE_URL).toBe('https://voicelog-audiorecorder.vercel.app');
     expect(config.APP_DATA_PROVIDER).toBe('remote');
     expect(config.remoteApiEnabled()).toBe(true);
   });

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -31,7 +31,7 @@ function readEnv(key: string, fallback = '') {
   return fallback;
 }
 
-const RAILWAY_API_BASE_URL = 'https://voicelog-production.up.railway.app';
+const STABLE_VERCEL_HOSTNAME = 'voicelog-audiorecorder.vercel.app';
 
 function readMode(value, fallback = 'local') {
   const normalized = String(value || '')
@@ -40,11 +40,28 @@ function readMode(value, fallback = 'local') {
   return normalized === 'remote' ? 'remote' : fallback;
 }
 
-function isHostedPreviewRuntime() {
+function isStableProductionVercelRuntime() {
   if (typeof window === 'undefined') {
     return false;
   }
-  return /^https:\/\/[a-z0-9.-]+\.vercel\.app$/i.test(String(window.location.origin || ''));
+  const location = window.location;
+  return (
+    String(location?.protocol || '') === 'https:' &&
+    String(location?.hostname || '').toLowerCase() === STABLE_VERCEL_HOSTNAME
+  );
+}
+
+function isHostedVercelPreviewRuntime() {
+  if (typeof window === 'undefined') {
+    return false;
+  }
+  const location = window.location;
+  const hostname = String(location?.hostname || '').toLowerCase();
+  return (
+    String(location?.protocol || '') === 'https:' &&
+    hostname.endsWith('.vercel.app') &&
+    hostname !== STABLE_VERCEL_HOSTNAME
+  );
 }
 
 function isHostedBrowserRuntime() {
@@ -66,6 +83,19 @@ function isHostedBrowserRuntime() {
 function readDefaultApiBaseUrl() {
   const env = (import.meta as any).env;
   const isProd = Boolean(env?.PROD);
+
+  if (isHostedVercelPreviewRuntime()) {
+    return '';
+  }
+
+  if (
+    isStableProductionVercelRuntime() &&
+    typeof window !== 'undefined' &&
+    window.location?.origin
+  ) {
+    return window.location.origin;
+  }
+
   if (!isProd) {
     if (typeof window !== 'undefined' && window.location?.hostname) {
       const hostname = window.location.hostname;
@@ -76,8 +106,8 @@ function readDefaultApiBaseUrl() {
     return 'http://localhost:4000';
   }
 
-  // In deployed frontend builds we proxy API paths through the same origin.
-  if (typeof window !== 'undefined' && window.location?.origin) {
+  // Stable production and custom hosted frontends proxy API paths through the same origin.
+  if (isProd && typeof window !== 'undefined' && window.location?.origin) {
     return window.location.origin;
   }
 
@@ -88,10 +118,6 @@ function resolveApiBaseUrl() {
   const configuredValue = String(
     readEnv('VITE_API_BASE_URL') || readEnv('REACT_APP_API_BASE_URL') || ''
   ).trim();
-
-  if (isHostedPreviewRuntime()) {
-    return configuredValue || RAILWAY_API_BASE_URL;
-  }
 
   return configuredValue || readDefaultApiBaseUrl();
 }
@@ -105,7 +131,7 @@ function hasExplicitApiBaseUrl() {
 const RAW_API_BASE_URL = String(resolveApiBaseUrl()).trim();
 
 export const APP_DATA_PROVIDER = readMode(
-  isHostedBrowserRuntime()
+  isHostedBrowserRuntime() && RAW_API_BASE_URL
     ? 'remote'
     : hasExplicitApiBaseUrl()
       ? 'remote'
@@ -120,9 +146,7 @@ export const MEDIA_PIPELINE_PROVIDER = readMode(
 
 export const API_BASE_URL = RAW_API_BASE_URL;
 export const MEDIA_API_BASE_URL = String(
-  readEnv('VITE_MEDIA_API_BASE_URL') ||
-    readEnv('REACT_APP_MEDIA_API_BASE_URL') ||
-    (isHostedPreviewRuntime() ? RAILWAY_API_BASE_URL : API_BASE_URL)
+  readEnv('VITE_MEDIA_API_BASE_URL') || readEnv('REACT_APP_MEDIA_API_BASE_URL') || API_BASE_URL
 ).trim();
 
 export function apiBaseUrlConfigured() {


### PR DESCRIPTION
## Summary
- Make the API base URL strategy explicit for Vercel and Railway.
- Stable production Vercel (`https://voicelog-audiorecorder.vercel.app`) now uses same-origin API routing, matching `vercel.json` rewrites.
- Vercel preview deployments no longer silently fall back to production Railway; they require explicit `VITE_API_BASE_URL` / `REACT_APP_API_BASE_URL` to talk to a backend.
- Keep manual API URL overrides as highest priority.
- Document the model in `.env.example` and `docs/ops/DEPLOYMENT.md`.

Closes #1307

## Before / After
- Before: code comments described same-origin routing, but any `*.vercel.app` host without env config silently used `https://voicelog-production.up.railway.app` directly.
- After: stable production Vercel is same-origin; preview deployments require an explicit backend URL; local development still defaults to `localhost/127.0.0.1:4000`.

## Validation
- `corepack pnpm exec vitest run src/services/config.test.ts --coverage.enabled=false` ? passed, 9 tests.
- `corepack pnpm exec vitest run src/services/config.test.ts src/services/httpClient.test.ts src/services/mediaService.test.ts --coverage.enabled=false` ? passed, 65 tests / 14 skipped.
- `corepack pnpm run typecheck` ? passed.
- `corepack pnpm exec prettier --check src/services/config.ts src/services/config.test.ts .env.example docs/ops/DEPLOYMENT.md` ? passed.
- `corepack pnpm run audit:mojibake` ? passed.
- Pre-push release guard ? passed: server 1468 passed / 82 skipped, frontend guard 81 passed, build warning audit passed.

## Notes / Risks
- Preview deployments without `VITE_API_BASE_URL` now run without remote API enabled. This is intentional for #1307 so previews do not accidentally target production Railway.
- This PR does not change `vercel.json` rewrite destinations. The current production Railway public-domain routing blocker is still tracked in #1436.
