### PR TITLE
feat(tasks): add diagnostics report (#1387)

### DIFF
--- a/src/lib/tasks.test.ts
+++ b/src/lib/tasks.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DEFAULT_TASK_COLUMNS, buildTaskDiagnosticsReport } from './tasks';
+
+describe('task diagnostics report', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('reports a healthy current workspace task set', () => {
+    vi.setSystemTime(new Date('2026-07-06T12:00:00.000Z'));
+
+    const report = buildTaskDiagnosticsReport(
+      [
+        {
+          id: 'task-1',
+          title: 'Prepare brief',
+          workspaceId: 'ws-1',
+          sourceType: 'manual',
+          status: 'todo',
+          dependencies: [],
+          recurrence: null,
+        },
+        {
+          id: 'task-2',
+          title: 'Send summary',
+          workspaceId: 'ws-1',
+          sourceType: 'google',
+          status: 'done',
+          dependencies: ['task-1'],
+          recurrenceGeneratedFromTaskId: 'task-1',
+        },
+      ],
+      { workspaceId: 'ws-1', columns: DEFAULT_TASK_COLUMNS }
+    );
+
+    expect(report.healthy).toBe(true);
+    expect(report.counts).toMatchObject({
+      totalTasks: 2,
+      manualTasks: 1,
+      archivedTasks: 0,
+      deletePendingTasks: 0,
+      conflicts: 0,
+      missingWorkspaceId: 0,
+      missingTitle: 0,
+      invalidStatus: 0,
+      brokenDependencies: 0,
+      recurringTasks: 1,
+      duplicateIds: 0,
+      excludedOtherWorkspace: 0,
+    });
+    expect(report.generatedAt).toBe('2026-07-06T12:00:00.000Z');
+  });
+
+  it('identifies invalid task data without exposing other workspace tasks', () => {
+    const report = buildTaskDiagnosticsReport(
+      [
+        {
+          id: 'dup',
+          title: '',
+          workspaceId: 'ws-1',
+          sourceType: 'manual',
+          status: 'stuck',
+          dependencies: ['missing-task'],
+          archived: true,
+          googleSyncStatus: 'conflict',
+        },
+        {
+          id: 'dup',
+          title: 'Duplicate',
+          workspaceId: 'ws-1',
+          sourceType: 'manual',
+          status: 'todo',
+          dependencies: [],
+          deletePending: true,
+        },
+        {
+          id: 'missing-workspace',
+          title: 'Legacy task',
+          sourceType: 'manual',
+          status: 'todo',
+          dependencies: [],
+        },
+        {
+          id: 'other-workspace-secret-id',
+          title: 'Other workspace title',
+          workspaceId: 'ws-2',
+          sourceType: 'manual',
+          status: 'not-a-column',
+          dependencies: ['also-secret'],
+        },
+      ],
+      { workspaceId: 'ws-1', columns: DEFAULT_TASK_COLUMNS }
+    );
+
+    expect(report.healthy).toBe(false);
+    expect(report.counts).toMatchObject({
+      totalTasks: 3,
+      manualTasks: 3,
+      archivedTasks: 1,
+      deletePendingTasks: 1,
+      conflicts: 1,
+      missingWorkspaceId: 1,
+      missingTitle: 1,
+      invalidStatus: 1,
+      brokenDependencies: 1,
+      duplicateIds: 1,
+      excludedOtherWorkspace: 1,
+    });
+    expect(report.issues.duplicateIds).toEqual([{ id: 'dup', count: 2 }]);
+    expect(report.issues.invalidStatus).toEqual([{ id: 'dup', status: 'stuck' }]);
+    expect(report.issues.brokenDependencies).toEqual([{ id: 'dup', dependencyId: 'missing-task' }]);
+    expect(JSON.stringify(report)).not.toContain('other-workspace-secret-id');
+    expect(JSON.stringify(report)).not.toContain('Other workspace title');
+  });
+});

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1445,3 +1445,104 @@ export function taskListStats(tasks) {
     slaBreached: slaSummary.overdue + slaSummary.breached,
   };
 }
