### PR TITLE
fix: use resolved upload dir for client error reports (#1445)

### DIFF
--- a/server/http/app-routes.ts
+++ b/server/http/app-routes.ts
@@ -277,5 +277,8 @@ export function registerAppRoutes(
   app.route('/digest', createDigestRoutes(services, middlewares));
   app.route('/integrations/google', createGoogleIntegrationRoutes(services, middlewares));
   app.route('/ai', createAiRoutes(services, middlewares));
-  app.route('/api/client-errors', createClientErrorRoutes());
+  app.route(
+    '/api/client-errors',
+    createClientErrorRoutes({ uploadDir: services.config?.uploadDir || services.db?.uploadDir })
+  );
 }

--- a/server/routes/clientErrors.ts
+++ b/server/routes/clientErrors.ts
@@ -19,12 +19,16 @@ const MAX_STORED_ERRORS = 500;
 const MAX_BODY_ERRORS = 50;
 const DEFAULT_CLIENT_ERROR_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
+interface ClientErrorRoutesOptions {
+  uploadDir?: string;
+}
+
 // In-memory store with periodic file persistence
 let errorStore: ClientErrorEntry[] = [];
 let storeLoaded = false;
 
-function getErrorsFilePath(): string {
-  const dataDir = process.env.VOICELOG_UPLOAD_DIR || './server/data/uploads';
+function getErrorsFilePath(options: ClientErrorRoutesOptions = {}): string {
+  const dataDir = options.uploadDir || process.env.VOICELOG_UPLOAD_DIR || './server/data/uploads';
   return path.resolve(dataDir, 'client-errors.json');
 }
 
@@ -59,10 +63,10 @@ function enforceMaxStoredErrors(errors: ClientErrorEntry[]): ClientErrorEntry[] 
   return errors.slice(-MAX_STORED_ERRORS);
 }
 
-function loadFromDisk(): void {
+function loadFromDisk(options: ClientErrorRoutesOptions = {}): void {
   if (storeLoaded) return;
   try {
-    const filePath = getErrorsFilePath();
+    const filePath = getErrorsFilePath(options);
     if (fs.existsSync(filePath)) {
       const raw = fs.readFileSync(filePath, 'utf-8');
       const parsed = JSON.parse(raw);
@@ -79,9 +83,9 @@ function loadFromDisk(): void {
   storeLoaded = true;
 }
 
-function persistToDisk(): void {
+function persistToDisk(options: ClientErrorRoutesOptions = {}): void {
   try {
-    const filePath = getErrorsFilePath();
+    const filePath = getErrorsFilePath(options);
     const dir = path.dirname(filePath);
     if (!fs.existsSync(dir)) {
       fs.mkdirSync(dir, { recursive: true });
@@ -98,7 +102,7 @@ export function _resetStoreForTest(): void {
   storeLoaded = true; // skip disk read in tests
 }
 
-export function createClientErrorRoutes() {
+export function createClientErrorRoutes(options: ClientErrorRoutesOptions = {}) {
   const router = new Hono();
 
   // POST /api/client-errors — receive error reports from frontend
@@ -135,7 +139,7 @@ export function createClientErrorRoutes() {
         return c.json({ ok: true, received: 0 });
       }
 
-      loadFromDisk();
+      loadFromDisk(options);
       const wasCleaned = cleanupExpiredClientErrors();
 
       // Deduplicate by id
@@ -144,9 +148,9 @@ export function createClientErrorRoutes() {
 
       if (newErrors.length > 0) {
         errorStore = enforceMaxStoredErrors([...errorStore, ...newErrors]);
-        persistToDisk();
+        persistToDisk(options);
       } else if (wasCleaned) {
-        persistToDisk();
+        persistToDisk(options);
       }
       if (newErrors.length > 0) {
         logger.info(`[ClientErrors] Received ${newErrors.length} new error(s) from client.`);
@@ -164,10 +168,10 @@ export function createClientErrorRoutes() {
 
   // GET /api/client-errors — retrieve stored errors
   router.get('/', (c) => {
-    loadFromDisk();
+    loadFromDisk(options);
     const wasCleaned = cleanupExpiredClientErrors();
     if (wasCleaned) {
-      persistToDisk();
+      persistToDisk(options);
     }
     return c.json({ count: errorStore.length, errors: errorStore });
   });
@@ -175,7 +179,7 @@ export function createClientErrorRoutes() {
   // DELETE /api/client-errors — clear stored errors
   router.delete('/', (c) => {
     errorStore = [];
-    persistToDisk();
+    persistToDisk(options);
     return c.json({ ok: true, cleared: true });
   });
 

--- a/server/tests/routes/clientErrors.test.ts
+++ b/server/tests/routes/clientErrors.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Hono } from 'hono';
+import path from 'node:path';
 import { createClientErrorRoutes, _resetStoreForTest } from '../../routes/clientErrors.ts';
 
 describe('clientErrors route', () => {
@@ -211,5 +212,45 @@ describe('clientErrors route', () => {
     for (let retainedId = 11; retainedId <= 510; retainedId += 1) {
       expect(storedIds.has(retainedId)).toBe(true);
     }
+  });
+
+  it('writes client error store to the resolved upload dir instead of stale VOICELOG_UPLOAD_DIR', async () => {
+    const fallbackUploadDir = path.join(process.cwd(), '.tmp-client-errors-fallback');
+    const staleEnvUploadDir = path.join(process.cwd(), '.tmp-client-errors-env');
+    const fsMocks = (global as any).__mockFs;
+    fsMocks.writeFileSync.mockClear();
+
+    vi.stubEnv('VOICELOG_UPLOAD_DIR', staleEnvUploadDir);
+    _resetStoreForTest();
+
+    const configuredApp = new Hono();
+    configuredApp.route(
+      '/api/client-errors',
+      createClientErrorRoutes({ uploadDir: fallbackUploadDir })
+    );
+
+    const res = await configuredApp.request('/api/client-errors', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        id: 'issue-1445',
+        type: 'runtime',
+        message: 'Railway client error persistence regression',
+        timestamp: new Date().toISOString(),
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({ ok: true, received: 1 });
+    expect(fsMocks.writeFileSync).toHaveBeenCalledWith(
+      path.resolve(fallbackUploadDir, 'client-errors.json'),
+      expect.any(String),
+      'utf-8'
+    );
+    expect(fsMocks.writeFileSync).not.toHaveBeenCalledWith(
+      path.resolve(staleEnvUploadDir, 'client-errors.json'),
+      expect.any(String),
+      'utf-8'
+    );
   });
 });


### PR DESCRIPTION
## Summary
- Fixes Railway client-error persistence by using the app's resolved writable upload directory instead of reading raw `VOICELOG_UPLOAD_DIR` inside the route.
- Keeps the existing env fallback for standalone route usage/tests.
- Adds regression coverage for the #1445 production pattern where `VOICELOG_UPLOAD_DIR` points at a stale/unwritable path but the app has already resolved a fallback upload dir.

## Root cause
Railway logs showed the database bootstrap correctly falling back from `/data/uploads` to `/app/server/data/uploads`, but `/api/client-errors` still persisted to `/data/uploads/client-errors.json` because `server/routes/clientErrors.ts` bypassed `services.config.uploadDir` and read the env var directly.

## Validation
- `corepack pnpm exec vitest run -c server/vitest.config.ts server/tests/routes/clientErrors.test.ts --coverage.enabled=false` — passed, 10 tests
- `corepack pnpm run typecheck:server` — passed
- `corepack pnpm exec prettier --check server/routes/clientErrors.ts server/http/app-routes.ts server/tests/routes/clientErrors.test.ts` — passed
- `corepack pnpm run audit:mojibake` — passed
- pre-push `test:release:guard` — passed: server suite 101 files / 1469 tests, frontend guard 3 files / 81 tests, build warning audit and Vite build

## Risks
- This fixes the path selection bug. It does not change Railway volume permissions themselves; production should still verify logs after deploy to confirm the monitor group stops recurring.

Closes #1445