### PR TITLE
fix: define canonical task lifecycle status (#1377)

### DIFF
--- a/docs/testing/ui-action-contracts.json
+++ b/docs/testing/ui-action-contracts.json
@@ -88,7 +88,7 @@
       "screen": "Tasks",
       "file": "src/TasksTab.tsx",
       "expectedActionCount": 3,
-      "fingerprint": "a3e432fadebfcbb2",
+      "fingerprint": "d77070c727c5105c",
       "contractStatus": "covered",
       "testFiles": ["src/TasksTab.test.tsx"],
       "testEvidence": [

--- a/src/TasksTab.test.tsx
+++ b/src/TasksTab.test.tsx
@@ -198,10 +198,13 @@ describe('TasksTab', () => {
 
     fireEvent.change(screen.getByPlaceholderText(/Szukaj/i), { target: { value: 'wysoki' } });
 
-    await waitFor(() => {
-      expect(screen.getByText('High priority review')).toBeInTheDocument();
-      expect(screen.queryByText('Low priority cleanup')).not.toBeInTheDocument();
-    });
+    await waitFor(
+      () => {
+        expect(screen.getByText('High priority review')).toBeInTheDocument();
+        expect(screen.queryByText('Low priority cleanup')).not.toBeInTheDocument();
+      },
+      { timeout: 5000 }
+    );
   });
 
   test('shows richer smart lists similar to task apps', () => {

--- a/src/TasksTab.tsx
+++ b/src/TasksTab.tsx
@@ -3,7 +3,12 @@ import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } f
 import { CheckCircle2, RotateCcw, Trash2, X } from 'lucide-react';
 import { useToast } from './shared/Toast';
 import { PageShell, SplitPane } from './ui/LayoutPrimitives';
-import { buildTaskGroups, taskListStats } from './lib/tasks';
+import {
+  buildTaskGroups,
+  getTaskLifecycleStatus,
+  TASK_LIFECYCLE_STATUSES,
+  taskListStats,
+} from './lib/tasks';
 import TaskDetailsPanel from './tasks/TaskDetailsPanel';
 import TasksSidebar from './tasks/TasksSidebar';
 import TasksWorkspaceView from './tasks/TasksWorkspaceView';
@@ -118,12 +123,18 @@ export default function TasksTab({
   }, [selectedListId]);
 
   const taskGroups = useMemo(() => buildTaskGroups(tasks), [tasks]);
-  const stats = useMemo(() => taskListStats(tasks), [tasks]);
+  const stats = useMemo(() => taskListStats(tasks, boardColumns), [boardColumns, tasks]);
   const sidebarLists = useMemo(() => buildSidebarLists(tasks, boardColumns), [tasks, boardColumns]);
 
   const visibleTasks = useMemo(() => {
     const filtered = applyMainListFilter(tasks, selectedListId, boardColumns).filter((task) => {
-      if (task._softDeleted) return false;
+      const lifecycle = getTaskLifecycleStatus(task, boardColumns, tasks);
+      if (
+        lifecycle === TASK_LIFECYCLE_STATUSES.DELETE_PENDING ||
+        lifecycle === TASK_LIFECYCLE_STATUSES.ARCHIVED
+      ) {
+        return false;
+      }
       if (
         ownerFilter === 'me' &&
         !(
@@ -176,7 +187,10 @@ export default function TasksTab({
     tasks,
   ]);
 
-  const visibleStats = useMemo(() => taskListStats(visibleTasks), [visibleTasks]);
+  const visibleStats = useMemo(
+    () => taskListStats(visibleTasks, boardColumns),
+    [boardColumns, visibleTasks]
+  );
 
   useEffect(() => {
     if (!visibleTasks.length) {
@@ -255,7 +269,13 @@ export default function TasksTab({
     () =>
       boardColumns.map((column) => ({
         ...column,
-        tasks: visibleTasks.filter((task) => task.status === column.id),
+        tasks: visibleTasks.filter((task) => {
+          const lifecycle = getTaskLifecycleStatus(task, boardColumns, visibleTasks);
+          if (column.isDone) {
+            return lifecycle === TASK_LIFECYCLE_STATUSES.DONE;
+          }
+          return task.status === column.id && lifecycle !== TASK_LIFECYCLE_STATUSES.DONE;
+        }),
       })),
     [boardColumns, visibleTasks]
   );

--- a/src/lib/tasks.coverage.test.ts
+++ b/src/lib/tasks.coverage.test.ts
@@ -12,7 +12,9 @@ import {
   createTaskFromGoogle,
   DEFAULT_TASK_COLUMNS,
   extractMeetingTasks,
+  getTaskLifecycleStatus,
   nextRecurringDueDate,
+  TASK_LIFECYCLE_STATUSES,
   taskListStats,
   updateTaskColumns,
   upsertGoogleImportedTasks,
@@ -45,6 +47,48 @@ describe('tasks extra coverage', () => {
 
     const update = buildTaskReorderUpdate([], {});
     expect(update.order).toBe(-new Date('2026-03-01T00:00:00.000Z').getTime());
+  });
+
+  // ------------------------------------------------------------------
+  // Issue #1377 - canonical task lifecycle status
+  // Date: 2026-07-06
+  // Bug: task lifecycle was inferred differently from status, completed,
+  //      archived, soft-delete, dependency and Google conflict fields.
+  // Fix: getTaskLifecycleStatus centralizes the lifecycle mapping.
+  // ------------------------------------------------------------------
+  test('maps canonical task lifecycle statuses', () => {
+    const columns = [
+      { id: 'todo', label: 'Todo', isDone: false },
+      { id: 'in_progress', label: 'Doing', isDone: false },
+      { id: 'waiting', label: 'Waiting', isDone: false },
+      { id: 'done', label: 'Done', isDone: true },
+    ];
+    const tasks = [
+      { id: 'active', status: 'todo', completed: false },
+      { id: 'in-progress', status: 'in_progress', completed: false },
+      { id: 'waiting', status: 'waiting', completed: false },
+      { id: 'dependency', status: 'todo', completed: false },
+      { id: 'blocked', status: 'todo', completed: false, dependencies: ['dependency'] },
+      { id: 'done-by-completed', status: 'todo', completed: true },
+      { id: 'done-by-column', status: 'done', completed: false },
+      { id: 'archived', status: 'done', completed: true, archived: true },
+      { id: 'delete-pending', status: 'done', completed: true, _softDeleted: true },
+      { id: 'conflict', status: 'todo', completed: false, googleSyncStatus: 'conflict' },
+    ];
+
+    expect(getTaskLifecycleStatus(tasks[0], columns, tasks)).toBe(TASK_LIFECYCLE_STATUSES.ACTIVE);
+    expect(getTaskLifecycleStatus(tasks[1], columns, tasks)).toBe(
+      TASK_LIFECYCLE_STATUSES.IN_PROGRESS
+    );
+    expect(getTaskLifecycleStatus(tasks[2], columns, tasks)).toBe(TASK_LIFECYCLE_STATUSES.WAITING);
+    expect(getTaskLifecycleStatus(tasks[4], columns, tasks)).toBe(TASK_LIFECYCLE_STATUSES.BLOCKED);
+    expect(getTaskLifecycleStatus(tasks[5], columns, tasks)).toBe(TASK_LIFECYCLE_STATUSES.DONE);
+    expect(getTaskLifecycleStatus(tasks[6], columns, tasks)).toBe(TASK_LIFECYCLE_STATUSES.DONE);
+    expect(getTaskLifecycleStatus(tasks[7], columns, tasks)).toBe(TASK_LIFECYCLE_STATUSES.ARCHIVED);
+    expect(getTaskLifecycleStatus(tasks[8], columns, tasks)).toBe(
+      TASK_LIFECYCLE_STATUSES.DELETE_PENDING
+    );
+    expect(getTaskLifecycleStatus(tasks[9], columns, tasks)).toBe(TASK_LIFECYCLE_STATUSES.CONFLICT);
   });
 
   test('nextRecurringDueDate advances based on recurrence', () => {
@@ -612,7 +656,7 @@ describe('tasks extra coverage', () => {
     expect(stats.scheduled).toBe(4);
     expect(stats.unassigned).toBe(2);
     expect(stats.waiting).toBe(1);
-    expect(stats.inProgress).toBe(1);
+    expect(stats.inProgress).toBe(0);
     expect(stats.grouped).toBe(1);
     expect(stats.recurring).toBe(1);
     expect(stats.blocked).toBe(1);

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -26,6 +26,17 @@ export const TASK_RECURRENCE_OPTIONS = [
   { id: 'custom', label: 'Wlasny interwal' },
 ];
 
+export const TASK_LIFECYCLE_STATUSES = {
+  ACTIVE: 'active',
+  IN_PROGRESS: 'in_progress',
+  WAITING: 'waiting',
+  BLOCKED: 'blocked',
+  DONE: 'done',
+  ARCHIVED: 'archived',
+  DELETE_PENDING: 'delete-pending',
+  CONFLICT: 'conflict',
+};
+
 function safeArray(value) {
   return Array.isArray(value) ? value : [];
 }
@@ -527,6 +538,48 @@ export function getTaskDependencyDetails(task, tasks) {
     unresolved,
     blocking: unresolved.length > 0,
   };
+}
+
+export function getTaskLifecycleStatus(
+  task: any,
+  columns: any[] = DEFAULT_TASK_COLUMNS,
+  allTasks: any[] = []
+) {
+  if (!task) {
+    return TASK_LIFECYCLE_STATUSES.ACTIVE;
+  }
+
+  if (task._softDeleted) {
+    return TASK_LIFECYCLE_STATUSES.DELETE_PENDING;
+  }
+
+  if (task.archived) {
+    return TASK_LIFECYCLE_STATUSES.ARCHIVED;
+  }
+
+  if (task.googleSyncConflict || task.googleSyncStatus === 'conflict') {
+    return TASK_LIFECYCLE_STATUSES.CONFLICT;
+  }
+
+  const normalizedColumns = normalizeColumns(columns);
+  const status = sanitizeStatus(normalizedColumns, task.status);
+  if (task.completed || isDoneStatus(normalizedColumns, status)) {
+    return TASK_LIFECYCLE_STATUSES.DONE;
+  }
+
+  if (getTaskDependencyDetails(task, allTasks).blocking) {
+    return TASK_LIFECYCLE_STATUSES.BLOCKED;
+  }
+
+  if (status === 'waiting') {
+    return TASK_LIFECYCLE_STATUSES.WAITING;
+  }
+
+  if (status === 'in_progress') {
+    return TASK_LIFECYCLE_STATUSES.IN_PROGRESS;
+  }
+
+  return TASK_LIFECYCLE_STATUSES.ACTIVE;
 }
 
 export function validateTaskDependencies(taskId, dependencyIds, tasks) {
@@ -1290,13 +1343,24 @@ export function buildTasksFromMeetings(
   });
 }
 
-export function taskListStats(tasks) {
+export function taskListStats(tasks, columns = DEFAULT_TASK_COLUMNS) {
   const list = safeArray(tasks);
+  const lifecycleByTaskId = new Map(
+    list.map((task) => [task.id, getTaskLifecycleStatus(task, columns, list)])
+  );
+  const hasLifecycle = (task, lifecycle) => lifecycleByTaskId.get(task.id) === lifecycle;
+  const isDoneTask = (task) => hasLifecycle(task, TASK_LIFECYCLE_STATUSES.DONE);
+  const isOpenTask = (task) =>
+    ![
+      TASK_LIFECYCLE_STATUSES.DONE,
+      TASK_LIFECYCLE_STATUSES.ARCHIVED,
+      TASK_LIFECYCLE_STATUSES.DELETE_PENDING,
+    ].includes(lifecycleByTaskId.get(task.id));
   const today = new Date();
   today.setHours(0, 0, 0, 0);
   const weekEdge = new Date(today);
   weekEdge.setDate(today.getDate() + 7);
-  const completedCount = list.filter((task) => task.completed).length;
+  const completedCount = list.filter(isDoneTask).length;
   const allSubtasks = list.flatMap((task) => safeArray(task.subtasks));
   const byPriority = TASK_PRIORITIES.reduce(
     (accumulator, priority) => ({
@@ -1336,22 +1400,22 @@ export function taskListStats(tasks) {
     assigned: list.filter((task) => task.assignedToMe).length,
     important: list.filter((task) => task.important).length,
     completed: completedCount,
-    open: list.filter((task) => !task.completed).length,
+    open: list.filter(isOpenTask).length,
     manual: list.filter((task) => task.sourceType === 'manual').length,
     overdue: list.filter((task) => {
-      if (!task.dueDate || task.completed) {
+      if (!task.dueDate || !isOpenTask(task)) {
         return false;
       }
       return new Date(task.dueDate).getTime() < today.getTime();
     }).length,
     dueToday: list.filter((task) => {
-      if (!task.dueDate || task.completed) {
+      if (!task.dueDate || !isOpenTask(task)) {
         return false;
       }
       return new Date(task.dueDate).toDateString() === today.toDateString();
     }).length,
     dueThisWeek: list.filter((task) => {
-      if (!task.dueDate || task.completed) {
+      if (!task.dueDate || !isOpenTask(task)) {
         return false;
       }
       const dueDate = new Date(task.dueDate).getTime();
@@ -1361,11 +1425,12 @@ export function taskListStats(tasks) {
     unassigned: list.filter(
       (task) => !(task.assignedTo || []).length && (!task.owner || task.owner === 'Nieprzypisane')
     ).length,
-    waiting: list.filter((task) => task.status === 'waiting').length,
-    inProgress: list.filter((task) => task.status === 'in_progress').length,
+    waiting: list.filter((task) => hasLifecycle(task, TASK_LIFECYCLE_STATUSES.WAITING)).length,
+    inProgress: list.filter((task) => hasLifecycle(task, TASK_LIFECYCLE_STATUSES.IN_PROGRESS))
+      .length,
     grouped: list.filter((task) => Boolean(task.group)).length,
     recurring: list.filter((task) => Boolean(task.recurrence)).length,
-    blocked: list.filter((task) => getTaskDependencyDetails(task, list).blocking).length,
+    blocked: list.filter((task) => hasLifecycle(task, TASK_LIFECYCLE_STATUSES.BLOCKED)).length,
     commented: list.filter((task) => (task.comments || []).length).length,
     subtasksOpen: allSubtasks.filter((subtask) => !subtask.completed).length,
     subtasksCompleted: allSubtasks.filter((subtask) => subtask.completed).length,

--- a/src/tasks/TaskDetailsPanel.test.tsx
+++ b/src/tasks/TaskDetailsPanel.test.tsx
@@ -71,7 +71,7 @@ describe('TaskDetailsPanel', () => {
   it('toggles task completion status', async () => {
     render(<TaskDetailsPanel {...mockProps} />);
 
-    const checkbox = screen.getByRole('button', { name: /Oznacz jako ukończone/i });
+    const checkbox = screen.getByRole('button', { name: /Oznacz jako uko(?:n|ń)czone/i });
     fireEvent.click(checkbox);
 
     expect(mockProps.onUpdateTask).toHaveBeenCalledWith('task-1', { completed: true });

--- a/src/tasks/TaskDetailsPanel.tsx
+++ b/src/tasks/TaskDetailsPanel.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useState } from 'react';
 import { AlignLeft, History, Link, Trash2 } from 'lucide-react';
 import { formatDateTime } from '../lib/storage';
+import { getTaskLifecycleStatus, TASK_LIFECYCLE_STATUSES } from '../lib/tasks';
 import { toInputDateTime } from './taskViewUtils';
 import { Input } from '../ui/Input';
 import MentionTextarea from '../shared/MentionTextarea';
@@ -113,6 +114,11 @@ function TaskDetailsPanel(props: any) {
   }
 
   const selectedTaskDraft = buildSelectedTaskDraft(selectedTask, boardColumns);
+  const selectedTaskLifecycle = getTaskLifecycleStatus(selectedTask, boardColumns, [selectedTask]);
+  const selectedTaskDone = selectedTaskLifecycle === TASK_LIFECYCLE_STATUSES.DONE;
+  const selectedTaskDoneLabel = selectedTaskDone
+    ? 'Oznacz jako nieukonczone'
+    : 'Oznacz jako ukonczone';
   const peopleSuggestions = normalizePeopleSuggestions(peopleOptions);
   const sharedTaskForm = (
     <TaskCreateForm
@@ -152,17 +158,12 @@ function TaskDetailsPanel(props: any) {
             <div className="todo-detail-title-row">
               <button
                 type="button"
-                className={
-                  selectedTask.completed ? 'todo-task-checkbox checked' : 'todo-task-checkbox'
-                }
-                aria-label={
-                  selectedTask.completed ? 'Oznacz jako nieukończone' : 'Oznacz jako ukończone'
-                }
-                onClick={() =>
-                  onUpdateTask(selectedTask.id, { completed: !selectedTask.completed })
-                }
+                className={selectedTaskDone ? 'todo-task-checkbox checked' : 'todo-task-checkbox'}
+                title={selectedTaskDoneLabel}
+                aria-label={selectedTaskDoneLabel}
+                onClick={() => onUpdateTask(selectedTask.id, { completed: !selectedTaskDone })}
               >
-                {selectedTask.completed ? '✓' : ''}
+                {selectedTaskDone ? '✓' : ''}
               </button>
               <span className="todo-detail-current-title">{selectedTask.title}</span>
             </div>

--- a/src/tasks/TaskKanbanView.tsx
+++ b/src/tasks/TaskKanbanView.tsx
@@ -1,5 +1,9 @@
 import { memo, useState, useEffect } from 'react';
-import { getTaskDependencyDetails } from '../lib/tasks';
+import {
+  getTaskDependencyDetails,
+  getTaskLifecycleStatus,
+  TASK_LIFECYCLE_STATUSES,
+} from '../lib/tasks';
 import { canDrop, formatListDueDate, handleCardKeyDown, writeDragTask } from './taskViewUtils';
 import './TaskKanbanViewStyles.css';
 import TagBadge from '../shared/TagBadge';
@@ -155,6 +159,8 @@ function KanbanCard({
   allTasks,
 }) {
   const dependencyState = getTaskDependencyDetails(task, allTasks);
+  const taskLifecycle = getTaskLifecycleStatus(task, boardColumns, allTasks);
+  const taskDone = taskLifecycle === TASK_LIFECYCLE_STATUSES.DONE;
   const subtasks = task.subtasks || [];
   const assignees = task.assignedTo?.length ? task.assignedTo : task.owner ? [task.owner] : [];
   const tags = task.tags || [];
@@ -165,7 +171,7 @@ function KanbanCard({
         role="button"
         tabIndex={0}
         draggable
-        className={`todo-kanban-card${isActive ? ' active' : ''}${task.completed ? ' completed' : ''}${dragTaskId === task.id ? ' dragging' : ''}`}
+        className={`todo-kanban-card${isActive ? ' active' : ''}${taskDone ? ' completed' : ''}${dragTaskId === task.id ? ' dragging' : ''}`}
         data-selected={isSelected}
         title="Kliknij aby otworzyc szczegoly. Zlap i przeciagnij, aby zmienic kolumne."
         onDragStart={(event) => {
@@ -203,11 +209,11 @@ function KanbanCard({
           <div className="todo-kanban-title">
             <button
               type="button"
-              className={`todo-task-circle${task.completed ? ' completed' : ''}`}
-              aria-label={task.completed ? 'Otworz ponownie' : 'Zakoncz zadanie'}
+              className={`todo-task-circle${taskDone ? ' completed' : ''}`}
+              aria-label={taskDone ? 'Otworz ponownie' : 'Zakoncz zadanie'}
               onClick={(event) => {
                 event.stopPropagation();
-                onUpdateTask(task.id, { completed: !task.completed });
+                onUpdateTask(task.id, { completed: !taskDone });
               }}
             />
             <strong className="kanban-card-title">{task.title}</strong>

--- a/src/tasks/TaskListView.tsx
+++ b/src/tasks/TaskListView.tsx
@@ -13,11 +13,21 @@ import {
   UsersRound,
 } from 'lucide-react';
 import { canDrop, formatListDueDate, handleCardKeyDown, writeDragTask } from './taskViewUtils';
-import { getTaskAssigneeSummary } from '../lib/tasks';
+import {
+  getTaskAssigneeSummary,
+  getTaskLifecycleStatus,
+  TASK_LIFECYCLE_STATUSES,
+} from '../lib/tasks';
 
 const DEFAULT_SORT = 'due:asc';
 
-function statusLabel(task, boardColumns) {
+function statusLabel(task, boardColumns, allTasks = []) {
+  const lifecycle = getTaskLifecycleStatus(task, boardColumns, allTasks);
+  if (lifecycle === TASK_LIFECYCLE_STATUSES.BLOCKED) return 'Zablokowane';
+  if (lifecycle === TASK_LIFECYCLE_STATUSES.CONFLICT) return 'Konflikt';
+  if (lifecycle === TASK_LIFECYCLE_STATUSES.DELETE_PENDING) return 'Usuwanie';
+  if (lifecycle === TASK_LIFECYCLE_STATUSES.ARCHIVED) return 'Archiwum';
+  if (lifecycle === TASK_LIFECYCLE_STATUSES.DONE) return 'Zakonczone';
   const status = String(task.status || '').toLowerCase();
   if (status === 'todo') return 'Do zrobienia';
   if (status === 'in_progress') return 'W toku';
@@ -26,7 +36,15 @@ function statusLabel(task, boardColumns) {
   return boardColumns.find((column) => column.id === task.status)?.label || task.status;
 }
 
-function statusTone(task) {
+function statusTone(task, boardColumns, allTasks = []) {
+  const lifecycle = getTaskLifecycleStatus(task, boardColumns, allTasks);
+  if (lifecycle === TASK_LIFECYCLE_STATUSES.DONE) return 'completed';
+  if (
+    lifecycle === TASK_LIFECYCLE_STATUSES.BLOCKED ||
+    lifecycle === TASK_LIFECYCLE_STATUSES.CONFLICT
+  ) {
+    return 'review';
+  }
   const status = String(task.status || '').toLowerCase();
   if (status === 'in_progress') return 'in-progress';
   if (status === 'waiting') return 'review';
@@ -291,7 +309,7 @@ function TaskListView({
             <option value="">Zmień status</option>
             {boardColumns.map((column) => (
               <option key={column.id} value={column.id}>
-                {statusLabel({ status: column.id }, boardColumns)}
+                {statusLabel({ status: column.id }, boardColumns, allTasks)}
               </option>
             ))}
           </select>
@@ -402,8 +420,10 @@ function TaskListView({
                       </span>
 
                       <span className="todo-status-cell">
-                        <span className={`todo-status-badge ${statusTone(task)}`}>
-                          {statusLabel(task, boardColumns)}
+                        <span
+                          className={`todo-status-badge ${statusTone(task, boardColumns, allTasks)}`}
+                        >
+                          {statusLabel(task, boardColumns, allTasks)}
                         </span>
                       </span>
 

--- a/src/tasks/taskViewUtils.test.ts
+++ b/src/tasks/taskViewUtils.test.ts
@@ -276,7 +276,10 @@ describe('groupTasks', () => {
 /*  applyMainListFilter                                               */
 /* ------------------------------------------------------------------ */
 describe('applyMainListFilter', () => {
-  const columns = [{ id: 'col1' }, { id: 'col2' }];
+  const columns = [
+    { id: 'col1', isDone: false },
+    { id: 'col2', isDone: true },
+  ];
   const tasks = [
     {
       id: '1',
@@ -321,6 +324,28 @@ describe('applyMainListFilter', () => {
   });
   it('filters completed tasks', () => {
     expect(applyMainListFilter(tasks, 'smart:completed', columns)).toHaveLength(1);
+  });
+  it('uses lifecycle when filtering completed tasks and done columns', () => {
+    const lifecycleColumns = [
+      { id: 'col1', isDone: false },
+      { id: 'col2', isDone: true },
+    ];
+    const lifecycleTasks = [
+      { id: 'done-by-flag', completed: true, status: 'col1' },
+      { id: 'open', completed: false, status: 'col1' },
+    ];
+
+    expect(
+      applyMainListFilter(lifecycleTasks, 'smart:completed', lifecycleColumns).map(
+        (task) => task.id
+      )
+    ).toEqual(['done-by-flag']);
+    expect(
+      applyMainListFilter(lifecycleTasks, 'column:col2', lifecycleColumns).map((task) => task.id)
+    ).toEqual(['done-by-flag']);
+    expect(
+      applyMainListFilter(lifecycleTasks, 'column:col1', lifecycleColumns).map((task) => task.id)
+    ).toEqual(['open']);
   });
   it('filters overdue tasks', () => {
     const overdue = applyMainListFilter(tasks, 'smart:overdue', columns);

--- a/src/tasks/taskViewUtils.ts
+++ b/src/tasks/taskViewUtils.ts
@@ -1,4 +1,9 @@
-import { getTaskOrder, TASK_PRIORITIES } from '../lib/tasks';
+import {
+  getTaskLifecycleStatus,
+  getTaskOrder,
+  TASK_LIFECYCLE_STATUSES,
+  TASK_PRIORITIES,
+} from '../lib/tasks';
 
 export function safeArray(value) {
   return Array.isArray(value) ? value : [];
@@ -65,6 +70,39 @@ function statusLabel(status, boardColumns) {
   return boardColumns.find((column) => column.id === status)?.label || status;
 }
 
+function taskLifecycle(task, boardColumns, allTasks) {
+  return getTaskLifecycleStatus(task, boardColumns, allTasks);
+}
+
+function isOpenLifecycle(lifecycle) {
+  return ![
+    TASK_LIFECYCLE_STATUSES.DONE,
+    TASK_LIFECYCLE_STATUSES.ARCHIVED,
+    TASK_LIFECYCLE_STATUSES.DELETE_PENDING,
+  ].includes(lifecycle);
+}
+
+function isDoneColumn(column, boardColumns) {
+  if (!column) {
+    return false;
+  }
+  const id = String(column.id || '').toLowerCase();
+  const label = String(column.label || '').toLowerCase();
+  if (
+    column.isDone ||
+    id === 'done' ||
+    id === 'completed' ||
+    /(^|\s)(done|completed)($|\s)/.test(label) ||
+    label.includes('zakoncz') ||
+    label.includes('zakończ') ||
+    label.includes('ukoncz') ||
+    label.includes('ukończ')
+  ) {
+    return true;
+  }
+  return false;
+}
+
 export function buildSidebarLists(tasks, boardColumns) {
   const todayStart = new Date();
   todayStart.setHours(0, 0, 0, 0);
@@ -74,13 +112,13 @@ export function buildSidebarLists(tasks, boardColumns) {
   weekEnd.setDate(todayStart.getDate() + 7);
 
   const isDueToday = (task) => {
-    if (!task.dueDate || task.completed) return false;
+    if (!task.dueDate || !isOpenLifecycle(taskLifecycle(task, boardColumns, tasks))) return false;
     const due = new Date(task.dueDate).getTime();
     return due >= todayStart.getTime() && due < tomorrowStart.getTime();
   };
 
   const isDueThisWeek = (task) => {
-    if (!task.dueDate || task.completed) return false;
+    if (!task.dueDate || !isOpenLifecycle(taskLifecycle(task, boardColumns, tasks))) return false;
     const due = new Date(task.dueDate).getTime();
     return due >= todayStart.getTime() && due < weekEnd.getTime();
   };
@@ -136,7 +174,10 @@ export function buildSidebarLists(tasks, boardColumns) {
       label: 'Zaległe',
       icon: 'overdue',
       count: tasks.filter(
-        (task) => task.dueDate && !task.completed && new Date(task.dueDate).getTime() < Date.now()
+        (task) =>
+          task.dueDate &&
+          isOpenLifecycle(taskLifecycle(task, boardColumns, tasks)) &&
+          new Date(task.dueDate).getTime() < Date.now()
       ).length,
     },
     {
@@ -195,7 +236,9 @@ export function applyMainListFilter(tasks, mainListId, boardColumns) {
     const tomorrowStart = new Date(todayStart);
     tomorrowStart.setDate(todayStart.getDate() + 1);
     return tasks.filter((task) => {
-      if (!task.dueDate || task.completed) return false;
+      if (!task.dueDate || !isOpenLifecycle(taskLifecycle(task, boardColumns, tasks))) {
+        return false;
+      }
       const due = new Date(task.dueDate).getTime();
       return due >= todayStart.getTime() && due < tomorrowStart.getTime();
     });
@@ -207,14 +250,18 @@ export function applyMainListFilter(tasks, mainListId, boardColumns) {
     const weekEnd = new Date(todayStart);
     weekEnd.setDate(todayStart.getDate() + 7);
     return tasks.filter((task) => {
-      if (!task.dueDate || task.completed) return false;
+      if (!task.dueDate || !isOpenLifecycle(taskLifecycle(task, boardColumns, tasks))) {
+        return false;
+      }
       const due = new Date(task.dueDate).getTime();
       return due >= todayStart.getTime() && due < weekEnd.getTime();
     });
   }
 
   if (mainListId === 'smart:my_day') {
-    return tasks.filter((task) => task.myDay && !task.completed);
+    return tasks.filter(
+      (task) => task.myDay && isOpenLifecycle(taskLifecycle(task, boardColumns, tasks))
+    );
   }
 
   if (mainListId === 'smart:important') {
@@ -227,12 +274,17 @@ export function applyMainListFilter(tasks, mainListId, boardColumns) {
 
   if (mainListId === 'smart:overdue') {
     return tasks.filter(
-      (task) => task.dueDate && !task.completed && new Date(task.dueDate).getTime() < Date.now()
+      (task) =>
+        task.dueDate &&
+        isOpenLifecycle(taskLifecycle(task, boardColumns, tasks)) &&
+        new Date(task.dueDate).getTime() < Date.now()
     );
   }
 
   if (mainListId === 'smart:completed') {
-    return tasks.filter((task) => task.completed);
+    return tasks.filter(
+      (task) => taskLifecycle(task, boardColumns, tasks) === TASK_LIFECYCLE_STATUSES.DONE
+    );
   }
 
   if (mainListId === 'smart:assigned') {
@@ -241,8 +293,15 @@ export function applyMainListFilter(tasks, mainListId, boardColumns) {
 
   if (mainListId.startsWith('column:')) {
     const columnId = mainListId.slice('column:'.length);
-    if (boardColumns.some((column) => column.id === columnId)) {
-      return tasks.filter((task) => task.status === columnId);
+    const column = boardColumns.find((candidate) => candidate.id === columnId);
+    if (column) {
+      return tasks.filter((task) => {
+        const lifecycle = taskLifecycle(task, boardColumns, tasks);
+        if (isDoneColumn(column, boardColumns)) {
+          return lifecycle === TASK_LIFECYCLE_STATUSES.DONE;
+        }
+        return task.status === columnId && isOpenLifecycle(lifecycle);
+      });
     }
   }
 


### PR DESCRIPTION
## Summary
- Adds a canonical task lifecycle mapper for active, in-progress, waiting, blocked, done, archived, delete-pending, and conflict states.
- Applies the lifecycle consistently to task stats, sidebar filters, list view, Kanban cards, details panel, and done-column filtering.
- Adds regression coverage for #1377 lifecycle mapping and completed/done-column filtering.

## Validation
- `corepack pnpm run typecheck` - passed
- `corepack pnpm exec vitest run src/lib/tasks.coverage.test.ts src/lib/tasks2.test.ts src/tasks/taskViewUtils.test.ts src/hooks/useTaskOperations.test.ts src/TasksTab.test.tsx --coverage.enabled=false --reporter=dot` - passed, 108 tests
- `corepack pnpm exec vitest run src/lib/tasks.coverage.test.ts src/tasks/taskViewUtils.test.ts src/hooks/useTaskOperations.test.ts src/TasksTab.test.tsx --coverage.enabled=false --reporter=dot` - passed, 96 tests after final panel fix
- `corepack pnpm exec prettier --check src/TasksTab.tsx src/TasksTab.test.tsx src/lib/tasks.ts src/lib/tasks.coverage.test.ts src/tasks/taskViewUtils.ts src/tasks/taskViewUtils.test.ts src/tasks/TaskListView.tsx src/tasks/TaskKanbanView.tsx src/tasks/TaskDetailsPanel.tsx` - passed
- `corepack pnpm run audit:mojibake` - passed
- Push pre-push `pnpm run test:release:guard` - passed: server 101 files / 1468 tests passed, frontend guard 3 files / 81 tests passed, build-warning audit passed

## Residual Risk
- `src/TasksTab.test.tsx` still emits an existing React Suspense/act warning in the falsy create-task test, but the test passes and this PR does not change lazy-loading behavior.
- Local commands were run through the repo's temporary Node 22 release guard because the shell default is Node 24.

Closes #1377