### PR TITLE
fix: make recurring follow-ups idempotent (#1378)

### DIFF
--- a/src/hooks/useTaskOperations.test.ts
+++ b/src/hooks/useTaskOperations.test.ts
@@ -139,6 +139,134 @@ describe('useTaskOperations', () => {
     expect(stateNext.t2.completed).toBe(true);
   });
 
+  test('completing the same recurring task twice creates one follow-up', () => {
+    const recurringTask = {
+      id: 'recurring-source',
+      title: 'Recurring check-in',
+      dueDate: '2026-03-01T00:00:00.000Z',
+      recurrence: { frequency: 'daily', interval: 1 },
+      status: 'c1',
+      sourceType: 'manual',
+      history: [],
+      completed: false,
+      tags: [],
+      assignedTo: [],
+    };
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: [recurringTask] })
+    );
+
+    act(() => {
+      result.current.updateTask('recurring-source', { completed: true });
+      result.current.updateTask('recurring-source', { completed: true });
+    });
+
+    const firstUpdater = mockSetManualTasks.mock.calls[0][0];
+    const secondUpdater = mockSetManualTasks.mock.calls[1][0];
+    const firstNext = firstUpdater([recurringTask]);
+    const secondNext = secondUpdater(firstNext);
+    const generated = secondNext.filter(
+      (task: any) => task.id !== 'recurring-source' && task.dueDate === '2026-03-02T00:00:00.000Z'
+    );
+
+    expect(generated).toHaveLength(1);
+  });
+
+  test('bulk completing recurring tasks creates one follow-up per source task', () => {
+    const recurringTasks = [
+      {
+        id: 'recurring-source-1',
+        title: 'Daily one',
+        dueDate: '2026-03-01T00:00:00.000Z',
+        recurrence: { frequency: 'daily', interval: 1 },
+        status: 'c1',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+      },
+      {
+        id: 'recurring-source-2',
+        title: 'Daily two',
+        dueDate: '2026-03-01T00:00:00.000Z',
+        recurrence: { frequency: 'daily', interval: 1 },
+        status: 'c1',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+      },
+    ];
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: recurringTasks })
+    );
+
+    act(() => {
+      result.current.bulkUpdateTasks(['recurring-source-1', 'recurring-source-2'], {
+        completed: true,
+      });
+    });
+
+    const updater = mockSetManualTasks.mock.calls[0][0];
+    const next = updater(recurringTasks);
+    const generated = next.filter(
+      (task: any) =>
+        !task.id.startsWith('recurring-source-') && task.dueDate === '2026-03-02T00:00:00.000Z'
+    );
+
+    expect(generated).toHaveLength(2);
+    expect(new Set(generated.map((task: any) => task.recurrenceGeneratedFromTaskId))).toEqual(
+      new Set(['recurring-source-1', 'recurring-source-2'])
+    );
+  });
+
+  test('sync retry skips an already generated recurring occurrence', () => {
+    const recurringTask = {
+      id: 'recurring-source',
+      title: 'Retry-safe recurring task',
+      dueDate: '2026-03-01T00:00:00.000Z',
+      recurrence: { frequency: 'daily', interval: 1 },
+      status: 'c1',
+      sourceType: 'manual',
+      history: [],
+      completed: false,
+      tags: [],
+      assignedTo: [],
+    };
+    const existingOccurrence = {
+      id: 'existing-occurrence',
+      title: recurringTask.title,
+      dueDate: '2026-03-02T00:00:00.000Z',
+      recurrence: recurringTask.recurrence,
+      recurrenceParentId: 'recurring-source',
+      recurrenceGeneratedFromTaskId: 'recurring-source',
+      recurrenceOccurrenceDate: '2026-03-02T00:00:00.000Z',
+      status: 'c1',
+      sourceType: 'manual',
+      completed: false,
+    };
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: [recurringTask, existingOccurrence] })
+    );
+
+    act(() => {
+      result.current.updateTask('recurring-source', { completed: true });
+    });
+
+    const updater = mockSetManualTasks.mock.calls[0][0];
+    const next = updater([existingOccurrence, recurringTask]);
+    const generated = next.filter(
+      (task: any) =>
+        task.id !== 'recurring-source' &&
+        task.title === recurringTask.title &&
+        task.dueDate === '2026-03-02T00:00:00.000Z'
+    );
+
+    expect(generated).toHaveLength(1);
+  });
+
   test('addTaskColumn, changeTaskColumn, removeTaskColumn', () => {
     const { result } = renderHook(() => useTaskOperations(baseProps));
 

--- a/src/hooks/useTaskOperations.ts
+++ b/src/hooks/useTaskOperations.ts
@@ -11,6 +11,64 @@ import {
 } from '../lib/tasks';
 import { normalizeTaskUpdatePayload } from '../lib/appState';
 
+function normalizedText(value) {
+  return String(value || '').trim();
+}
+
+function sameJson(left, right) {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
+function isSameRecurringOccurrence(candidate, generatedTask) {
+  if (!candidate || !generatedTask) {
+    return false;
+  }
+
+  const occurrenceDate = normalizedText(generatedTask.recurrenceOccurrenceDate);
+  if (!occurrenceDate) {
+    return false;
+  }
+
+  const candidateOccurrenceDate =
+    normalizedText(candidate.recurrenceOccurrenceDate) || normalizedText(candidate.dueDate);
+  if (candidateOccurrenceDate !== occurrenceDate) {
+    return false;
+  }
+
+  const generatedFromTaskId = normalizedText(generatedTask.recurrenceGeneratedFromTaskId);
+  const parentId = normalizedText(generatedTask.recurrenceParentId);
+  const candidateGeneratedFromTaskId = normalizedText(candidate.recurrenceGeneratedFromTaskId);
+  const candidateParentId = normalizedText(candidate.recurrenceParentId);
+
+  if (generatedFromTaskId && candidateGeneratedFromTaskId === generatedFromTaskId) {
+    return true;
+  }
+  if (parentId && candidateParentId === parentId) {
+    return true;
+  }
+
+  return (
+    !candidateGeneratedFromTaskId &&
+    !candidateParentId &&
+    normalizedText(candidate.title) === normalizedText(generatedTask.title) &&
+    sameJson(candidate.recurrence, generatedTask.recurrence)
+  );
+}
+
+function prependUniqueRecurringTasks(previous, recurringTasks) {
+  const uniqueRecurringTasks: any[] = [];
+  (Array.isArray(recurringTasks) ? recurringTasks : []).filter(Boolean).forEach((recurringTask) => {
+    const exists =
+      previous.some((candidate) => isSameRecurringOccurrence(candidate, recurringTask)) ||
+      uniqueRecurringTasks.some((candidate) => isSameRecurringOccurrence(candidate, recurringTask));
+    if (!exists) {
+      uniqueRecurringTasks.push(recurringTask);
+    }
+  });
+
+  return uniqueRecurringTasks.length ? [...uniqueRecurringTasks, ...previous] : previous;
+}
+
 export default function useTaskOperations({
   currentUser,
   currentWorkspaceId,
@@ -89,17 +147,19 @@ export default function useTaskOperations({
     const { nextPayload, nextTask, recurringTask } = prepareTaskMutation(task, updates);
 
     if (task.sourceType === 'manual' || task.sourceType === 'google') {
-      setManualTasks((previous) => [
-        ...(recurringTask ? [recurringTask] : []),
-        ...previous.map((item) =>
-          item.id !== taskId
-            ? item
-            : {
-                ...item,
-                ...nextPayload,
-              }
-        ),
-      ]);
+      setManualTasks((previous) =>
+        prependUniqueRecurringTasks(
+          previous.map((item) =>
+            item.id !== taskId
+              ? item
+              : {
+                  ...item,
+                  ...nextPayload,
+                }
+          ),
+          recurringTask ? [recurringTask] : []
+        )
+      );
       return nextTask;
     }
 
@@ -112,7 +172,7 @@ export default function useTaskOperations({
     }));
 
     if (recurringTask) {
-      setManualTasks((previous) => [recurringTask, ...previous]);
+      setManualTasks((previous) => prependUniqueRecurringTasks(previous, [recurringTask]));
     }
 
     return nextTask;
@@ -188,19 +248,21 @@ export default function useTaskOperations({
     );
 
     if (manualPayloads.size) {
-      setManualTasks((previous) => [
-        ...recurringTasks,
-        ...previous.map((item) =>
-          manualPayloads.has(item.id)
-            ? {
-                ...item,
-                ...manualPayloads.get(item.id),
-              }
-            : item
-        ),
-      ]);
+      setManualTasks((previous) =>
+        prependUniqueRecurringTasks(
+          previous.map((item) =>
+            manualPayloads.has(item.id)
+              ? {
+                  ...item,
+                  ...manualPayloads.get(item.id),
+                }
+              : item
+          ),
+          recurringTasks
+        )
+      );
     } else if (recurringTasks.length) {
-      setManualTasks((previous) => [...recurringTasks, ...previous]);
+      setManualTasks((previous) => prependUniqueRecurringTasks(previous, recurringTasks));
     }
 
     if (Object.keys(derivedPayloads).length) {

--- a/src/lib/tasks.coverage.test.ts
+++ b/src/lib/tasks.coverage.test.ts
@@ -162,6 +162,7 @@ describe('tasks extra coverage', () => {
     vi.setSystemTime(new Date('2026-03-10T10:00:00.000Z'));
 
     const baseTask = {
+      id: 'task_recurring_source',
       title: 'Przygotuj demo',
       owner: 'Ola',
       assignedTo: ['Ola'],
@@ -200,9 +201,15 @@ describe('tasks extra coverage', () => {
 
     expect(recurring).not.toBeNull();
     expect(recurring.dueDate).toBe('2026-03-17T00:00:00.000Z');
+    expect(recurring.recurrenceParentId).toBe(baseTask.id);
+    expect(recurring.recurrenceGeneratedFromTaskId).toBe(baseTask.id);
+    expect(recurring.recurrenceOccurrenceDate).toBe('2026-03-17T00:00:00.000Z');
     expect(recurring.history[0].type).toBe('recurrence');
     expect(recurring.subtasks[0].completed).toBe(false);
     expect(recurring.subtasks[0].completedAt).toBe('');
+    expect(
+      createRecurringTaskFromTask(baseTask, 'user_3', 'ws_1', DEFAULT_TASK_COLUMNS, [recurring])
+    ).toBeNull();
   });
 
   test('upsertGoogleImportedTasks merges synced tasks and detects conflicts', () => {

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -82,6 +82,10 @@ function normalizeWhitespace(value) {
     .trim();
 }
 
+function sameJson(left, right) {
+  return JSON.stringify(left ?? null) === JSON.stringify(right ?? null);
+}
+
 // Custom people/tags storage in localStorage to persist user-created values
 const CUSTOM_TASK_PEOPLE_KEY = 'voicelog_custom_task_people';
 const CUSTOM_TASK_TAGS_KEY = 'voicelog_custom_task_tags';
@@ -383,6 +387,47 @@ function recurrenceLabel(recurrence) {
 
 function normalizeRecurrenceFrequency(value) {
   return TASK_RECURRENCE_OPTIONS.some((option) => option.id === value) ? value : 'none';
+}
+
+function recurrenceParentId(task) {
+  return normalizeWhitespace(task?.recurrenceParentId) || normalizeWhitespace(task?.id);
+}
+
+function isRecurringOccurrenceFor(candidate, sourceTask, occurrenceDate, recurrence) {
+  if (!candidate || candidate.id === sourceTask.id) {
+    return false;
+  }
+
+  const candidateOccurrenceDate =
+    normalizeWhitespace(candidate.recurrenceOccurrenceDate) ||
+    normalizeWhitespace(candidate.dueDate);
+  if (candidateOccurrenceDate !== occurrenceDate) {
+    return false;
+  }
+
+  const sourceTaskId = normalizeWhitespace(sourceTask.id);
+  const parentId = recurrenceParentId(sourceTask);
+  const candidateGeneratedFrom = normalizeWhitespace(candidate.recurrenceGeneratedFromTaskId);
+  const candidateParentId = normalizeWhitespace(candidate.recurrenceParentId);
+  if (candidateGeneratedFrom && candidateGeneratedFrom === sourceTaskId) {
+    return true;
+  }
+  if (candidateParentId && candidateParentId === parentId) {
+    return true;
+  }
+
+  return (
+    !candidateGeneratedFrom &&
+    !candidateParentId &&
+    normalizeWhitespace(candidate.title) === normalizeWhitespace(sourceTask.title) &&
+    sameJson(normalizeTaskRecurrence(candidate.recurrence), recurrence)
+  );
+}
+
+function existingRecurringOccurrence(tasks, sourceTask, occurrenceDate, recurrence) {
+  return safeArray(tasks).find((candidate) =>
+    isRecurringOccurrenceFor(candidate, sourceTask, occurrenceDate, recurrence)
+  );
 }
 
 function sameTextList(left, right) {
@@ -937,6 +982,15 @@ function mergeTaskState(task, state, currentUser, columns) {
     recurrence: hasOwn(state, 'recurrence')
       ? normalizeTaskRecurrence(state.recurrence)
       : normalizeTaskRecurrence(task.recurrence),
+    recurrenceParentId: hasOwn(state, 'recurrenceParentId')
+      ? normalizeWhitespace(state.recurrenceParentId)
+      : normalizeWhitespace(task.recurrenceParentId),
+    recurrenceGeneratedFromTaskId: hasOwn(state, 'recurrenceGeneratedFromTaskId')
+      ? normalizeWhitespace(state.recurrenceGeneratedFromTaskId)
+      : normalizeWhitespace(task.recurrenceGeneratedFromTaskId),
+    recurrenceOccurrenceDate: hasOwn(state, 'recurrenceOccurrenceDate')
+      ? normalizeWhitespace(state.recurrenceOccurrenceDate)
+      : normalizeWhitespace(task.recurrenceOccurrenceDate),
     subtasks: hasOwn(state, 'subtasks')
       ? normalizeTaskSubtasks(state.subtasks)
       : normalizeTaskSubtasks(task.subtasks),
@@ -1071,6 +1125,9 @@ export function createManualTask(userId, draft, columns, workspaceId) {
     ),
     dependencies: normalizeTaskDependencies(draft.dependencies),
     recurrence: normalizeTaskRecurrence(draft.recurrence),
+    recurrenceParentId: normalizeWhitespace(draft.recurrenceParentId),
+    recurrenceGeneratedFromTaskId: normalizeWhitespace(draft.recurrenceGeneratedFromTaskId),
+    recurrenceOccurrenceDate: normalizeWhitespace(draft.recurrenceOccurrenceDate),
     subtasks: normalizeTaskSubtasks(draft.subtasks),
     links: normalizeTaskLinks(draft.links),
     order: Number.isFinite(Number(draft.order)) ? Number(draft.order) : -Date.now(),
@@ -1146,6 +1203,13 @@ export function createRecurringTaskFromTask(task, userId, workspaceId, columns, 
     return null;
   }
 
+  const existingOccurrence = existingRecurringOccurrence(tasks, task, dueDate, recurrence);
+  if (existingOccurrence) {
+    return null;
+  }
+
+  const parentId = recurrenceParentId(task);
+
   return createManualTask(
     userId,
     {
@@ -1175,6 +1239,9 @@ export function createRecurringTaskFromTask(task, userId, workspaceId, columns, 
       links: task.links,
       order: getNextTaskOrderTop(tasks),
       workspaceId,
+      recurrenceParentId: parentId,
+      recurrenceGeneratedFromTaskId: task.id,
+      recurrenceOccurrenceDate: dueDate,
     },
     columns,
     workspaceId


### PR DESCRIPTION
## Summary
- Adds recurrence identity fields to generated follow-up tasks: `recurrenceParentId`, `recurrenceGeneratedFromTaskId`, and `recurrenceOccurrenceDate`.
- Prevents duplicate recurring occurrences before creation and again inside `setManualTasks` updaters, covering stale props, double-clicks, retries, and bulk updates.
- Adds regression coverage for double completion, bulk completion, sync retry, and core `createRecurringTaskFromTask` identity/dedupe behavior.

## Validation
- RED confirmed first: `corepack pnpm exec vitest run src/hooks/useTaskOperations.test.ts --coverage.enabled=false --reporter=dot` failed on duplicate recurring follow-ups and missing identity fields.
- `corepack pnpm run typecheck` - passed
- `corepack pnpm exec vitest run src/hooks/useTaskOperations.test.ts --coverage.enabled=false --reporter=dot` - passed, 14 tests
- `corepack pnpm exec vitest run src/hooks/useTaskOperations.test.ts src/lib/tasks.coverage.test.ts --coverage.enabled=false --reporter=dot` - passed, 34 tests
- `corepack pnpm exec prettier --check src/lib/tasks.ts src/lib/tasks.coverage.test.ts src/hooks/useTaskOperations.ts src/hooks/useTaskOperations.test.ts` - passed
- Push pre-push `pnpm run test:release:guard` - passed: server 101 files / 1468 tests passed, frontend guard 3 files / 81 tests passed, build-warning audit passed

## Residual Risk
- `manualTasks` are currently typed as `unknown[]` in the workspace-state contract, so the new recurrence identity fields are preserved in task objects but are not represented by a public manual-task interface.
- Local shell default is Node 24; the repo pre-push hook correctly ran release guard through its temporary Node 22 toolchain.

Closes #1378