### PR TITLE
feat(tasks): define task data contracts (#1379)

### DIFF
--- a/src/hooks/meetingDeletion.ts
+++ b/src/hooks/meetingDeletion.ts
@@ -1,4 +1,5 @@
 import type { WorkspaceStatePayload } from '../shared/contracts';
+import type { TaskRecord, TaskStateOverlay, TaskStatePatch } from '../shared/types';
 
 interface PersistDeletedMeetingRemoteStateOptions {
   stateService: {
@@ -72,6 +73,38 @@ function collectRecordingIdsFromMeeting(meeting: unknown) {
   return [...ids];
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value));
+}
+
+function normalizeTaskRecords(value: unknown): TaskRecord[] {
+  return Array.isArray(value)
+    ? value.filter(isRecord).map((item) => item as unknown as TaskRecord)
+    : [];
+}
+
+function normalizeTaskStatePatch(value: unknown): TaskStatePatch | null {
+  if (isRecord(value)) {
+    return value as TaskStatePatch;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return { status: value.trim() };
+  }
+  return null;
+}
+
+function normalizeTaskState(value: unknown): TaskStateOverlay {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, patch]) => [key, normalizeTaskStatePatch(patch)] as const)
+      .filter((entry): entry is [string, TaskStatePatch] => Boolean(entry[1]))
+  );
+}
+
 export function buildDeletedMeetingRemotePayload({
   meetingId,
   recordingIds = [],
@@ -101,8 +134,8 @@ export function buildDeletedMeetingRemotePayload({
     meetings: safeMeetings.filter(
       (meeting: any) => String(meeting?.id || '').trim() !== normalizedMeetingId
     ),
-    manualTasks: Array.isArray(manualTasks) ? manualTasks : [],
-    taskState: taskState && typeof taskState === 'object' ? taskState : {},
+    manualTasks: normalizeTaskRecords(manualTasks),
+    taskState: normalizeTaskState(taskState),
     taskBoards: taskBoards && typeof taskBoards === 'object' ? taskBoards : {},
     calendarMeta: {
       ...meta,

--- a/src/hooks/useWorkspaceData.test.tsx
+++ b/src/hooks/useWorkspaceData.test.tsx
@@ -183,7 +183,7 @@ describe('useWorkspaceData', () => {
     expect(workspaceState.setWorkspaces).toHaveBeenCalledWith([{ id: 'ws2' }]);
     expect(meetingsState.setMeetings).toHaveBeenCalledWith([{ id: 'm1' }]);
     expect(meetingsState.setManualTasks).toHaveBeenCalledWith([{ id: 't1' }]);
-    expect(meetingsState.setTaskState).toHaveBeenCalledWith({ t1: 'done' });
+    expect(meetingsState.setTaskState).toHaveBeenCalledWith({ t1: { status: 'done' } });
     expect(meetingsState.setTaskBoards).toHaveBeenCalledWith({ ws2: [] });
     expect(meetingsState.setCalendarMeta).toHaveBeenCalledWith({
       'meeting:m1': { googleEventId: 'g1' },

--- a/src/lib/appState.test.ts
+++ b/src/lib/appState.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from 'vitest';
 import { buildProfileDraft, normalizeTaskUpdatePayload } from './appState';
+import type { TaskRecord, TaskStatePatch } from '../shared/types';
 
 describe('appState library', () => {
   test('buildProfileDraft should provide defaults', () => {
@@ -31,12 +32,34 @@ describe('appState library', () => {
       { id: 'todo', isDone: false },
       { id: 'done', isDone: true },
     ];
-    const previousTask = {
+    const previousTask: TaskRecord = {
       id: 't1',
       title: 'Old Title',
       status: 'todo',
       completed: false,
       owner: 'Jan',
+      assignedTo: ['Jan'],
+      sourceType: 'manual',
+      userId: 'user_1',
+      workspaceId: 'ws_1',
+      priority: 'medium',
+      tags: [],
+      group: '',
+      description: '',
+      notes: '',
+      dueDate: '',
+      reminderAt: '',
+      myDay: false,
+      important: false,
+      comments: [],
+      history: [],
+      dependencies: [],
+      recurrence: null,
+      subtasks: [],
+      links: [],
+      order: 0,
+      createdAt: '2026-03-01T00:00:00.000Z',
+      updatedAt: '2026-03-01T00:00:00.000Z',
     };
 
     test('should update basic fields', () => {
@@ -51,6 +74,8 @@ describe('appState library', () => {
     test('should sync completed status with columns', () => {
       // Set status to done, should auto-complete
       const result = normalizeTaskUpdatePayload(previousTask, { status: 'done' }, columns);
+      const typedPatch = result satisfies TaskStatePatch;
+      expect(typedPatch.status).toBe('done');
       expect(result.completed).toBe(true);
       expect(result.status).toBe('done');
 

--- a/src/lib/appState.ts
+++ b/src/lib/appState.ts
@@ -8,6 +8,7 @@ import {
   normalizeTaskSubtasks,
   parseTagInput,
 } from './tasks';
+import type { TaskColumn, TaskRecord, TaskStatePatch, TaskStatePatchInput } from '../shared/types';
 
 export function buildProfileDraft(user) {
   return {
@@ -31,25 +32,30 @@ export function buildProfileDraft(user) {
   };
 }
 
-export function normalizeTaskUpdatePayload(previousTask, updates, columns) {
+export function normalizeTaskUpdatePayload(
+  previousTask: TaskRecord,
+  updates: TaskStatePatchInput = {},
+  columns: TaskColumn[] = []
+): TaskStatePatch {
+  const safeColumns = Array.isArray(columns) ? columns : [];
   const openColumnId =
-    columns.find((column) => !column.isDone)?.id || columns[0]?.id || previousTask.status;
-  const doneColumnId = columns.find((column) => column.isDone)?.id || previousTask.status;
-  const statusExists = columns.some((column) => column.id === updates.status);
+    safeColumns.find((column) => !column.isDone)?.id || safeColumns[0]?.id || previousTask.status;
+  const doneColumnId = safeColumns.find((column) => column.isDone)?.id || previousTask.status;
+  const statusExists = safeColumns.some((column) => column.id === updates.status);
   let nextStatus = statusExists ? updates.status : previousTask.status;
 
   if (typeof updates.completed === 'boolean' && !updates.status) {
     nextStatus = updates.completed ? doneColumnId : openColumnId;
   }
 
-  if (!columns.some((column) => column.id === nextStatus)) {
+  if (!safeColumns.some((column) => column.id === nextStatus)) {
     nextStatus = openColumnId;
   }
 
   const completed =
     typeof updates.completed === 'boolean'
       ? updates.completed
-      : columns.some((column) => column.id === nextStatus && column.isDone);
+      : safeColumns.some((column) => column.id === nextStatus && column.isDone);
   let assignedTo =
     updates.assignedTo === undefined
       ? normalizeTaskPeopleList(

--- a/src/lib/tasks.coverage.test.ts
+++ b/src/lib/tasks.coverage.test.ts
@@ -17,6 +17,7 @@ import {
   updateTaskColumns,
   upsertGoogleImportedTasks,
 } from './tasks';
+import type { TaskRecord } from '../shared/types';
 
 describe('tasks extra coverage', () => {
   afterEach(() => {
@@ -85,7 +86,9 @@ describe('tasks extra coverage', () => {
       columns,
       'ws_1'
     );
+    const typedTask = task satisfies TaskRecord;
 
+    expect(typedTask.sourceType).toBe('manual');
     expect(task.completed).toBe(true);
     expect(task.status).toBe('done');
     expect(task.tags).toEqual(['finanse', 'raport']);
@@ -149,7 +152,9 @@ describe('tasks extra coverage', () => {
       { name: 'Anna' },
       'ws_1'
     );
+    const typedTask = task satisfies TaskRecord;
 
+    expect(typedTask.sourceType).toBe('google');
     expect(task.status).toBe('done');
     expect(task.completed).toBe(true);
     expect(task.group).toBe('Moj list');

--- a/src/lib/workspaceBackup.test.ts
+++ b/src/lib/workspaceBackup.test.ts
@@ -61,6 +61,14 @@ describe('workspaceBackup', () => {
     expect(preview.calendarMetaToUpdate).toBeGreaterThan(0);
   });
 
+  // ---------------------------------------------------------------
+  // Issue #1379 - taskState backup imports keep legacy string statuses
+  // Date: 2026-07-06
+  // Bug: the backup merge expectation still treated taskState entries as
+  //      raw strings after task contracts moved them to structured patches.
+  // Fix: legacy string statuses are accepted as input and normalized to
+  //      TaskStatePatch objects during merge.
+  // ---------------------------------------------------------------
   test('merges imported state into the current workspace state', () => {
     const merged = mergeWorkspaceBackup(
       {
@@ -95,7 +103,7 @@ describe('workspaceBackup', () => {
       { id: 't1', title: 'Task new' },
       { id: 't2', title: 'Task added' },
     ]);
-    expect(merged.taskState).toEqual({ t1: 'done', t2: 'todo' });
+    expect(merged.taskState).toEqual({ t1: { status: 'done' }, t2: { status: 'todo' } });
     expect(merged.taskBoards).toEqual({ board: ['y'], extra: [] });
     expect(merged.calendarMeta).toEqual({ 'meeting:m1': { googleEventId: 'g2' } });
     expect(merged.vocabulary).toEqual(['AI', 'Product']);

--- a/src/shared/contracts.test.ts
+++ b/src/shared/contracts.test.ts
@@ -70,6 +70,47 @@ describe('shared contracts', () => {
     });
   });
 
+  test('Issue #1379 - normalizes task records and task state overlays separately', () => {
+    const state = normalizeWorkspaceState({
+      meetings: [],
+      manualTasks: [
+        {
+          id: 'manual_1',
+          title: 'Manual',
+          status: 'todo',
+          completed: false,
+          sourceType: 'manual',
+        },
+        {
+          id: 'google_1',
+          title: 'Google',
+          status: 'done',
+          completed: true,
+          sourceType: 'google',
+          googleTaskId: 'gt_1',
+          googleTaskListId: 'list_1',
+        },
+        null,
+        'broken-task',
+      ],
+      taskState: {
+        derived_1: { status: 'done', completed: true, archived: false },
+        derived_legacy: 'waiting',
+        derived_2: 123,
+      },
+      taskBoards: {},
+      calendarMeta: {},
+      vocabulary: [],
+    });
+
+    expect(state.manualTasks).toHaveLength(2);
+    expect(state.manualTasks.map((task) => task.sourceType)).toEqual(['manual', 'google']);
+    expect(state.taskState).toEqual({
+      derived_1: { status: 'done', completed: true, archived: false },
+      derived_legacy: { status: 'waiting' },
+    });
+  });
+
   test('Regression: #0 - meeting remove delta creates meeting and recording tombstones', () => {
     const next = applyWorkspaceStateDelta(
       {

--- a/src/shared/contracts.ts
+++ b/src/shared/contracts.ts
@@ -10,13 +10,16 @@ import type {
   WorkspaceFeatureFlags,
   WorkspaceState,
   WorkspaceSttProvider,
+  TaskRecord,
+  TaskStatePatch,
+  TaskStateOverlay,
 } from './types.js';
 
 export interface WorkspaceStatePayload {
   meetings: unknown[];
-  manualTasks: unknown[];
+  manualTasks: TaskRecord[];
   manualPeople?: unknown[];
-  taskState: Record<string, unknown>;
+  taskState: TaskStateOverlay;
   taskBoards: Record<string, unknown>;
   calendarMeta: Record<string, unknown>;
   vocabulary: string[];
@@ -33,7 +36,7 @@ export interface WorkspaceStateDeltaPayload {
   meetings?: WorkspaceCollectionDelta | unknown[];
   manualTasks?: WorkspaceCollectionDelta | unknown[];
   manualPeople?: WorkspaceCollectionDelta | unknown[];
-  taskState?: Record<string, unknown>;
+  taskState?: Record<string, TaskStatePatch | null>;
   taskBoards?: Record<string, unknown>;
   calendarMeta?: Record<string, unknown>;
   vocabulary?: string[];
@@ -171,6 +174,34 @@ function isRecord(value: unknown): value is UnknownRecord {
 
 function asRecord(value: unknown): UnknownRecord {
   return isRecord(value) ? value : {};
+}
+
+function normalizeTaskRecords(value: unknown): TaskRecord[] {
+  return Array.isArray(value)
+    ? value.filter(isRecord).map((item) => item as unknown as TaskRecord)
+    : [];
+}
+
+function normalizeTaskStatePatch(value: unknown): TaskStatePatch | null {
+  if (isRecord(value)) {
+    return value as TaskStatePatch;
+  }
+  if (typeof value === 'string' && value.trim()) {
+    return { status: value.trim() };
+  }
+  return null;
+}
+
+function normalizeTaskState(value: unknown): TaskStateOverlay {
+  if (!isRecord(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value)
+      .map(([key, patch]) => [key, normalizeTaskStatePatch(patch)] as const)
+      .filter((entry): entry is [string, TaskStatePatch] => Boolean(entry[1]))
+  );
 }
 
 function itemId(item: unknown) {
@@ -429,9 +460,9 @@ export function normalizeWorkspaceState(input: unknown = {}): WorkspaceState {
       Array.isArray(source.meetings) ? source.meetings : [],
       calendarMeta
     ),
-    manualTasks: Array.isArray(source.manualTasks) ? source.manualTasks : [],
+    manualTasks: normalizeTaskRecords(source.manualTasks),
     manualPeople: Array.isArray(source.manualPeople) ? source.manualPeople : [],
-    taskState: isRecord(source.taskState) ? source.taskState : {},
+    taskState: normalizeTaskState(source.taskState),
     taskBoards: isRecord(source.taskBoards) ? source.taskBoards : {},
     calendarMeta,
     vocabulary: Array.isArray(source.vocabulary) ? source.vocabulary : [],
@@ -541,7 +572,7 @@ export function buildWorkspaceStateDelta(
   const taskStateDelta = buildObjectDelta(
     prevState.taskState as Record<string, unknown>,
     nextState.taskState as Record<string, unknown>
-  );
+  ) as Record<string, TaskStatePatch | null>;
   if (Object.keys(taskStateDelta).length) {
     delta.taskState = taskStateDelta;
   }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -259,6 +259,157 @@ export interface MeetingTask {
   sourceUnsupported?: boolean;
 }
 
+export type TaskPriority = 'low' | 'medium' | 'high' | 'urgent';
+export type TaskSourceType =
+  'manual' | 'google' | 'meeting' | 'calendar' | 'microsoft' | 'ai' | (string & {});
+export type GoogleTaskSyncStatus = 'synced' | 'local_changes' | 'conflict' | 'error' | 'pending';
+
+export interface TaskColumn {
+  id: string;
+  label?: string;
+  color?: string;
+  isDone?: boolean;
+  system?: boolean;
+  wipLimit?: number | null;
+}
+
+export interface TaskComment {
+  id: string;
+  author?: string;
+  text: string;
+  createdAt: string;
+}
+
+export interface TaskHistoryEntry {
+  id: string;
+  type?: string;
+  actor?: string;
+  message: string;
+  createdAt: string;
+}
+
+export interface TaskDependency {
+  taskId: string;
+  type?: 'blocks' | 'blocked_by' | string;
+}
+
+export interface TaskRecurrence {
+  frequency: 'none' | 'daily' | 'weekly' | 'monthly' | 'custom' | string;
+  interval?: number;
+  until?: string;
+}
+
+export interface TaskSubtask {
+  id: string;
+  title: string;
+  completed: boolean;
+  completedAt?: string;
+}
+
+export interface TaskLink {
+  id: string;
+  url: string;
+  title?: string;
+}
+
+export interface GoogleTaskSyncConflict {
+  id?: string;
+  reason?: string;
+  localUpdatedAt?: string;
+  remoteUpdatedAt?: string;
+  remoteSnapshot?: Record<string, unknown>;
+}
+
+// Persisted task entity stored in WorkspaceState.manualTasks for manual and external tasks.
+export interface TaskRecord {
+  id: string;
+  title: string;
+  status: string;
+  completed: boolean;
+  sourceType: TaskSourceType;
+  owner: string;
+  assignedTo: string[];
+  userId?: string;
+  createdByUserId?: string;
+  workspaceId?: string;
+  sourceMeetingId?: string;
+  sourceMeetingTitle?: string;
+  sourceQuote?: string;
+  sourceSegmentId?: string;
+  sourceTimestamp?: number;
+  sourceUnsupported?: boolean;
+  googleTaskId?: string;
+  googleTaskListId?: string;
+  googleUpdatedAt?: string;
+  googleSyncedAt?: string;
+  googlePulledAt?: string;
+  googleLocalUpdatedAt?: string;
+  googleSyncStatus?: GoogleTaskSyncStatus;
+  googleSyncConflict?: GoogleTaskSyncConflict | null;
+  group: string;
+  description: string;
+  notes: string;
+  dueDate: string;
+  reminderAt: string;
+  myDay: boolean;
+  important: boolean;
+  priority: TaskPriority;
+  tags: string[];
+  comments: TaskComment[];
+  history: TaskHistoryEntry[];
+  dependencies: Array<string | TaskDependency>;
+  recurrence: TaskRecurrence | null;
+  subtasks: TaskSubtask[];
+  links: TaskLink[];
+  order: number;
+  archived?: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+// Overlay stored in WorkspaceState.taskState for derived meeting tasks and local UI state patches.
+export type TaskStatePatch = Partial<
+  Pick<
+    TaskRecord,
+    | 'title'
+    | 'status'
+    | 'completed'
+    | 'owner'
+    | 'assignedTo'
+    | 'group'
+    | 'description'
+    | 'notes'
+    | 'dueDate'
+    | 'reminderAt'
+    | 'myDay'
+    | 'important'
+    | 'priority'
+    | 'tags'
+    | 'comments'
+    | 'history'
+    | 'dependencies'
+    | 'recurrence'
+    | 'subtasks'
+    | 'links'
+    | 'order'
+    | 'googleUpdatedAt'
+    | 'googleSyncedAt'
+    | 'googlePulledAt'
+    | 'googleLocalUpdatedAt'
+    | 'googleSyncStatus'
+    | 'googleSyncConflict'
+    | 'updatedAt'
+    | 'archived'
+  >
+>;
+
+export type TaskStateOverlay = Record<string, TaskStatePatch>;
+
+export type TaskStatePatchInput = Omit<TaskStatePatch, 'assignedTo' | 'tags'> & {
+  assignedTo?: string[] | string | null;
+  tags?: string[] | string | null;
+};
+
 export interface MeetingNeedAnswer {
   need: string;
   answer: string;
@@ -381,9 +532,9 @@ export interface MeetingAnalysis {
 
 export interface WorkspaceState {
   meetings: unknown[];
-  manualTasks: unknown[];
+  manualTasks: TaskRecord[];
   manualPeople?: unknown[];
-  taskState: Record<string, unknown>;
+  taskState: TaskStateOverlay;
   taskBoards: Record<string, unknown>;
   calendarMeta: Record<string, unknown>;
   vocabulary: string[];

--- a/src/store/meetingsStore.ts
+++ b/src/store/meetingsStore.ts
@@ -1,12 +1,13 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createEmptyMeetingDraft } from '../lib/meeting';
+import type { TaskRecord, TaskStatePatch } from '../shared/types';
 
 interface MeetingsState {
   meetings: any[];
-  manualTasks: any[];
+  manualTasks: TaskRecord[];
   manualPeople: any[];
-  taskState: Record<string, any>;
+  taskState: Record<string, TaskStatePatch>;
   taskBoards: Record<string, any>;
   calendarMeta: Record<string, any>;
   vocabulary: any[];
@@ -20,10 +21,12 @@ interface MeetingsState {
   hasMeetingDraftChanges: boolean;
 
   setMeetings: (updater: any[] | ((prev: any[]) => any[])) => void;
-  setManualTasks: (updater: any[] | ((prev: any[]) => any[])) => void;
+  setManualTasks: (updater: TaskRecord[] | ((prev: TaskRecord[]) => TaskRecord[])) => void;
   setManualPeople: (updater: any[] | ((prev: any[]) => any[])) => void;
   setTaskState: (
-    updater: Record<string, any> | ((prev: Record<string, any>) => Record<string, any>)
+    updater:
+      | Record<string, TaskStatePatch>
+      | ((prev: Record<string, TaskStatePatch>) => Record<string, TaskStatePatch>)
   ) => void;
   setTaskBoards: (
     updater: Record<string, any> | ((prev: Record<string, any>) => Record<string, any>)


### PR DESCRIPTION
## Summary
- Adds explicit shared TaskRecord, TaskStatePatch, TaskStateOverlay and TaskColumn contracts.
- Types workspace manualTasks/taskState boundaries and store setters around those contracts.
- Normalizes legacy taskState string statuses into object overlays so older remote state still hydrates safely.

## Validation
- pnpm run typecheck
- pnpm exec vitest run src/lib/tasks.coverage.test.ts src/lib/tasks2.test.ts src/hooks/useTaskOperations.test.ts src/shared/contracts.test.ts src/lib/appState.test.ts --coverage.enabled=false --reporter=dot
- pnpm exec vitest run src/hooks/useWorkspaceData.test.tsx --coverage.enabled=false --reporter=dot
- pnpm exec prettier --check src/shared/types.ts src/shared/contracts.ts src/shared/contracts.test.ts src/lib/appState.ts src/lib/appState.test.ts src/lib/tasks.coverage.test.ts src/store/meetingsStore.ts src/hooks/meetingDeletion.ts
- pnpm run audit:mojibake
- pre-push release guard: pnpm run test:release:guard

## Risk
- Task contracts are intentionally typed at workspace/app-state boundaries only; src/lib/tasks.ts still has @ts-nocheck and should be tightened in a later issue.

Closes #1379