### PR TITLE
feat(studio): simplify summary panel structure (#1397)

### DIFF
--- a/src/studio/StudioMeetingView.tsx
+++ b/src/studio/StudioMeetingView.tsx
@@ -2966,7 +2966,7 @@ export default function StudioMeetingView({
                 )}
 
                 {studioAnalysis?.summary || isEditingAnalysis ? (
-                  <div className="panel-body ff-summary-layout">
+                  <div className="panel-body ff-summary-layout ff-summary-sectioned">
                     <div className="summary-hero">
                       {/*
                          We render a single <ul className="summary-highlights"> for the blocks.
@@ -3026,7 +3026,7 @@ export default function StudioMeetingView({
                     </div>
 
                     <div
-                      className={`summary-grid${!isEditingAnalysis ? ' summary-grid-meta-only' : ''}`}
+                      className={`summary-grid summary-grid-sectioned${!isEditingAnalysis ? ' summary-grid-meta-only' : ''}`}
                     >
                       <section className="summary-card summary-card-overflow-visible">
                         <div className="summary-card-head">
@@ -3106,7 +3106,7 @@ export default function StudioMeetingView({
                         </div>
                       </section>
 
-                      <section className="summary-card">
+                      <section className="summary-card summary-card-priority">
                         <div className="summary-card-head">
                           <h3>Decyzje</h3>
                           {safeArray(studioAnalysis.decisions).length > 0 && (
@@ -3151,7 +3151,7 @@ export default function StudioMeetingView({
                           <p className="soft-copy">Brak wykrytych decyzji.</p>
                         )}
                       </section>
-                      <section className="summary-card">
+                      <section className="summary-card summary-card-priority">
                         <div className="summary-card-head">
                           <h3>Action items</h3>
                           {actionItems.length > 0 && <span>{actionItems.length}</span>}

--- a/src/studio/StudioMeetingViewStyles.css
+++ b/src/studio/StudioMeetingViewStyles.css
@@ -2636,6 +2636,114 @@
   font-size: 0.74rem;
 }
 
+.ff-summary-sectioned {
+  gap: 0;
+  padding-top: 6px;
+}
+
+.ff-summary-sectioned .summary-hero {
+  padding: 0 0 18px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.ff-summary-sectioned .summary-highlights {
+  gap: 12px;
+}
+
+.ff-summary-sectioned .summary-highlight,
+.ff-summary-sectioned .summary-hero .summary-highlight:first-child {
+  padding: 0;
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
+
+.summary-grid-sectioned {
+  grid-template-columns: 1fr;
+  gap: 0;
+}
+
+.summary-grid-sectioned .summary-card {
+  gap: 14px;
+  padding: 18px 0;
+  border: 0;
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  background: transparent;
+}
+
+.summary-grid-sectioned .summary-card:first-child {
+  border-top: 0;
+}
+
+.summary-grid-sectioned .summary-card-priority {
+  padding-block: 20px;
+}
+
+.summary-grid-sectioned .summary-card-head h3 {
+  color: var(--text-main, #fff);
+  font-size: 0.86rem;
+  letter-spacing: 0.08em;
+}
+
+.summary-grid-sectioned .summary-card-head span {
+  min-width: 28px;
+  min-height: 24px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  background: rgba(117, 214, 196, 0.1);
+  color: #9af0de;
+  font-weight: 700;
+  text-align: center;
+}
+
+.summary-grid-sectioned .analysis-list {
+  display: grid;
+  gap: 8px;
+}
+
+.summary-grid-sectioned .analysis-list li {
+  margin-bottom: 0;
+  padding: 10px 12px 10px 30px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.025);
+}
+
+.summary-grid-sectioned .analysis-list li::before {
+  top: 10px;
+  left: 12px;
+}
+
+.summary-grid-sectioned .summary-pill-card {
+  width: 100%;
+}
+
+.studio-analysis-summary-panel .ff-sov-card {
+  margin: 18px 24px 0;
+  padding: 0 0 20px;
+  border: 0;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+.studio-analysis-summary-panel .ff-sov-card-head {
+  margin-bottom: 16px;
+}
+
+.studio-analysis-summary-panel .ff-sov-bar-track {
+  height: 30px;
+}
+
+.studio-analysis-summary-panel .ff-sov-legend {
+  gap: 10px;
+}
+
+.studio-analysis-summary-panel .ff-sov-legend-item {
+  padding: 7px 12px;
+}
+
 .meeting-task-list {
   display: grid;
   gap: 10px;
@@ -4426,6 +4534,37 @@
 
 :root[data-theme='premium-light'] .ff-sov-percent {
   color: #087062;
+}
+
+:root[data-theme='premium-light'] .ff-summary-sectioned .summary-hero,
+:root[data-theme='premium-light'] .ff-summary-sectioned .summary-highlight,
+:root[data-theme='premium-light']
+  .ff-summary-sectioned
+  .summary-hero
+  .summary-highlight:first-child,
+:root[data-theme='premium-light'] .summary-grid-sectioned .summary-card,
+:root[data-theme='premium-light'] .studio-analysis-summary-panel .ff-sov-card {
+  background: transparent;
+  box-shadow: none;
+}
+
+:root[data-theme='premium-light'] .ff-summary-sectioned .summary-hero,
+:root[data-theme='premium-light'] .summary-grid-sectioned .summary-card,
+:root[data-theme='premium-light'] .studio-analysis-summary-panel .ff-sov-card {
+  border-color: rgba(43, 82, 74, 0.12);
+}
+
+:root[data-theme='premium-light'] .summary-grid-sectioned .analysis-list li {
+  background: rgba(255, 255, 252, 0.66);
+}
+
+:root[data-theme='premium-light'] .summary-grid-sectioned .summary-card-head h3 {
+  color: var(--text-1);
+}
+
+:root[data-theme='premium-light'] .summary-grid-sectioned .summary-card-head span {
+  background: rgba(28, 141, 122, 0.08);
+  color: var(--accent-strong);
 }
 
 :root[data-theme='premium-light'] .ff-player-bar {


### PR DESCRIPTION
## Summary
- Simplifies the Studio meeting summary panel by replacing nested card visual weight with section dividers.
- Keeps one main summary panel while making conversation share, decisions and action items easier to scan.
- Preserves existing data/editing behavior, evidence links, tags, participants and action item rendering.

## Before / After
- Before: summary, conversation share, decisions and actions were shown as several nested cards inside one panel.
- After: the panel uses a lighter sectioned layout, with share-of-voice as a divider section and priority sections for decisions/action items.
- Visual artifacts captured locally:
  - test-results/playwright/studio-compact-player-desktop-1440.png
  - test-results/playwright/studio-compact-player-mobile-390.png

## UX Scorecard
- Layout hierarchy: 9/10
- Density and scanability: 9/10
- Responsive risk: 8/10
- Accessibility preservation: 8/10
- Overall: 8.5/10

## Validation
- corepack pnpm run typecheck: PASS
- corepack pnpm run lint:css: PASS
- corepack pnpm exec playwright test tests/e2e/visual-regression.spec.ts --grep "studio compact player keeps content reachable": PASS
- corepack pnpm exec playwright test tests/e2e/visual-regression.spec.ts --grep "authenticated shell tabs desktop-1440": PASS
- corepack pnpm run audit:mojibake: PASS
- corepack pnpm run build: PASS
- Pre-push test:release:guard: PASS

## Full Visual Run
- corepack pnpm exec playwright test tests/e2e/visual-regression.spec.ts: 51 passed, 2 failed.
- The failures are unrelated console-noise failures in @state overlays and failure states mobile-320/desktop-1920: Failed to load resource: net::ERR_CONNECTION_REFUSED.
- Studio summary/player scenarios passed in the full run.

## Risks / Notes
- Presentation-only change in Studio summary panel.
- Does not change transcript, recording, backend, task lifecycle or AI analysis logic.
- The mobile artifact still exposes an existing player retry-button clipping risk in the failure state; that is outside this issue's summary-panel scope.

Closes #1397
