### PR TITLE
Refactor Tasks light-theme reference variant (#1390)

### DIFF
--- a/src/TasksTab.tsx
+++ b/src/TasksTab.tsx
@@ -830,7 +830,7 @@ export default function TasksTab({
   return (
     <PageShell className="tasks-page-shell">
       <SplitPane
-        className="tasks-layout ms-todo"
+        className="tasks-layout ms-todo tasks-layout--reference-list"
         sidebarWidth="default"
         sidebar={
           <TasksSidebar

--- a/src/styles/mobileResponsiveContracts.test.ts
+++ b/src/styles/mobileResponsiveContracts.test.ts
@@ -56,6 +56,27 @@ describe('mobile responsive CSS contracts', () => {
     expect(css).toContain('.tasks-layout.ms-todo .todo-primary-toolbar');
   });
 
+  // ─────────────────────────────────────────────────────────────────
+  // Issue #1390 — Tasks reference-list light-theme variant
+  // Date: 2026-07-07
+  // Bug: screenshot-specific light-theme overrides were scoped only to
+  //      `.tasks-layout.ms-todo`, making the cascade too broad.
+  // Fix: require an explicit root variant class for the reference list view.
+  // ─────────────────────────────────────────────────────────────────
+  it('scopes screenshot-first task list overrides to the reference-list variant', () => {
+    const css = readCss('./tasks.css');
+    const tasksTab = readFileSync('src/TasksTab.tsx', 'utf8');
+    const referenceBlock = css.slice(0, css.indexOf('@keyframes todoOverlayFadeIn'));
+
+    expect(tasksTab).toContain('tasks-layout ms-todo tasks-layout--reference-list');
+    expect(referenceBlock).toContain(
+      ":root[data-theme='premium-light'] .tasks-layout.ms-todo:where(.tasks-layout--reference-list)"
+    );
+    expect(referenceBlock).not.toContain(
+      ":root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-sidebar"
+    );
+  });
+
   it('turns recordings tables into labeled mobile cards', () => {
     const css = readCss('./recordings.css');
 

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -13,15 +13,18 @@
   animation: todoOverlayFadeIn 0.2s ease-out;
 }
 
-/* Screenshot-first reference: task list table, 2026-06-10 */
-:root[data-theme='premium-light'] .tasks-layout.ms-todo {
+/* Reference-list variant: approved screenshot-first task table, 2026-06-10.
+   Scope these forceful light-theme overrides to the explicit Tasks root variant. */
+:root[data-theme='premium-light'] .tasks-layout.ms-todo:where(.tasks-layout--reference-list) {
   grid-template-columns: 240px minmax(0, 1fr) !important;
   gap: 0 !important;
   padding: 0 !important;
   background: rgba(248, 250, 247, 0.74) !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-sidebar {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-sidebar {
   width: 240px !important;
   min-width: 240px !important;
   max-width: 240px !important;
@@ -33,11 +36,15 @@
   box-shadow: none !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-nav-panel {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-nav-panel {
   gap: 24px !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-workspace-title {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-workspace-title {
   min-height: 32px !important;
   padding: 0 !important;
   color: #17233b !important;
@@ -45,12 +52,18 @@
   font-weight: 760 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-workspace-toggle-arrow {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-workspace-toggle-arrow {
   display: none !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-side-link,
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-manage-lists-button {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-side-link,
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-manage-lists-button {
   min-height: 44px !important;
   grid-template-columns: 24px minmax(0, 1fr) auto !important;
   gap: 12px !important;
@@ -59,21 +72,29 @@
   color: #1d2a44 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-side-link.active {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-side-link.active {
   background: rgba(219, 245, 238, 0.86) !important;
   border-color: rgba(8, 126, 112, 0.18) !important;
   box-shadow: none !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-side-icon {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-side-icon {
   color: #007f73 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-main {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-main {
   padding: 26px 32px 22px !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-workspace-topline {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-workspace-topline {
   display: flex !important;
   align-items: center !important;
   justify-content: space-between !important;
@@ -81,7 +102,10 @@
   margin-bottom: 16px !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-workspace-topline h1 {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-workspace-topline
+  h1 {
   margin: 0 !important;
   color: #17233b !important;
   font-size: 1.72rem !important;
@@ -90,24 +114,34 @@
   letter-spacing: 0 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-workspace-actions,
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-primary-toolbar {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-workspace-actions,
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-primary-toolbar {
   display: flex !important;
   align-items: center !important;
   gap: 12px !important;
   min-width: 0 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-workspace-actions {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-workspace-actions {
   justify-content: flex-end !important;
   flex-wrap: wrap !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-primary-toolbar {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-primary-toolbar {
   margin-bottom: 26px !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-commandbar {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-commandbar {
   min-height: 48px !important;
   display: block !important;
   padding: 0 0 14px !important;
@@ -118,12 +152,16 @@
   box-shadow: none !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-commandbar-left {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-commandbar-left {
   width: 100% !important;
   overflow: visible !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-view-switch {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-view-switch {
   display: flex !important;
   gap: 28px !important;
   border: 0 !important;
@@ -132,7 +170,9 @@
   box-shadow: none !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-view-button {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-view-button {
   min-width: auto !important;
   min-height: 42px !important;
   display: inline-flex !important;
@@ -146,12 +186,16 @@
   font-weight: 620 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-view-button.active {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-view-button.active {
   color: #007f73 !important;
   background: transparent !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-view-button.active::after {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-view-button.active::after {
   left: 0 !important;
   right: 0 !important;
   bottom: 0 !important;
@@ -159,7 +203,9 @@
   background: #008d7d !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-add-inline-trigger {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-add-inline-trigger {
   min-height: 40px !important;
   padding: 0 18px !important;
   border-radius: 8px !important;
@@ -167,7 +213,9 @@
   box-shadow: 0 12px 24px rgba(0, 143, 128, 0.22) !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-toolbar-search {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-toolbar-search {
   width: 250px !important;
   max-width: 32vw !important;
   min-height: 40px !important;
@@ -176,8 +224,12 @@
   background: rgba(255, 255, 255, 0.88) !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-icon-button,
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-command-button {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-icon-button,
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-command-button {
   min-height: 40px !important;
   display: inline-flex !important;
   align-items: center !important;
@@ -190,30 +242,42 @@
   font-weight: 620 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-icon-button {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-icon-button {
   width: 42px !important;
   justify-content: center !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-view-panel {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-view-panel {
   margin-top: 18px !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-table-wrap {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-table-wrap {
   border-radius: 10px !important;
   border-color: rgba(31, 55, 84, 0.1) !important;
   background: rgba(255, 255, 255, 0.88) !important;
   box-shadow: 0 18px 42px rgba(31, 55, 84, 0.07) !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-table-head,
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-table-row {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-table-head,
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-table-row {
   min-width: 1040px !important;
   grid-template-columns: 38px minmax(320px, 2fr) 152px 128px 132px 190px 42px !important;
   column-gap: 12px !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-table-head {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-table-head {
   min-height: 44px !important;
   padding: 0 22px !important;
   color: #59657d !important;
@@ -224,74 +288,103 @@
   text-transform: none !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-table-row {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-table-row {
   min-height: 62px !important;
   padding: 0 22px !important;
   border-bottom-color: rgba(31, 55, 84, 0.1) !important;
   background: rgba(255, 255, 255, 0.72) !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-row-tools {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-row-tools {
   grid-template-columns: 18px !important;
   justify-content: start !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-drag-handle {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-drag-handle {
   display: none !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-task-circle {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-task-circle {
   width: 14px !important;
   height: 14px !important;
   border-radius: 3px !important;
   border: 1.5px solid #8a98ad !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-title-cell strong {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-title-cell
+  strong {
   color: #14213a !important;
   font-size: 0.89rem !important;
   font-weight: 760 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-title-meta {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-title-meta {
   color: #66708a !important;
   font-size: 0.78rem !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-status-badge,
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-priority-badge {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-status-badge,
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-priority-badge {
   min-height: 24px !important;
   padding: 0 9px !important;
   border-radius: 5px !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-priority-badge.high {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-priority-badge.high {
   color: #ef2b2a !important;
   background: transparent !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-priority-badge.medium {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-priority-badge.medium {
   color: #d96b00 !important;
   background: transparent !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-priority-badge.low {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-priority-badge.low {
   color: #008f5d !important;
   background: transparent !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-date {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-date {
   color: #17233b !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-assignee-cell {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-assignee-cell {
   display: inline-flex !important;
   align-items: center !important;
   gap: 12px !important;
   color: #23304b !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-assignee-avatar {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-assignee-avatar {
   width: 34px !important;
   height: 34px !important;
   display: inline-flex !important;
@@ -304,7 +397,9 @@
   font-weight: 780 !important;
 }
 
-:root[data-theme='premium-light'] .tasks-layout.ms-todo .todo-star {
+:root[data-theme='premium-light']
+  .tasks-layout.ms-todo:where(.tasks-layout--reference-list)
+  .todo-star {
   width: 28px !important;
   height: 28px !important;
   color: #60708a !important;


### PR DESCRIPTION
﻿## Summary
- Closes #1390.
- Added an explicit `tasks-layout--reference-list` root variant for the approved screenshot-first Tasks list layout.
- Scoped the forceful premium-light reference list overrides through `:where(.tasks-layout--reference-list)` so the variant is explicit without increasing specificity over later mobile rules.
- Added a CSS contract that guards the root class and scoped reference-list selector.

## Before / After
- Before: screenshot-specific light-theme overrides targeted every `.tasks-layout.ms-todo` instance in the top `tasks.css` block.
- After: the same approved visual styling applies only when the Tasks root opts into `tasks-layout--reference-list`; mobile/tablet override order remains intact because `:where()` keeps specificity flat.
- Visual baselines are unchanged.

## Validation
- `corepack pnpm run lint:css` — passed.
- `node_modules/.bin/vitest.cmd run src/styles/mobileResponsiveContracts.test.ts --coverage.enabled=false --reporter=dot` — 11 passed.
- `corepack pnpm run typecheck` — passed.
- `corepack pnpm run audit:mojibake` — passed.
- `node_modules/.bin/playwright.cmd test tests/e2e/visual-regression.spec.ts --grep "@reference tasks list with detail panel|@state empty tasks"` — 5 passed.
- `node_modules/.bin/playwright.cmd test tests/e2e/visual-regression.spec.ts --grep "@baseline authenticated shell tabs mobile-(320|390)"` — 2 passed after the specificity fix.
- `node_modules/.bin/playwright.cmd test tests/e2e/visual-regression.spec.ts` — 56 passed.
- Pre-push release guard — passed: server retry 1471 passed / 82 skipped, focused frontend 82 passed, build warning audit passed.

## Risks
- This intentionally scopes only the top reference-list override block. Broader Tasks CSS ownership cleanup is left to follow-up issues so this PR does not change product behavior.