+
+function isDeletePendingTask(task) {
+  return Boolean(
+    task?.deletePending ||
+    task?._softDeleted ||
+    task?.pendingDelete ||
+    task?.status === 'delete_pending' ||
+    task?.lifecycleStatus === 'delete_pending'
+  );
+}
+
+function isRecurringTask(task) {
+  return Boolean(
+    task?.recurrence ||
+    task?.recurrenceParentId ||
+    task?.recurrenceGeneratedFromTaskId ||
+    task?.recurrenceOccurrenceDate
+  );
+}
+
+export function buildTaskDiagnosticsReport(tasks, options = {}) {
+  const workspaceId = normalizeWhitespace(options.workspaceId);
+  const columns = normalizeColumns(options.columns || DEFAULT_TASK_COLUMNS);
+  const validStatuses = new Set(columns.map((column) => column.id));
+  const sourceTasks = safeArray(tasks).filter(isTaskRecord);
+  const scopedTasks = sourceTasks.filter((task) => {
+    if (!workspaceId) {
+      return true;
+    }
+    return !task.workspaceId || task.workspaceId === workspaceId;
+  });
+  const excludedOtherWorkspace = sourceTasks.length - scopedTasks.length;
+  const idCounts = new Map();
+
+  scopedTasks.forEach((task) => {
+    const id = normalizeWhitespace(task.id);
+    if (!id) {
+      return;
+    }
+    idCounts.set(id, (idCounts.get(id) || 0) + 1);
+  });
+
+  const taskIds = new Set([...idCounts.keys()]);
+  const duplicateIds = [...idCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([id, count]) => ({ id, count }));
+  const missingWorkspaceId = scopedTasks
+    .filter((task) => !normalizeWhitespace(task.workspaceId))
+    .map((task) => normalizeWhitespace(task.id) || '<missing-id>');
+  const missingTitle = scopedTasks
+    .filter((task) => !normalizeWhitespace(task.title))
+    .map((task) => normalizeWhitespace(task.id) || '<missing-id>');
+  const invalidStatus = scopedTasks
+    .filter((task) => !validStatuses.has(normalizeWhitespace(task.status)))
+    .map((task) => ({
+      id: normalizeWhitespace(task.id) || '<missing-id>',
+      status: normalizeWhitespace(task.status) || '<missing-status>',
+    }));
+  const brokenDependencies = scopedTasks.flatMap((task) => {
+    const taskId = normalizeWhitespace(task.id) || '<missing-id>';
+    return normalizeTaskDependencies(task.dependencies)
+      .filter((dependencyId) => !taskIds.has(dependencyId))
+      .map((dependencyId) => ({ id: taskId, dependencyId }));
+  });
+
+  const counts = {
+    manualTasks: scopedTasks.filter((task) => task.sourceType === 'manual').length,
+    archivedTasks: scopedTasks.filter((task) => task.archived).length,
+    deletePendingTasks: scopedTasks.filter(isDeletePendingTask).length,
+    conflicts: scopedTasks.filter(
+      (task) => task.googleSyncStatus === 'conflict' || Boolean(task.googleSyncConflict)
+    ).length,
+    missingWorkspaceId: missingWorkspaceId.length,
+    missingTitle: missingTitle.length,
+    invalidStatus: invalidStatus.length,
+    brokenDependencies: brokenDependencies.length,
+    recurringTasks: scopedTasks.filter(isRecurringTask).length,
+    duplicateIds: duplicateIds.length,
+    totalTasks: scopedTasks.length,
+    excludedOtherWorkspace,
+  };
+
+  return {
+    workspaceId,
+    generatedAt: new Date().toISOString(),
+    counts,
+    healthy:
+      counts.missingWorkspaceId === 0 &&
+      counts.missingTitle === 0 &&
+      counts.invalidStatus === 0 &&
+      counts.brokenDependencies === 0 &&
+      counts.duplicateIds === 0,
+    issues: {
+      missingWorkspaceId,
+      missingTitle,
+      invalidStatus,
+      brokenDependencies,
+      duplicateIds,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `buildTaskDiagnosticsReport` for support/QA diagnostics on workspace task data.
- Reports counts for manual, archived, delete-pending, conflict, missing workspace, missing title, invalid status, broken dependency, recurring and duplicate-ID task states.
- Filters out other-workspace records from issue details and reports only an excluded count.
- Adds `src/lib/tasks.test.ts` matching the validation command from the issue.

## Validation
- `corepack pnpm exec vitest run src/lib/tasks.test.ts --coverage.enabled=false --reporter=dot` - passed, 2 tests
- `corepack pnpm exec vitest run src/lib/tasks.coverage.test.ts --coverage.enabled=false --reporter=dot` - passed, 20 tests
- `corepack pnpm run typecheck` - passed
- `corepack pnpm exec prettier --check src/lib/tasks.ts src/lib/tasks.test.ts` - passed
- Push pre-push `pnpm run test:release:guard` - passed: server 101 files / 1468 tests passed, frontend guard 3 files / 81 tests passed, build-warning audit passed

## Residual Risk
- The report is a library-level diagnostic generator; no UI entry point is added in this PR, so surfacing it in the app can be a follow-up.
- Mixed legacy records without `workspaceId` are included only as technical diagnostics; other explicit workspace records are excluded from issue details.

Closes #1387