### PR TITLE
ci(css): add CSS debt audit gate (#1388)

### DIFF
--- a/docs/ui/css-debt-baseline.json
+++ b/docs/ui/css-debt-baseline.json
@@ -1,0 +1,22 @@
+{
+  "version": 1,
+  "generatedAt": "2026-07-06T14:13:54.190Z",
+  "sourceFiles": 55,
+  "importantByFile": {
+    "src/PeopleTabStyles.css": 1,
+    "src/RecordingsTabStyles.css": 17,
+    "src/shared/MentionTextareaStyles.css": 3,
+    "src/shared/TagBadge.css": 1,
+    "src/studio/StudioBriefModalStyles.css": 33,
+    "src/studio/StudioMeetingViewStyles.css": 13,
+    "src/studio/TranscriptPanelStyles.css": 1,
+    "src/studio/UnifiedPlayerStyles.css": 1,
+    "src/styles/foundation.css": 1,
+    "src/styles/mobile-utilities.css": 3,
+    "src/styles/modern-layout.css": 14,
+    "src/styles/people.css": 1,
+    "src/styles/tasks.css": 500,
+    "src/tasks/TaskDetailsPanelStyles.css": 69,
+    "src/tasks/TasksWorkspaceViewStyles.css": 1042
+  }
+}

--- a/docs/ui/css-layout-audit.md
+++ b/docs/ui/css-layout-audit.md
@@ -1,0 +1,110 @@
+# CSS Layout Debt Audit
+
+Generated: 2026-07-06T14:13:54.190Z
+
+## Gate
+
+- Local/CI command: `pnpm run audit:css-debt`
+- The command compares current `!important` counts against `docs/ui/css-debt-baseline.json`.
+- New `!important` usage fails the audit per file unless the baseline is intentionally updated.
+- This issue is report-mode only: existing CSS debt is documented, not mass-refactored.
+
+## Summary
+
+- Files scanned: 55
+- Total findings: 14780
+- `!important`: 1700
+- Duplicate selectors: 892
+- Hardcoded spacing values: 5875
+- Hardcoded colors: 4711
+- z-index outside token scale: 28
+- Global selectors: 1574
+
+## Priority
+
+- P0: `!important` and z-index values outside the token scale.
+- P1: duplicate selectors and hardcoded colors.
+- P2: hardcoded spacing and broad global selectors.
+
+## Top Files
+
+| Priority | File                                          | Total | !important | Duplicate selectors | Hardcoded spacing | Hardcoded colors | z-index | Global selectors |
+| -------- | --------------------------------------------- | ----: | ---------: | ------------------: | ----------------: | ---------------: | ------: | ---------------: |
+| P0       | `src/styles/tasks.css`                        |  2588 |        500 |                 184 |               819 |              847 |       2 |              236 |
+| P0       | `src/tasks/TasksWorkspaceViewStyles.css`      |  2326 |       1042 |                  81 |               524 |              346 |       3 |              330 |
+| P0       | `src/studio/StudioMeetingViewStyles.css`      |  1676 |         13 |                  54 |               790 |              667 |       7 |              145 |
+| P1       | `src/NotesTabStyles.css`                      |   770 |          0 |                  51 |               338 |              211 |       0 |              170 |
+| P0       | `src/PeopleTabStyles.css`                     |   672 |          1 |                  47 |               301 |              223 |       1 |               99 |
+| P1       | `src/styles/reference-ui.css`                 |   579 |          0 |                  29 |               197 |              167 |       0 |              186 |
+| P0       | `src/RecordingsTabStyles.css`                 |   511 |         17 |                  42 |               189 |              166 |       1 |               96 |
+| P0       | `src/tasks/TaskDetailsPanelStyles.css`        |   506 |         69 |                  22 |               223 |              146 |       5 |               41 |
+| P0       | `src/styles/modern-layout.css`                |   487 |         14 |                  41 |               234 |              185 |       3 |               10 |
+| P1       | `src/styles/studio.css`                       |   478 |          0 |                  11 |               244 |              222 |       0 |                1 |
+| P1       | `src/ProfileTabStyles.css`                    |   437 |          0 |                  37 |               241 |              123 |       0 |               36 |
+| P1       | `src/App.css`                                 |   424 |          0 |                  24 |               228 |              162 |       0 |               10 |
+| P0       | `src/studio/StudioBriefModalStyles.css`       |   313 |         33 |                  19 |               119 |               77 |       0 |               65 |
+| P0       | `src/studio/UnifiedPlayerStyles.css`          |   289 |          1 |                  37 |               144 |               98 |       0 |                9 |
+| P1       | `src/styles/calendar.css`                     |   258 |          0 |                  16 |               143 |               86 |       0 |               13 |
+| P0       | `src/studio/TranscriptPanelStyles.css`        |   182 |          1 |                  34 |                92 |               55 |       0 |                0 |
+| P1       | `src/index.css`                               |   179 |          0 |                   3 |                16 |              147 |       0 |               13 |
+| P1       | `src/styles/reset.css`                        |   142 |          0 |                   7 |                61 |               63 |       0 |               11 |
+| P1       | `src/CalendarTabStyles.css`                   |   137 |          0 |                   6 |                71 |               42 |       0 |               18 |
+| P1       | `src/styles/variables.css`                    |   128 |          0 |                   0 |                 9 |              113 |       0 |                6 |
+| P1       | `src/styles/JapaneseFlatDesign.css`           |   120 |          0 |                   5 |                22 |               92 |       0 |                1 |
+| P1       | `src/styles/auth.css`                         |   110 |          0 |                   5 |                59 |               46 |       0 |                0 |
+| P1       | `src/NotificationCenterStyles.css`            |   106 |          0 |                  10 |                60 |               30 |       0 |                6 |
+| P1       | `src/CommandPaletteStyles.css`                |   102 |          0 |                   8 |                49 |               34 |       0 |               11 |
+| P1       | `src/styles/recordings.css`                   |    99 |          0 |                  12 |                45 |               42 |       0 |                0 |
+| P1       | `src/components/RecordingPipelineStatus.css`  |    91 |          0 |                   7 |                20 |               47 |       0 |               17 |
+| P1       | `src/styles/layout.css`                       |    84 |          0 |                   5 |                46 |               33 |       0 |                0 |
+| P1       | `src/TopbarStyles.css`                        |    65 |          0 |                  10 |                44 |                9 |       0 |                2 |
+| P1       | `src/studio/AiTaskSuggestionsPanelStyles.css` |    64 |          0 |                  16 |                44 |                4 |       0 |                0 |
+| P1       | `src/tasks/TaskKanbanViewStyles.css`          |    63 |          0 |                   0 |                39 |               24 |       0 |                0 |
+
+## P0: Existing `!important` Debt
+
+| File                                     | Count | First lines                                    |
+| ---------------------------------------- | ----: | ---------------------------------------------- |
+| `src/styles/tasks.css`                   |   500 | 18, 19, 20, 21, 25, 26, 27, 28                 |
+| `src/tasks/TasksWorkspaceViewStyles.css` |  1042 | 78, 87, 91, 107, 108, 114, 118, 124            |
+| `src/studio/StudioMeetingViewStyles.css` |    13 | 4003, 5562, 5563, 5564, 5565, 5573, 5574, 5581 |
+| `src/PeopleTabStyles.css`                |     1 | 766                                            |
+| `src/RecordingsTabStyles.css`            |    17 | 998, 1008, 1010, 1013, 1014, 1020, 1022, 1023  |
+| `src/tasks/TaskDetailsPanelStyles.css`   |    69 | 31, 32, 1162, 1167, 1168, 1169, 1222, 1233     |
+| `src/styles/modern-layout.css`           |    14 | 658, 680, 681, 682, 694, 695, 1367, 1368       |
+| `src/studio/StudioBriefModalStyles.css`  |    33 | 227, 228, 229, 230, 231, 232, 233, 237         |
+| `src/studio/UnifiedPlayerStyles.css`     |     1 | 820                                            |
+| `src/studio/TranscriptPanelStyles.css`   |     1 | 564                                            |
+| `src/styles/people.css`                  |     1 | 210                                            |
+| `src/styles/foundation.css`              |     1 | 36                                             |
+| `src/styles/mobile-utilities.css`        |     3 | 269, 270, 271                                  |
+| `src/shared/TagBadge.css`                |     1 | 64                                             |
+| `src/shared/MentionTextareaStyles.css`   |     3 | 11, 14, 39                                     |
+
+## P0: z-index Outside Token Scale
+
+| File                                     | Count | First lines                              |
+| ---------------------------------------- | ----: | ---------------------------------------- |
+| `src/styles/tasks.css`                   |     2 | 7, 5662                                  |
+| `src/tasks/TasksWorkspaceViewStyles.css` |     3 | 13, 1197, 1382                           |
+| `src/studio/StudioMeetingViewStyles.css` |     7 | 1005, 1299, 1323, 1327, 4001, 4018, 4894 |
+| `src/PeopleTabStyles.css`                |     1 | 1928                                     |
+| `src/RecordingsTabStyles.css`            |     1 | 10                                       |
+| `src/tasks/TaskDetailsPanelStyles.css`   |     5 | 3, 26, 31, 55, 141                       |
+| `src/styles/modern-layout.css`           |     3 | 578, 595, 758                            |
+| `src/shared/AssigneeInput.css`           |     1 | 105                                      |
+| `src/shared/TagInput.css`                |     1 | 101                                      |
+| `src/styles/tasks.mobile.css`            |     3 | 19, 87, 114                              |
+| `src/shared/Tooltip.css`                 |     1 | 11                                       |
+
+## Recommended Cleanup Order
+
+1. Remove or localize `!important` from the top P0 files, starting with component-owned CSS before legacy global bundles.
+2. Replace out-of-scale `z-index` values with a documented token scale.
+3. Consolidate duplicate selectors in the largest CSS bundles before changing visual styling.
+4. Move repeated hardcoded colors and spacing into existing design tokens as files are touched.
+
+## Notes
+
+- Counts are static-analysis heuristics and should guide cleanup, not replace visual review.
+- The report intentionally does not fail on existing debt. The baseline gate fails only when `!important` usage increases.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
     "audit:a11y": "node scripts/accessibility-audit.cjs",
     "audit:a11y:ci": "node scripts/accessibility-audit.cjs --ci --strict",
     "audit:build-warnings": "node scripts/audit-build-warnings.mjs",
+    "audit:css-debt": "node scripts/css-debt-audit.mjs",
+    "audit:css-debt:update": "node scripts/css-debt-audit.mjs --write",
     "audit:lighthouse": "node scripts/run-lighthouse-audit.mjs",
     "audit:mojibake": "node scripts/audit-mojibake.mjs",
     "audit:repo-hygiene": "node scripts/validate-repo-hygiene.mjs && node scripts/validate-secret-hygiene.mjs && node scripts/validate-critical-path-coverage.mjs && node scripts/validate-database-schema-audit.mjs",

--- a/scripts/css-debt-audit.mjs
+++ b/scripts/css-debt-audit.mjs
@@ -1,0 +1,398 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const DEFAULT_SOURCE_DIR = 'src';
+const DEFAULT_REPORT_PATH = 'docs/ui/css-layout-audit.md';
+const DEFAULT_BASELINE_PATH = 'docs/ui/css-debt-baseline.json';
+const IMPORTANT_PATTERN = /!important\b/i;
+const HARDCODED_COLOR_PATTERN =
+  /(?:#[0-9a-f]{3,8}\b|rgba?\([^)]*\)|hsla?\([^)]*\)|\b(?:white|black|red|blue|green|yellow|orange|purple|gray|grey)\b)/i;
+const HARDCODED_SPACING_PATTERN =
+  /\b(?:margin|padding|gap|row-gap|column-gap|inset|top|right|bottom|left|width|height|min-width|max-width|min-height|max-height|border-radius|translate|transform)\s*:[^;]*(?:-?(?!0(?:px|rem|em)?\b)\d*\.?\d+(?:px|rem|em|vh|vw))/i;
+const Z_INDEX_PATTERN = /\bz-index\s*:\s*([^;]+)/i;
+const GLOBAL_SELECTOR_PATTERN =
+  /^(?:html|body|:root|\*|button|input|textarea|select|a|p|h[1-6])(?:\b|[,:.#\s[{>+~])/i;
+const TOKEN_Z_INDEX_VALUES = new Set(['0', '1', '2', '5', '10', '20', '30', '40', '50', '100']);
+
+export function collectStyleFiles(rootDir = process.cwd(), sourceDir = DEFAULT_SOURCE_DIR) {
+  const sourceRoot = path.resolve(rootDir, sourceDir);
+  const files = [];
+
+  function visit(directory) {
+    if (!fs.existsSync(directory)) {
+      return;
+    }
+
+    for (const entry of fs.readdirSync(directory, { withFileTypes: true })) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        visit(absolutePath);
+        continue;
+      }
+
+      if (!/\.(css|scss)$/i.test(entry.name) || /\.(test|spec)\.(css|scss)$/i.test(entry.name)) {
+        continue;
+      }
+
+      files.push(absolutePath);
+    }
+  }
+
+  visit(sourceRoot);
+  return files.sort();
+}
+
+function toPosix(relativePath) {
+  return relativePath.split(path.sep).join('/');
+}
+
+function extractSelectors(line) {
+  if (!line.includes('{')) {
+    return [];
+  }
+
+  const selectorText = line.split('{')[0].trim();
+  if (!selectorText || selectorText.startsWith('@')) {
+    return [];
+  }
+
+  return selectorText
+    .split(',')
+    .map((selector) => selector.trim().replace(/\s+/g, ' '))
+    .filter(Boolean);
+}
+
+function isTokenizedZIndex(value) {
+  const normalized = value.trim();
+  if (/^var\(/i.test(normalized)) {
+    return true;
+  }
+  const numeric = normalized.match(/^-?\d+/)?.[0];
+  return Boolean(numeric && TOKEN_Z_INDEX_VALUES.has(numeric));
+}
+
+export function auditCssText(text, filePath = 'inline.css') {
+  const lines = text.split(/\r?\n/);
+  const selectorCounts = new Map();
+  const findings = {
+    file: filePath,
+    important: [],
+    hardcodedSpacing: [],
+    hardcodedColors: [],
+    zIndexOutsideTokenScale: [],
+    globalSelectors: [],
+    duplicateSelectors: [],
+  };
+
+  lines.forEach((line, index) => {
+    const lineNumber = index + 1;
+    const trimmed = line.trim();
+
+    if (IMPORTANT_PATTERN.test(line)) {
+      findings.important.push({ line: lineNumber, text: trimmed });
+    }
+
+    if (HARDCODED_SPACING_PATTERN.test(line)) {
+      findings.hardcodedSpacing.push({ line: lineNumber, text: trimmed });
+    }
+
+    if (HARDCODED_COLOR_PATTERN.test(line) && !line.includes('var(')) {
+      findings.hardcodedColors.push({ line: lineNumber, text: trimmed });
+    }
+
+    const zIndex = line.match(Z_INDEX_PATTERN);
+    if (zIndex && !isTokenizedZIndex(zIndex[1])) {
+      findings.zIndexOutsideTokenScale.push({ line: lineNumber, text: trimmed });
+    }
+
+    for (const selector of extractSelectors(line)) {
+      if (GLOBAL_SELECTOR_PATTERN.test(selector)) {
+        findings.globalSelectors.push({ line: lineNumber, selector });
+      }
+      const previous = selectorCounts.get(selector) ?? [];
+      previous.push(lineNumber);
+      selectorCounts.set(selector, previous);
+    }
+  });
+
+  for (const [selector, occurrences] of selectorCounts.entries()) {
+    if (occurrences.length > 1) {
+      findings.duplicateSelectors.push({ selector, lines: occurrences });
+    }
+  }
+
+  return findings;
+}
+
+function priorityFor(fileAudit) {
+  if (fileAudit.important.length > 0 || fileAudit.zIndexOutsideTokenScale.length > 0) {
+    return 'P0';
+  }
+  if (fileAudit.duplicateSelectors.length > 0 || fileAudit.hardcodedColors.length > 0) {
+    return 'P1';
+  }
+  if (fileAudit.hardcodedSpacing.length > 0 || fileAudit.globalSelectors.length > 0) {
+    return 'P2';
+  }
+  return 'P3';
+}
+
+export function auditCssFiles(files, rootDir = process.cwd()) {
+  const fileAudits = files.map((file) => {
+    const relativePath = toPosix(path.relative(rootDir, file));
+    const audit = auditCssText(fs.readFileSync(file, 'utf8'), relativePath);
+    const counts = {
+      important: audit.important.length,
+      duplicateSelectors: audit.duplicateSelectors.length,
+      hardcodedSpacing: audit.hardcodedSpacing.length,
+      hardcodedColors: audit.hardcodedColors.length,
+      zIndexOutsideTokenScale: audit.zIndexOutsideTokenScale.length,
+      globalSelectors: audit.globalSelectors.length,
+    };
+    const totalFindings = Object.values(counts).reduce((sum, count) => sum + count, 0);
+
+    return {
+      ...audit,
+      counts,
+      totalFindings,
+      priority: priorityFor(audit),
+    };
+  });
+
+  const totals = fileAudits.reduce(
+    (accumulator, audit) => {
+      for (const [key, value] of Object.entries(audit.counts)) {
+        accumulator[key] += value;
+      }
+      accumulator.totalFindings += audit.totalFindings;
+      return accumulator;
+    },
+    {
+      important: 0,
+      duplicateSelectors: 0,
+      hardcodedSpacing: 0,
+      hardcodedColors: 0,
+      zIndexOutsideTokenScale: 0,
+      globalSelectors: 0,
+      totalFindings: 0,
+    }
+  );
+
+  return {
+    generatedAt: new Date().toISOString(),
+    generatedOn: os.hostname(),
+    sourceFiles: fileAudits.length,
+    totals,
+    files: fileAudits.sort(
+      (a, b) => b.totalFindings - a.totalFindings || a.file.localeCompare(b.file)
+    ),
+  };
+}
+
+export function createImportantBaseline(result) {
+  return {
+    version: 1,
+    generatedAt: result.generatedAt,
+    sourceFiles: result.sourceFiles,
+    importantByFile: Object.fromEntries(
+      result.files
+        .filter((file) => file.counts.important > 0)
+        .map((file) => [file.file, file.counts.important])
+        .sort(([a], [b]) => a.localeCompare(b))
+    ),
+  };
+}
+
+export function assertNoNewImportant(result, baseline) {
+  const baselineByFile = baseline?.importantByFile ?? {};
+  const violations = [];
+
+  for (const file of result.files) {
+    const allowed = Number(baselineByFile[file.file] ?? 0);
+    if (file.counts.important > allowed) {
+      violations.push({
+        file: file.file,
+        allowed,
+        actual: file.counts.important,
+        added: file.counts.important - allowed,
+      });
+    }
+  }
+
+  return violations;
+}
+
+function renderCount(value) {
+  return String(value).padStart(1, '0');
+}
+
+export function renderMarkdownReport(result, options = {}) {
+  const command = options.command ?? 'pnpm run audit:css-debt';
+  const topFiles = result.files.filter((file) => file.totalFindings > 0).slice(0, 30);
+  const importantFiles = result.files.filter((file) => file.counts.important > 0);
+  const zIndexFiles = result.files.filter((file) => file.counts.zIndexOutsideTokenScale > 0);
+
+  return [
+    '# CSS Layout Debt Audit',
+    '',
+    `Generated: ${result.generatedAt}`,
+    '',
+    '## Gate',
+    '',
+    `- Local/CI command: \`${command}\``,
+    '- The command compares current `!important` counts against `docs/ui/css-debt-baseline.json`.',
+    '- New `!important` usage fails the audit per file unless the baseline is intentionally updated.',
+    '- This issue is report-mode only: existing CSS debt is documented, not mass-refactored.',
+    '',
+    '## Summary',
+    '',
+    `- Files scanned: ${result.sourceFiles}`,
+    `- Total findings: ${renderCount(result.totals.totalFindings)}`,
+    `- \`!important\`: ${renderCount(result.totals.important)}`,
+    `- Duplicate selectors: ${renderCount(result.totals.duplicateSelectors)}`,
+    `- Hardcoded spacing values: ${renderCount(result.totals.hardcodedSpacing)}`,
+    `- Hardcoded colors: ${renderCount(result.totals.hardcodedColors)}`,
+    `- z-index outside token scale: ${renderCount(result.totals.zIndexOutsideTokenScale)}`,
+    `- Global selectors: ${renderCount(result.totals.globalSelectors)}`,
+    '',
+    '## Priority',
+    '',
+    '- P0: `!important` and z-index values outside the token scale.',
+    '- P1: duplicate selectors and hardcoded colors.',
+    '- P2: hardcoded spacing and broad global selectors.',
+    '',
+    '## Top Files',
+    '',
+    '| Priority | File | Total | !important | Duplicate selectors | Hardcoded spacing | Hardcoded colors | z-index | Global selectors |',
+    '| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |',
+    ...topFiles.map(
+      (file) =>
+        `| ${file.priority} | \`${file.file}\` | ${file.totalFindings} | ${file.counts.important} | ${file.counts.duplicateSelectors} | ${file.counts.hardcodedSpacing} | ${file.counts.hardcodedColors} | ${file.counts.zIndexOutsideTokenScale} | ${file.counts.globalSelectors} |`
+    ),
+    '',
+    '## P0: Existing `!important` Debt',
+    '',
+    importantFiles.length
+      ? '| File | Count | First lines |\n| --- | ---: | --- |\n' +
+        importantFiles
+          .map((file) => {
+            const firstLines = file.important
+              .slice(0, 8)
+              .map((item) => item.line)
+              .join(', ');
+            return `| \`${file.file}\` | ${file.counts.important} | ${firstLines} |`;
+          })
+          .join('\n')
+      : 'No `!important` declarations found.',
+    '',
+    '## P0: z-index Outside Token Scale',
+    '',
+    zIndexFiles.length
+      ? '| File | Count | First lines |\n| --- | ---: | --- |\n' +
+        zIndexFiles
+          .map((file) => {
+            const firstLines = file.zIndexOutsideTokenScale
+              .slice(0, 8)
+              .map((item) => item.line)
+              .join(', ');
+            return `| \`${file.file}\` | ${file.counts.zIndexOutsideTokenScale} | ${firstLines} |`;
+          })
+          .join('\n')
+      : 'No out-of-scale z-index declarations found.',
+    '',
+    '## Recommended Cleanup Order',
+    '',
+    '1. Remove or localize `!important` from the top P0 files, starting with component-owned CSS before legacy global bundles.',
+    '2. Replace out-of-scale `z-index` values with a documented token scale.',
+    '3. Consolidate duplicate selectors in the largest CSS bundles before changing visual styling.',
+    '4. Move repeated hardcoded colors and spacing into existing design tokens as files are touched.',
+    '',
+    '## Notes',
+    '',
+    '- Counts are static-analysis heuristics and should guide cleanup, not replace visual review.',
+    '- The report intentionally does not fail on existing debt. The baseline gate fails only when `!important` usage increases.',
+    '',
+  ].join('\n');
+}
+
+function parseArgs(argv) {
+  const args = {
+    sourceDir: DEFAULT_SOURCE_DIR,
+    reportPath: DEFAULT_REPORT_PATH,
+    baselinePath: DEFAULT_BASELINE_PATH,
+    write: false,
+  };
+
+  for (const arg of argv) {
+    if (arg === '--write') {
+      args.write = true;
+      continue;
+    }
+    const [key, value] = arg.split('=');
+    if (key === '--source' && value) {
+      args.sourceDir = value;
+    }
+    if (key === '--report' && value) {
+      args.reportPath = value;
+    }
+    if (key === '--baseline' && value) {
+      args.baselinePath = value;
+    }
+  }
+
+  return args;
+}
+
+export function run(argv = process.argv.slice(2), rootDir = process.cwd()) {
+  const args = parseArgs(argv);
+  const files = collectStyleFiles(rootDir, args.sourceDir);
+  const result = auditCssFiles(files, rootDir);
+  const reportPath = path.resolve(rootDir, args.reportPath);
+  const baselinePath = path.resolve(rootDir, args.baselinePath);
+
+  if (args.write) {
+    fs.mkdirSync(path.dirname(reportPath), { recursive: true });
+    fs.writeFileSync(
+      reportPath,
+      renderMarkdownReport(result, { command: 'pnpm run audit:css-debt' })
+    );
+    fs.writeFileSync(baselinePath, JSON.stringify(createImportantBaseline(result), null, 2) + '\n');
+    console.log(`CSS debt report updated: ${args.reportPath}`);
+    console.log(`CSS !important baseline updated: ${args.baselinePath}`);
+    return { result, violations: [] };
+  }
+
+  if (!fs.existsSync(baselinePath)) {
+    throw new Error(`Missing CSS debt baseline: ${args.baselinePath}`);
+  }
+
+  const baseline = JSON.parse(fs.readFileSync(baselinePath, 'utf8'));
+  const violations = assertNoNewImportant(result, baseline);
+  if (violations.length > 0) {
+    const details = violations
+      .map((violation) => {
+        return `- ${violation.file}: ${violation.actual} !important declarations, baseline ${violation.allowed} (+${violation.added})`;
+      })
+      .join('\n');
+    throw new Error(
+      `New CSS !important usage detected. Run \`pnpm run audit:css-debt:update\` only when intentionally accepting baseline changes.\n${details}`
+    );
+  }
+
+  console.log(
+    `CSS debt audit passed: ${result.sourceFiles} files, ${result.totals.important} existing !important declarations, no per-file increases.`
+  );
+  return { result, violations };
+}
+
+const currentFilePath = fileURLToPath(import.meta.url);
+if (process.argv[1] && path.resolve(process.argv[1]) === currentFilePath) {
+  try {
+    run();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exitCode = 1;
+  }
+}

--- a/scripts/css-debt-audit.test.ts
+++ b/scripts/css-debt-audit.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  assertNoNewImportant,
+  auditCssFiles,
+  auditCssText,
+  createImportantBaseline,
+  renderMarkdownReport,
+} from './css-debt-audit.mjs';
+
+describe('css debt audit', () => {
+  it('detects important declarations, duplicates, hardcoded values and global selectors', () => {
+    const audit = auditCssText(
+      [
+        ':root { --token: 1; }',
+        'body { margin: 0; }',
+        '.panel { color: #123456; padding: 12px; z-index: 10000; }',
+        '.panel { background: rgba(255, 255, 255, 0.9) !important; }',
+      ].join('\n'),
+      'src/example.css'
+    );
+
+    expect(audit.important).toHaveLength(1);
+    expect(audit.duplicateSelectors).toEqual([{ selector: '.panel', lines: [3, 4] }]);
+    expect(audit.hardcodedColors.map((item) => item.line)).toEqual([3, 4]);
+    expect(audit.hardcodedSpacing.map((item) => item.line)).toEqual([3]);
+    expect(audit.zIndexOutsideTokenScale.map((item) => item.line)).toEqual([3]);
+    expect(audit.globalSelectors.map((item) => item.selector)).toEqual([':root', 'body']);
+  });
+
+  it('creates an important baseline and fails only when a file exceeds it', () => {
+    const baseline = {
+      version: 1,
+      importantByFile: {
+        'src/a.css': 1,
+      },
+    };
+    const result = {
+      files: [
+        { file: 'src/a.css', counts: { important: 1 } },
+        { file: 'src/b.css', counts: { important: 2 } },
+      ],
+    } as any;
+
+    expect(assertNoNewImportant(result, baseline)).toEqual([
+      { file: 'src/b.css', allowed: 0, actual: 2, added: 2 },
+    ]);
+  });
+
+  it('renders the command and priority sections in the committed report', () => {
+    const result = {
+      generatedAt: '2026-07-06T00:00:00.000Z',
+      sourceFiles: 1,
+      totals: {
+        important: 1,
+        duplicateSelectors: 1,
+        hardcodedSpacing: 1,
+        hardcodedColors: 1,
+        zIndexOutsideTokenScale: 1,
+        globalSelectors: 1,
+        totalFindings: 6,
+      },
+      files: [
+        {
+          file: 'src/example.css',
+          priority: 'P0',
+          totalFindings: 6,
+          counts: {
+            important: 1,
+            duplicateSelectors: 1,
+            hardcodedSpacing: 1,
+            hardcodedColors: 1,
+            zIndexOutsideTokenScale: 1,
+            globalSelectors: 1,
+          },
+          important: [{ line: 2 }],
+          zIndexOutsideTokenScale: [{ line: 3 }],
+        },
+      ],
+    } as any;
+
+    const markdown = renderMarkdownReport(result);
+
+    expect(markdown).toContain('pnpm run audit:css-debt');
+    expect(markdown).toContain('## P0: Existing `!important` Debt');
+    expect(markdown).toContain('## P0: z-index Outside Token Scale');
+    expect(markdown).toContain('`src/example.css`');
+  });
+
+  it('builds a baseline from audited files', () => {
+    const result = {
+      generatedAt: '2026-07-06T00:00:00.000Z',
+      sourceFiles: 2,
+      files: [
+        { file: 'src/b.css', counts: { important: 0 } },
+        { file: 'src/a.css', counts: { important: 3 } },
+      ],
+    } as any;
+
+    expect(createImportantBaseline(result)).toEqual({
+      version: 1,
+      generatedAt: '2026-07-06T00:00:00.000Z',
+      sourceFiles: 2,
+      importantByFile: {
+        'src/a.css': 3,
+      },
+    });
+  });
+
+  it('summarizes real files without mutating source content', () => {
+    const files = ['src/PeopleTabStyles.css'];
+    const result = auditCssFiles(
+      files.map((file) => `${process.cwd()}/${file}`),
+      process.cwd()
+    );
+
+    expect(result.sourceFiles).toBe(1);
+    expect(result.files[0].file).toBe('src/PeopleTabStyles.css');
+    expect(result.totals.totalFindings).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a deterministic CSS debt audit script for `src/**/*.{css,scss}`.
- Commits `docs/ui/css-layout-audit.md` with current duplicate selector, `!important`, hardcoded spacing/color, z-index and global-selector debt.
- Adds `docs/ui/css-debt-baseline.json` and a report-mode gate that fails when per-file `!important` usage increases.
- Adds script coverage for the audit parser, baseline gate and report rendering.

## Validation
- `corepack pnpm exec vitest run -c vitest.scripts.config.ts scripts/css-debt-audit.test.ts --coverage.enabled=false --reporter=dot` - passed, 5 tests
- `corepack pnpm run audit:css-debt` - passed, 55 CSS files, 1700 existing `!important`, no per-file increases
- `corepack pnpm run lint:css` - passed
- `corepack pnpm run audit:mojibake` - passed
- `corepack pnpm run typecheck` - passed
- Push pre-push `pnpm run test:release:guard` - passed: server 101 files / 1468 tests passed, frontend guard 3 files / 81 tests passed, build-warning audit passed

## Residual Risk
- This is a static-analysis governance gate, not a visual cleanup PR; existing CSS debt is reported and baselined, not removed.
- The audit uses heuristics, so counts should guide cleanup priority and be paired with visual review when CSS is refactored.
- Local shell uses Node 24, so commands print the expected engine warning; pre-push release guard ran through the repo's temporary Node 22 toolchain.

Closes #1388