### PR TITLE
feat(tasks): complete My Day reminder metadata (#1386)

### DIFF
--- a/src/TasksTab.test.tsx
+++ b/src/TasksTab.test.tsx
@@ -252,6 +252,84 @@ describe('TasksTab', () => {
     expect(screen.getByText(/(Overdue|Zaległe|Zalegle)/i)).toBeInTheDocument();
   });
 
+  test('filters tasks from the visible My Day smart list', async () => {
+    renderTasksTab({
+      defaultView: 'list',
+      tasks: [
+        {
+          id: 'task_my_day',
+          title: 'Widoczne w Moim dniu',
+          owner: 'Anna',
+          group: '',
+          description: '',
+          dueDate: '',
+          reminderAt: '2026-03-20T09:00:00.000Z',
+          myDay: true,
+          notes: '',
+          sourceType: 'manual',
+          sourceMeetingId: '',
+          sourceMeetingTitle: '',
+          sourceMeetingDate: '',
+          sourceRecordingId: '',
+          sourceQuote: '',
+          createdAt: '2026-03-14T09:00:00.000Z',
+          updatedAt: '2026-03-14T09:00:00.000Z',
+          status: 'todo',
+          important: false,
+          completed: false,
+          priority: 'medium',
+          tags: [],
+          assignedTo: ['Anna'],
+          comments: [],
+          history: [],
+          dependencies: [],
+          subtasks: [],
+          order: -100,
+          assignedToMe: true,
+        },
+        {
+          id: 'task_other',
+          title: 'Poza Moim dniem',
+          owner: 'Anna',
+          group: '',
+          description: '',
+          dueDate: '',
+          reminderAt: '',
+          myDay: false,
+          notes: '',
+          sourceType: 'manual',
+          sourceMeetingId: '',
+          sourceMeetingTitle: '',
+          sourceMeetingDate: '',
+          sourceRecordingId: '',
+          sourceQuote: '',
+          createdAt: '2026-03-14T09:00:00.000Z',
+          updatedAt: '2026-03-14T09:00:00.000Z',
+          status: 'todo',
+          important: false,
+          completed: false,
+          priority: 'medium',
+          tags: [],
+          assignedTo: ['Anna'],
+          comments: [],
+          history: [],
+          dependencies: [],
+          subtasks: [],
+          order: -99,
+          assignedToMe: true,
+        },
+      ],
+    });
+
+    await userEvent.click(screen.getAllByRole('button', { name: /Mój dzień/i })[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText('Widoczne w Moim dniu')).toBeInTheDocument();
+      expect(screen.queryByText('Poza Moim dniem')).not.toBeInTheDocument();
+    });
+    expect(screen.getByText(/Przypomnienie:/i)).toBeInTheDocument();
+  });
+
   test('pokazuje komunikat bledu, gdy onCreateTask zwraca falsy (np. brak workspace)', async () => {
     const toastModule = await import('./shared/Toast');
     const errorSpy = vi.fn();

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -8290,3 +8290,57 @@
     column-gap: 12px !important;
   }
 }
