### PR TITLE
fix(tasks): rebalance crowded task order values (#1385)

### DIFF
--- a/src/hooks/useTaskOperations.test.ts
+++ b/src/hooks/useTaskOperations.test.ts
@@ -121,6 +121,145 @@ describe('useTaskOperations', () => {
     expect(mockSetTaskState).toHaveBeenCalledTimes(1);
   });
 
+  test('reorderTask rebalances a crowded column without changing visual order', () => {
+    const crowdedTasks = [
+      {
+        id: 'first',
+        title: 'First',
+        status: 'c1',
+        group: 'Ops',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+        order: 0,
+      },
+      {
+        id: 'second',
+        title: 'Second',
+        status: 'c1',
+        group: 'Ops',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+        order: 0.000001,
+      },
+      {
+        id: 'dragged',
+        title: 'Dragged',
+        status: 'c2',
+        group: 'Ops',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+        order: 100,
+      },
+      {
+        id: 'other-group',
+        title: 'Other group',
+        status: 'c1',
+        group: 'Sales',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+        order: 0.000002,
+      },
+    ];
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: crowdedTasks })
+    );
+
+    act(() => {
+      result.current.reorderTask('dragged', {
+        status: 'c1',
+        group: 'Ops',
+        previousTaskId: 'first',
+        nextTaskId: 'second',
+      });
+    });
+
+    expect(mockSetManualTasks).toHaveBeenCalledTimes(1);
+    expect(mockSetTaskState).not.toHaveBeenCalled();
+
+    const updater = mockSetManualTasks.mock.calls[0][0];
+    const next = updater(crowdedTasks);
+    const opsTasks = next
+      .filter((task: any) => task.status === 'c1' && task.group === 'Ops')
+      .sort((left: any, right: any) => left.order - right.order);
+
+    expect(opsTasks.map((task: any) => task.id)).toEqual(['first', 'dragged', 'second']);
+    expect(opsTasks[1].order - opsTasks[0].order).toBeGreaterThanOrEqual(1024);
+    expect(opsTasks[2].order - opsTasks[1].order).toBeGreaterThanOrEqual(1024);
+    expect(next.find((task: any) => task.id === 'other-group').order).toBe(0.000002);
+  });
+
+  test('reorderTask keeps the single-task update path when order gaps are healthy', () => {
+    const healthyTasks = [
+      {
+        id: 'first',
+        title: 'First',
+        status: 'c1',
+        group: 'Ops',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+        order: 0,
+      },
+      {
+        id: 'second',
+        title: 'Second',
+        status: 'c1',
+        group: 'Ops',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+        order: 2048,
+      },
+      {
+        id: 'dragged',
+        title: 'Dragged',
+        status: 'c1',
+        group: 'Ops',
+        sourceType: 'manual',
+        history: [],
+        completed: false,
+        tags: [],
+        assignedTo: [],
+        order: 4096,
+      },
+    ];
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: healthyTasks })
+    );
+
+    act(() => {
+      result.current.reorderTask('dragged', {
+        group: 'Ops',
+        previousTaskId: 'first',
+        nextTaskId: 'second',
+      });
+    });
+
+    expect(mockSetManualTasks).toHaveBeenCalledTimes(1);
+    const updater = mockSetManualTasks.mock.calls[0][0];
+    const next = updater(healthyTasks);
+
+    expect(next.find((task: any) => task.id === 'first').order).toBe(0);
+    expect(next.find((task: any) => task.id === 'second').order).toBe(2048);
+    expect(next.find((task: any) => task.id === 'dragged').order).toBe(1024);
+  });
+
   test('bulkUpdateTasks invokes correct updaters with payload', () => {
     const { result } = renderHook(() => useTaskOperations(baseProps));
 

--- a/src/hooks/useTaskOperations.ts
+++ b/src/hooks/useTaskOperations.ts
@@ -4,6 +4,9 @@ import {
   createManualTask,
   createRecurringTaskFromTask,
   getNextTaskOrderTop,
+  getTaskOrder,
+  rebalanceTaskOrders,
+  shouldRebalanceTaskOrders,
   updateTaskColumns,
   createTaskColumn,
   validateTaskDependencies,
@@ -67,6 +70,35 @@ function prependUniqueRecurringTasks(previous, recurringTasks) {
   });
 
   return uniqueRecurringTasks.length ? [...uniqueRecurringTasks, ...previous] : previous;
+}
+
+function taskScopeValue(value) {
+  return String(value || '');
+}
+
+function isTaskInOrderScope(task, status, group) {
+  return (
+    taskScopeValue(task?.status) === taskScopeValue(status) &&
+    taskScopeValue(task?.group) === taskScopeValue(group)
+  );
+}
+
+function insertTaskByPlacement(sortedTasks, movingTask, placement) {
+  const nextTasks = sortedTasks.filter((task) => task.id !== movingTask.id);
+  const previousIndex = nextTasks.findIndex((task) => task.id === placement.previousTaskId);
+  const nextIndex = nextTasks.findIndex((task) => task.id === placement.nextTaskId);
+
+  if (previousIndex >= 0) {
+    nextTasks.splice(previousIndex + 1, 0, movingTask);
+    return nextTasks;
+  }
+
+  if (nextIndex >= 0) {
+    nextTasks.splice(nextIndex, 0, movingTask);
+    return nextTasks;
+  }
+
+  return [movingTask, ...nextTasks];
 }
 
 export default function useTaskOperations({
@@ -178,6 +210,100 @@ export default function useTaskOperations({
     return nextTask;
   }
 
+  function applyTaskOrderPayloads(payloadsByTaskId) {
+    if (!payloadsByTaskId?.size) {
+      return;
+    }
+
+    const updatedAt = new Date().toISOString();
+    const manualPayloads = new Map();
+    const derivedPayloads = {};
+
+    payloadsByTaskId.forEach((payload, taskId) => {
+      const task = meetingTasks.find((item) => item.id === taskId);
+      if (!task) {
+        return;
+      }
+
+      const nextPayload = {
+        ...payload,
+        updatedAt,
+      };
+
+      if (task.sourceType === 'manual' || task.sourceType === 'google') {
+        manualPayloads.set(taskId, nextPayload);
+        return;
+      }
+
+      derivedPayloads[taskId] = nextPayload;
+    });
+
+    if (manualPayloads.size) {
+      setManualTasks((previous) =>
+        previous.map((item) =>
+          manualPayloads.has(item.id)
+            ? {
+                ...item,
+                ...manualPayloads.get(item.id),
+              }
+            : item
+        )
+      );
+    }
+
+    if (Object.keys(derivedPayloads).length) {
+      setTaskState((previous) => {
+        const nextState = { ...previous };
+        Object.entries(derivedPayloads).forEach(([taskId, nextPayload]) => {
+          nextState[taskId] = {
+            ...(previous[taskId] || {}),
+            ...(nextPayload && typeof nextPayload === 'object' ? nextPayload : {}),
+          };
+        });
+        return nextState;
+      });
+    }
+  }
+
+  function buildRebalancedReorderPayloads(task, placement) {
+    const nextStatus = placement.status !== undefined ? placement.status : task.status;
+    const nextGroup = placement.group !== undefined ? placement.group : task.group;
+    const destinationTasks = meetingTasks
+      .filter((item) => item.id !== task.id && isTaskInOrderScope(item, nextStatus, nextGroup))
+      .sort((left, right) => getTaskOrder(left) - getTaskOrder(right));
+
+    if (!shouldRebalanceTaskOrders(destinationTasks)) {
+      return null;
+    }
+
+    const movingTask = {
+      ...task,
+      ...(placement.status !== undefined ? { status: placement.status } : {}),
+      ...(placement.group !== undefined ? { group: placement.group } : {}),
+    };
+    const orderedTasks = insertTaskByPlacement(destinationTasks, movingTask, placement);
+    const payloadsByTaskId = new Map();
+
+    rebalanceTaskOrders(orderedTasks).forEach((nextTask) => {
+      const payload: Record<string, any> = {
+        order: nextTask.order,
+      };
+
+      if (nextTask.id === task.id) {
+        if (placement.status !== undefined) {
+          payload.status = placement.status;
+        }
+        if (placement.group !== undefined) {
+          payload.group = placement.group;
+        }
+      }
+
+      payloadsByTaskId.set(nextTask.id, payload);
+    });
+
+    return payloadsByTaskId;
+  }
+
   function createTaskFromComposer(draft) {
     if (!currentUser || !currentWorkspaceId) return null;
 
@@ -211,6 +337,12 @@ export default function useTaskOperations({
   function reorderTask(taskId, placement) {
     const task = meetingTasks.find((item) => item.id === taskId);
     if (!task) return;
+    const rebalancedPayloads = buildRebalancedReorderPayloads(task, placement);
+    if (rebalancedPayloads) {
+      applyTaskOrderPayloads(rebalancedPayloads);
+      return;
+    }
+
     updateTask(taskId, buildTaskReorderUpdate(meetingTasks, placement));
   }
 

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -3,6 +3,7 @@ import { createId } from './storage';
 import { createGoogleTaskConflictState } from './googleSync';
 
 const ORDER_GAP = 1024;
+const ORDER_REBALANCE_MIN_GAP = 1;
 
 export const DEFAULT_TASK_COLUMNS = [
   { id: 'todo', label: 'Do zrobienia', color: '#5a92ff', isDone: false, system: true },
@@ -761,6 +762,36 @@ export function buildTaskReorderUpdate(tasks, placement = {}) {
     ...(placement.group !== undefined ? { group: placement.group } : {}),
     order,
   };
+}
+
+export function shouldRebalanceTaskOrders(tasks, options = {}) {
+  const minGap = Math.max(0, Number(options.minGap) || ORDER_REBALANCE_MIN_GAP);
+  const sorted = [...safeArray(tasks)].sort(
+    (left, right) => getTaskOrder(left) - getTaskOrder(right)
+  );
+
+  if (sorted.length < 2) {
+    return false;
+  }
+
+  for (let index = 1; index < sorted.length; index += 1) {
+    const gap = getTaskOrder(sorted[index]) - getTaskOrder(sorted[index - 1]);
+    if (!Number.isFinite(gap) || gap < minGap) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
+export function rebalanceTaskOrders(tasks, options = {}) {
+  const gap = Math.max(1, Number(options.gap) || ORDER_GAP);
+  const startOrder = Number.isFinite(Number(options.startOrder)) ? Number(options.startOrder) : 0;
+
+  return safeArray(tasks).map((task, index) => ({
+    ...task,
+    order: startOrder + index * gap,
+  }));
 }
 
 export function nextRecurringDueDate(value, recurrence) {


### PR DESCRIPTION
## Summary
- Adds task order rebalance helpers for crowded manual-order scopes.
- Rebalances only the affected status/group when order gaps collapse below the safe threshold.
- Preserves the requested visual order and keeps the existing single-task reorder path when gaps are healthy.

Closes #1385

## Validation
- `pnpm run typecheck` ✅
- `pnpm exec vitest run src/hooks/useTaskOperations.test.ts --coverage.enabled=false --reporter=dot` ✅
- `pnpm exec vitest run src/lib/tasks.coverage.test.ts src/hooks/useTaskOperations.test.ts --coverage.enabled=false --reporter=dot` ✅
- `pnpm exec prettier --check src/lib/tasks.ts src/hooks/useTaskOperations.ts src/hooks/useTaskOperations.test.ts` ✅
- pre-push `test:release:guard` ✅ (server 101 files / 1471 tests passed, focused frontend guard 82 tests passed, build warning audit passed)

## Risks
- Rebalance intentionally updates order values for all tasks in the affected status/group scope when gaps are crowded; unrelated groups/columns are left untouched.