+
+.tasks-layout.ms-todo .todo-row-meta-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.tasks-layout.ms-todo .todo-metadata-badge {
+  display: inline-flex;
+  align-items: center;
+  min-height: 22px;
+  padding: 0 8px;
+  border: 1px solid rgba(20, 184, 166, 0.24);
+  border-radius: 999px;
+  background: rgba(20, 184, 166, 0.1);
+  color: var(--color-teal-700, #0f766e);
+  font-size: 0.75rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.tasks-layout.ms-todo .todo-date-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  align-items: flex-start;
+}
+
+.tasks-layout.ms-todo .todo-date-stack small {
+  color: var(--color-muted);
+  font-size: 0.75rem;
+  line-height: 1.25;
+}
+
+.tasks-layout.ms-todo .todo-create-my-day {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  min-height: 48px;
+  padding: 10px 12px;
+  border: 1px solid var(--color-border);
+  border-radius: 12px;
+  background: var(--color-surface-subtle, rgba(15, 23, 42, 0.03));
+  color: var(--color-text);
+  font-weight: 700;
+}
+
+.tasks-layout.ms-todo .todo-create-my-day span {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}

--- a/src/tasks/TaskCreateForm.test.tsx
+++ b/src/tasks/TaskCreateForm.test.tsx
@@ -98,6 +98,8 @@ describe('TaskCreateForm', () => {
     expect(screen.getByPlaceholderText('Dodaj zadanie (N)...')).toBeInTheDocument();
     expect(screen.getByText('Termin')).toBeInTheDocument();
     expect(screen.getByText('Godzina')).toBeInTheDocument();
+    expect(screen.getByText('Przypomnienie')).toBeInTheDocument();
+    expect(screen.getByText('Dodaj do Mojego dnia')).toBeInTheDocument();
     expect(screen.getByLabelText('Cały dzień')).toBeInTheDocument();
     expect(screen.getByText('Osoba')).toBeInTheDocument();
     expect(screen.getByText('Priorytet')).toBeInTheDocument();
@@ -112,7 +114,6 @@ describe('TaskCreateForm', () => {
   it('does not render fields absent from the create modal reference', () => {
     render(<TaskCreateForm {...defaultProps} />);
 
-    expect(screen.queryByText('Przypomnienie')).not.toBeInTheDocument();
     expect(screen.queryByText('Status')).not.toBeInTheDocument();
     expect(screen.queryByText('Grupa')).not.toBeInTheDocument();
     expect(screen.queryByText('Ważne')).not.toBeInTheDocument();
@@ -262,6 +263,27 @@ describe('TaskCreateForm', () => {
       expect.objectContaining({
         description: 'Opis zadania',
         notes: '',
+      })
+    );
+  });
+
+  it('submits reminder metadata and My Day without implying push notifications', () => {
+    const onSubmit = vi.fn();
+    render(<TaskCreateForm {...defaultProps} onSubmit={onSubmit} />);
+
+    const titleInput = screen.getByPlaceholderText('Dodaj zadanie (N)...');
+    fireEvent.change(titleInput, { target: { value: 'Zadanie na dzisiaj' } });
+    fireEvent.change(screen.getByLabelText('Przypomnienie zadania'), {
+      target: { value: '2026-03-20T09:15' },
+    });
+    fireEvent.click(screen.getByLabelText('Dodaj do Mojego dnia'));
+    fireEvent.keyDown(titleInput, { key: 'Enter' });
+
+    expect(screen.getByText(/nie wysyła powiadomień push/i)).toBeInTheDocument();
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        reminderAt: '2026-03-20T09:15',
+        myDay: true,
       })
     );
   });

--- a/src/tasks/TaskCreateForm.tsx
+++ b/src/tasks/TaskCreateForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
+  Bell,
   Calendar,
   Check,
   ChevronDown,
@@ -10,6 +11,7 @@ import {
   Lightbulb,
   Plus,
   Sparkles,
+  SunMedium,
   Tag,
   User,
 } from 'lucide-react';
@@ -31,6 +33,7 @@ export interface TaskDraft {
   reminderAt: string;
   tags: string | string[];
   important: boolean;
+  myDay: boolean;
   description: string;
   notes: string;
   allDay?: boolean;
@@ -116,6 +119,18 @@ function splitDraftDateTime(value: string) {
     date,
     time: /^\d{2}:\d{2}/.test(timeValue) ? timeValue.slice(0, 5) : '',
   };
+}
+
+function toDateTimeLocalInput(value: string) {
+  if (!value) return '';
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}/.test(value) ? value.slice(0, 16) : '';
+  }
+
+  const offset = date.getTimezoneOffset() * 60 * 1000;
+  return new Date(date.getTime() - offset).toISOString().slice(0, 16);
 }
 
 function composeDueDate(displayDate: string, time: string, allDay: boolean) {
@@ -231,6 +246,7 @@ function buildInitialDraft(
     reminderAt: initialDraft.reminderAt || '',
     tags: normalizeDraftTags(initialDraft.tags),
     important: initialDraft.important || false,
+    myDay: Boolean(initialDraft.myDay),
     description: initialDraft.description || '',
     notes: initialDraft.notes || '',
     allDay: Boolean(initialDraft.allDay),
@@ -291,6 +307,8 @@ export default function TaskCreateForm({
     initialDraft.priority,
     initialDraft.status,
     initialDraft.dueDate,
+    initialDraft.reminderAt,
+    initialDraft.myDay,
     Array.isArray(initialDraft.tags) ? initialDraft.tags.join('|') : initialDraft.tags,
     initialDraft.description,
     initialDraft.notes,
@@ -398,6 +416,8 @@ export default function TaskCreateForm({
         ...draft,
         title: draft.title.trim(),
         dueDate,
+        reminderAt: draft.reminderAt || '',
+        myDay: Boolean(draft.myDay),
         allDay,
         notes: draft.notes || '',
       });
@@ -726,6 +746,38 @@ export default function TaskCreateForm({
             </select>
             <ChevronDown size={16} aria-hidden="true" />
           </div>
+        </label>
+
+        <label className="todo-create-field">
+          <span>
+            <Bell size={16} aria-hidden="true" />
+            Przypomnienie
+          </span>
+          <input
+            type="datetime-local"
+            className="todo-detail-unified-field"
+            value={toDateTimeLocalInput(draft.reminderAt)}
+            onChange={(event) => applyDraftPatch({ reminderAt: event.target.value })}
+            aria-label="Przypomnienie zadania"
+            aria-describedby="task-reminder-metadata-hint"
+          />
+          <small id="task-reminder-metadata-hint" className="todo-create-field-hint">
+            Metadane w zadaniu; aplikacja nie wysyła powiadomień push.
+          </small>
+        </label>
+
+        <label className="todo-create-my-day">
+          <span>
+            <SunMedium size={16} aria-hidden="true" />
+            Dodaj do Mojego dnia
+          </span>
+          <input
+            className="ui-checkbox"
+            type="checkbox"
+            checked={Boolean(draft.myDay)}
+            onChange={(event) => applyDraftPatch({ myDay: event.target.checked })}
+            aria-label="Dodaj do Mojego dnia"
+          />
         </label>
 
         <label className="todo-create-field todo-create-field--full">

--- a/src/tasks/TaskDetailsPanel.tsx
+++ b/src/tasks/TaskDetailsPanel.tsx
@@ -39,6 +39,8 @@ function buildTaskUpdatePatch(patch: Partial<TaskDraft>) {
 
   if ('title' in patch) nextPatch.title = patch.title;
   if ('dueDate' in patch) nextPatch.dueDate = patch.dueDate;
+  if ('reminderAt' in patch) nextPatch.reminderAt = patch.reminderAt || '';
+  if ('myDay' in patch) nextPatch.myDay = Boolean(patch.myDay);
   if ('owner' in patch) nextPatch.owner = patch.owner;
   if ('assignedTo' in patch) nextPatch.assignedTo = patch.assignedTo || [];
   if ('priority' in patch) nextPatch.priority = patch.priority;

--- a/src/tasks/TaskKanbanView.tsx
+++ b/src/tasks/TaskKanbanView.tsx
@@ -4,7 +4,13 @@ import {
   getTaskLifecycleStatus,
   TASK_LIFECYCLE_STATUSES,
 } from '../lib/tasks';
-import { canDrop, formatListDueDate, handleCardKeyDown, writeDragTask } from './taskViewUtils';
+import {
+  canDrop,
+  formatListDueDate,
+  formatReminderDateTime,
+  handleCardKeyDown,
+  writeDragTask,
+} from './taskViewUtils';
 import './TaskKanbanViewStyles.css';
 import TagBadge from '../shared/TagBadge';
 
@@ -164,6 +170,7 @@ function KanbanCard({
   const subtasks = task.subtasks || [];
   const assignees = task.assignedTo?.length ? task.assignedTo : task.owner ? [task.owner] : [];
   const tags = task.tags || [];
+  const reminderLabel = formatReminderDateTime(task.reminderAt);
 
   return (
     <div className="todo-kanban-card-shell">
@@ -278,8 +285,16 @@ function KanbanCard({
                 ↻
               </span>
             ) : null}
-            {task.reminderAt ? (
-              <span className="kanban-flag-icon" title="Przypomnienie">
+            {task.myDay ? (
+              <span className="kanban-flag-icon" title="Mój dzień">
+                MD
+              </span>
+            ) : null}
+            {reminderLabel ? (
+              <span
+                className="kanban-flag-icon"
+                title={`Przypomnienie: ${reminderLabel}. Bez powiadomień push.`}
+              >
                 ⏰
               </span>
             ) : null}

--- a/src/tasks/TaskListView.tsx
+++ b/src/tasks/TaskListView.tsx
@@ -12,7 +12,13 @@ import {
   PencilLine,
   UsersRound,
 } from 'lucide-react';
-import { canDrop, formatListDueDate, handleCardKeyDown, writeDragTask } from './taskViewUtils';
+import {
+  canDrop,
+  formatListDueDate,
+  formatReminderDateTime,
+  handleCardKeyDown,
+  writeDragTask,
+} from './taskViewUtils';
 import {
   getTaskAssigneeSummary,
   getTaskLifecycleStatus,
@@ -383,6 +389,7 @@ function TaskListView({
                 const ai = aiMeta(task);
                 const SourceIcon = source.Icon;
                 const canOpenSource = Boolean(task.sourceMeetingId && openMeetingHandler);
+                const reminderLabel = formatReminderDateTime(task.reminderAt);
 
                 return (
                   <div key={task.id} className="todo-list-row-shell">
@@ -417,6 +424,11 @@ function TaskListView({
                       <span className="todo-title-cell">
                         <strong>{task.title}</strong>
                         <small className="todo-row-description">{displayDescription(task)}</small>
+                        {task.myDay ? (
+                          <span className="todo-row-meta-badges">
+                            <span className="todo-metadata-badge">Mój dzień</span>
+                          </span>
+                        ) : null}
                       </span>
 
                       <span className="todo-status-cell">
@@ -433,8 +445,13 @@ function TaskListView({
                         </span>
                       </span>
 
-                      <span className="todo-date">
-                        {formatListDueDate(task.dueDate) || 'Brak terminu'}
+                      <span className="todo-date todo-date-stack">
+                        <span>{formatListDueDate(task.dueDate) || 'Brak terminu'}</span>
+                        {reminderLabel ? (
+                          <small title="Metadane w zadaniu; aplikacja nie wysyła powiadomień push.">
+                            Przypomnienie: {reminderLabel}
+                          </small>
+                        ) : null}
                       </span>
 
                       <span className="todo-assignee-cell">

--- a/src/tasks/TasksSidebar.tsx
+++ b/src/tasks/TasksSidebar.tsx
@@ -19,6 +19,7 @@ import {
 
 const iconMap = {
   today: SunMedium,
+  my_day: SunMedium,
   week: CalendarRange,
   planned: Clock3,
   overdue: AlertCircle,

--- a/src/tasks/taskViewUtils.test.ts
+++ b/src/tasks/taskViewUtils.test.ts
@@ -3,6 +3,7 @@ import {
   safeArray,
   toInputDateTime,
   formatListDueDate,
+  formatReminderDateTime,
   dueTone,
   canDrop,
   writeDragTask,
@@ -68,6 +69,19 @@ describe('formatListDueDate', () => {
     expect(result).toMatch(/sty|01/i);
     expect(result).toMatch(/15/);
     expect(result).toMatch(/2026/);
+  });
+});
+
+describe('formatReminderDateTime', () => {
+  it('returns empty string for missing or invalid reminder metadata', () => {
+    expect(formatReminderDateTime('')).toBe('');
+    expect(formatReminderDateTime('not-a-date')).toBe('');
+  });
+
+  it('formats reminder metadata with date and time', () => {
+    const result = formatReminderDateTime('2026-03-20T09:15:00.000Z');
+    expect(result).toMatch(/20/);
+    expect(result).toMatch(/\d{2}:15/);
   });
 });
 
@@ -380,13 +394,21 @@ describe('buildSidebarLists', () => {
       { id: 'done', label: 'Zakonczone', isDone: true },
     ];
     const tasks = [
-      { id: '1', status: 'c1', important: true, group: 'Sprint1', priority: 'high' },
+      {
+        id: '1',
+        status: 'c1',
+        important: true,
+        group: 'Sprint1',
+        priority: 'high',
+        myDay: true,
+      },
       { id: '2', status: 'c1', group: '', priority: 'medium' },
     ];
     const result = buildSidebarLists(tasks, columns);
     expect(result.baseLists.length).toBeGreaterThan(0);
     expect(result.taskLists.map((item) => item.label)).toEqual([
       'Dziś',
+      'Mój dzień',
       'Ten tydzień',
       'Zaplanowane',
       'Zaległe',
@@ -445,6 +467,10 @@ describe('buildContextualDraft', () => {
   it('does not override existing group', () => {
     const draft = buildContextualDraft({ group: 'Beta' }, 'group:Alpha', cols);
     expect(draft.group).toBe('Beta');
+  });
+  it('marks contextual drafts as My Day from the My Day smart list', () => {
+    const draft = buildContextualDraft({ myDay: false }, 'smart:my_day', cols);
+    expect(draft.myDay).toBe(true);
   });
 });
 

--- a/src/tasks/taskViewUtils.ts
+++ b/src/tasks/taskViewUtils.ts
@@ -42,6 +42,26 @@ export function formatListDueDate(value) {
     .replace(/\./g, '');
 }
 
+export function formatReminderDateTime(value) {
+  if (!value) {
+    return '';
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return '';
+  }
+
+  return new Intl.DateTimeFormat('pl-PL', {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+    .format(date)
+    .replace(/\./g, '');
+}
+
 export function dueTone(value) {
   if (!value) {
     return 'normal';
@@ -123,6 +143,9 @@ export function buildSidebarLists(tasks, boardColumns) {
     return due >= todayStart.getTime() && due < weekEnd.getTime();
   };
 
+  const isMyDay = (task) =>
+    Boolean(task.myDay) && isOpenLifecycle(taskLifecycle(task, boardColumns, tasks));
+
   const normalizeStatusLabel = (column) => {
     const id = String(column.id || '').toLowerCase();
     const label = String(column.label || '');
@@ -156,6 +179,12 @@ export function buildSidebarLists(tasks, boardColumns) {
       label: 'Dziś',
       icon: 'today',
       count: tasks.filter(isDueToday).length,
+    },
+    {
+      id: 'smart:my_day',
+      label: 'Mój dzień',
+      icon: 'my_day',
+      count: tasks.filter(isMyDay).length,
     },
     {
       id: 'smart:week',
@@ -501,6 +530,10 @@ export function buildContextualDraft(quickDraft, selectedListId, boardColumns) {
 
   if (selectedListId?.startsWith('group:') && !nextDraft.group) {
     nextDraft.group = selectedListId.slice('group:'.length);
+  }
+
+  if (selectedListId === 'smart:my_day') {
+    nextDraft.myDay = true;
   }
 
   return nextDraft;


### PR DESCRIPTION
﻿## Summary
- Adds the visible `Mój dzień` smart list and count for open `myDay` tasks.
- Makes contextual task creation from that smart list set `myDay: true`.
- Adds reminder metadata editing and display without implying push/browser notifications.
- Shows lightweight My Day/reminder metadata in list and kanban task surfaces.

Closes #1386

## Validation
- `corepack pnpm exec vitest run src\tasks\taskViewUtils.test.ts src\TasksTab.test.tsx src\tasks\TaskCreateForm.test.tsx --coverage.enabled=false --reporter=dot` passed: 3 files / 92 tests.
- `corepack pnpm run typecheck` passed.
- `corepack pnpm run lint:css` passed.
- `corepack pnpm run audit:mojibake` passed.
- `corepack pnpm exec prettier --check ...` passed for touched files.
- `corepack pnpm run build` passed.
- Pre-push `pnpm run test:release:guard` passed: backend 101 files / 1471 tests, focused frontend guard 82 tests, build warning audit passed.

## Visual evidence / residual risk
- Attempted `corepack pnpm exec playwright test tests/e2e/visual-regression.spec.ts --project=chromium --grep "@reference tasks list with detail panel"`.
- Local run was inconclusive: Playwright webServer used the wrong global `pnpm.cmd` in one attempt, then the Vite server became unavailable mid-run with `ERR_CONNECTION_REFUSED`; production build and unit/UI tests stayed green.
- No public API, backend, DB schema, auth, Google sync, task lifecycle, or recording logic changed.
