### PR TITLE
fix(tasks): separate Google sync lifecycle (#1384)

### DIFF
--- a/src/hooks/useGoogleIntegrations.ts
+++ b/src/hooks/useGoogleIntegrations.ts
@@ -18,6 +18,11 @@ import {
   upsertGoogleImportedTasks,
 } from '../lib/tasks';
 import {
+  getGoogleTaskSyncConflict,
+  getGoogleTaskSyncStatus,
+  normalizeGoogleTaskSyncState,
+} from '../lib/googleSync';
+import {
   disconnectGoogleCalendar as disconnectGoogleCalendarOnServer,
   fetchGoogleCalendarEvents,
   getGoogleCalendarStatus,
@@ -556,13 +561,15 @@ export default function useGoogleIntegrations({
       return undefined;
     }
 
-    const pendingTasks = manualTasks.filter(
-      (task) =>
-        task?.googleTaskId &&
-        task?.googleTaskListId === selectedGoogleTaskListId &&
-        task?.googleSyncStatus === 'local_changes' &&
-        !task?.googleSyncConflict
-    );
+    const pendingTasks = manualTasks.filter((task) => {
+      const sync = normalizeGoogleTaskSyncState(task);
+      return (
+        sync?.taskId &&
+        sync?.taskListId === selectedGoogleTaskListId &&
+        getGoogleTaskSyncStatus(task) === 'local_changes' &&
+        !getGoogleTaskSyncConflict(task)
+      );
+    });
 
     if (!pendingTasks.length) {
       return undefined;
@@ -576,7 +583,12 @@ export default function useGoogleIntegrations({
           break;
         }
 
-        const taskKey = `${task.googleTaskListId}:${task.googleTaskId}`;
+        const sync = normalizeGoogleTaskSyncState(task);
+        if (!sync?.taskId || !sync?.taskListId) {
+          continue;
+        }
+
+        const taskKey = `${sync.taskListId}:${sync.taskId}`;
         if (inFlightTaskSyncRef.current.has(taskKey)) {
           continue;
         }
@@ -585,8 +597,8 @@ export default function useGoogleIntegrations({
         try {
           const remoteResponse = await updateGoogleTask(
             googleTasksTokenRef.current,
-            task.googleTaskListId,
-            task.googleTaskId,
+            sync.taskListId,
+            sync.taskId,
             buildGoogleTaskPayloadFromSnapshot(task)
           );
           const now = new Date().toISOString();
@@ -605,6 +617,16 @@ export default function useGoogleIntegrations({
                     googleLocalUpdatedAt: now,
                     googleSyncStatus: 'synced',
                     googleSyncConflict: null,
+                    googleSync: normalizeGoogleTaskSyncState(item, {
+                      taskId: sync.taskId,
+                      taskListId: sync.taskListId,
+                      remoteUpdatedAt,
+                      syncedAt: now,
+                      pulledAt: now,
+                      localUpdatedAt: now,
+                      status: 'synced',
+                      conflict: null,
+                    }),
                     updatedAt: now,
                   }
             )
@@ -723,10 +745,11 @@ export default function useGoogleIntegrations({
   const resolveGoogleTaskConflict = useCallback(
     async (taskId, mode, finalSnapshot = null) => {
       const task = meetingTasks.find((item) => item.id === taskId);
-      const conflict = task?.googleSyncConflict;
+      const conflict = getGoogleTaskSyncConflict(task);
       if (!task || !conflict) {
         return;
       }
+      const sync = normalizeGoogleTaskSyncState(task);
 
       const nextSnapshot: Record<string, any> =
         mode === 'google'
@@ -741,14 +764,14 @@ export default function useGoogleIntegrations({
       let remoteResponse: { updated?: string } | null = null;
 
       if (mode !== 'google') {
-        if (!googleTasksTokenRef.current || !task.googleTaskId || !task.googleTaskListId) {
+        if (!googleTasksTokenRef.current || !sync?.taskId || !sync?.taskListId) {
           throw new Error('Najpierw polacz Google Tasks, aby zapisac finalna wersje.');
         }
 
         remoteResponse = await updateGoogleTask(
           googleTasksTokenRef.current,
-          task.googleTaskListId,
-          task.googleTaskId,
+          sync.taskListId,
+          sync.taskId,
           buildGoogleTaskPayloadFromSnapshot(nextSnapshot)
         );
       }
@@ -768,7 +791,7 @@ export default function useGoogleIntegrations({
                 updatedAt: now,
                 googleUpdatedAt:
                   remoteResponse?.updated ||
-                  task.googleSyncConflict?.remoteUpdatedAt ||
+                  conflict.remoteUpdatedAt ||
                   task.googleUpdatedAt ||
                   now,
                 googleSyncedAt: now,
@@ -776,6 +799,16 @@ export default function useGoogleIntegrations({
                 googleLocalUpdatedAt: now,
                 googleSyncStatus: 'synced',
                 googleSyncConflict: null,
+                googleSync: normalizeGoogleTaskSyncState(item, {
+                  taskId: sync?.taskId || item.googleTaskId,
+                  taskListId: sync?.taskListId || item.googleTaskListId,
+                  remoteUpdatedAt: remoteResponse?.updated || conflict.remoteUpdatedAt || now,
+                  syncedAt: now,
+                  pulledAt: now,
+                  localUpdatedAt: now,
+                  status: 'synced',
+                  conflict: null,
+                }),
                 history: [
                   ...(item.history || []),
                   createTaskHistoryEntry(

--- a/src/hooks/useTaskOperations.test.ts
+++ b/src/hooks/useTaskOperations.test.ts
@@ -102,6 +102,58 @@ describe('useTaskOperations', () => {
     expect(next.t2.title).toBe('Updated T2');
   });
 
+  test('local edit of a Google task updates nested sync state separately from task status', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-03-20T10:00:00.000Z'));
+
+    const googleTask = {
+      id: 'google-task',
+      title: 'Imported task',
+      status: 'c1',
+      sourceType: 'google',
+      googleTaskId: 'remote-1',
+      googleTaskListId: 'list-1',
+      googleSync: {
+        provider: 'google_tasks',
+        taskId: 'remote-1',
+        taskListId: 'list-1',
+        status: 'synced',
+        syncedAt: '2026-03-20T09:00:00.000Z',
+      },
+      history: [],
+      completed: false,
+      tags: [],
+      assignedTo: [],
+    };
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: [googleTask] })
+    );
+
+    act(() => {
+      result.current.updateTask('google-task', { title: 'Local title' });
+    });
+
+    const updater = mockSetManualTasks.mock.calls[0][0];
+    const next = updater([googleTask]);
+    const updatedTask = next.find((task: any) => task.id === 'google-task');
+
+    expect(updatedTask.status).toBe('c1');
+    expect(updatedTask.googleSyncStatus).toBe('local_changes');
+    expect(updatedTask.googleLocalUpdatedAt).toBe('2026-03-20T10:00:00.000Z');
+    expect(updatedTask.googleSync).toEqual(
+      expect.objectContaining({
+        provider: 'google_tasks',
+        taskId: 'remote-1',
+        taskListId: 'list-1',
+        status: 'local_changes',
+        localUpdatedAt: '2026-03-20T10:00:00.000Z',
+        conflict: null,
+      })
+    );
+
+    vi.useRealTimers();
+  });
+
   test('moveTaskToColumn, rescheduleTask, reorderTask', () => {
     const { result } = renderHook(() => useTaskOperations(baseProps));
 

--- a/src/hooks/useTaskOperations.ts
+++ b/src/hooks/useTaskOperations.ts
@@ -13,6 +13,7 @@ import {
   validateTaskCompletion,
 } from '../lib/tasks';
 import { normalizeTaskUpdatePayload } from '../lib/appState';
+import { normalizeGoogleTaskSyncState } from '../lib/googleSync';
 
 function normalizedText(value) {
   return String(value || '').trim();
@@ -83,6 +84,11 @@ function isTaskInOrderScope(task, status, group) {
   );
 }
 
+function getGoogleTaskSyncIdentity(task) {
+  const sync = normalizeGoogleTaskSyncState(task);
+  return sync?.taskId || task?.googleTaskId || '';
+}
+
 function insertTaskByPlacement(sortedTasks, movingTask, placement) {
   const nextTasks = sortedTasks.filter((task) => task.id !== movingTask.id);
   const previousIndex = nextTasks.findIndex((task) => task.id === placement.previousTaskId);
@@ -119,33 +125,35 @@ export default function useTaskOperations({
 
     const updatedAt = new Date().toISOString();
     const actor = currentUser?.name || currentUser?.email || 'Ty';
+    const shouldMarkGoogleLocalChanges =
+      Boolean(getGoogleTaskSyncIdentity(task)) &&
+      updates.googleSyncStatus === undefined &&
+      updates.googleSync === undefined;
+    const googleSyncPatch = shouldMarkGoogleLocalChanges
+      ? {
+          googleSyncStatus: 'local_changes',
+          googleLocalUpdatedAt: updatedAt,
+          googleSyncConflict: null,
+          googleSync: normalizeGoogleTaskSyncState(task, {
+            status: 'local_changes',
+            localUpdatedAt: updatedAt,
+            conflict: null,
+          }),
+        }
+      : {};
     const nextTask = {
       ...task,
       ...normalizedUpdates,
-      ...(task.googleTaskId && updates.googleSyncStatus === undefined
-        ? {
-            googleSyncStatus: 'local_changes',
-            googleLocalUpdatedAt: updatedAt,
-            googleSyncConflict: null,
-          }
-        : {}),
+      ...googleSyncPatch,
       updatedAt,
     };
-    const syncPayload =
-      task.googleTaskId && updates.googleSyncStatus === undefined
-        ? {
-            googleSyncStatus: 'local_changes',
-            googleLocalUpdatedAt: updatedAt,
-            googleSyncConflict: null,
-          }
-        : {};
     const nextHistory = [
       ...(normalizedUpdates.history || task.history || []),
       ...buildTaskChangeHistory(task, nextTask, actor, taskColumns),
     ];
     const nextPayload = {
       ...normalizedUpdates,
-      ...syncPayload,
+      ...googleSyncPatch,
       history: nextHistory,
       updatedAt,
     };

--- a/src/lib/googleSync.test.ts
+++ b/src/lib/googleSync.test.ts
@@ -6,6 +6,9 @@ import {
   createGoogleCalendarConflictState,
   createGoogleTaskConflictState,
   detectGoogleTaskConflict,
+  getGoogleTaskSyncConflict,
+  getGoogleTaskSyncStatus,
+  normalizeGoogleTaskSyncState,
 } from './googleSync';
 
 describe('googleSync helpers', () => {
@@ -109,5 +112,57 @@ describe('googleSync helpers', () => {
     );
 
     expect(snapshot.endsAt).toBe('2026-03-15T10:30:00.000Z');
+  });
+
+  test('normalizes legacy Google Task fields into the nested sync model', () => {
+    const conflict = {
+      detectedAt: '2026-03-15T09:30:00.000Z',
+      localSnapshot: { title: 'Local' },
+      remoteSnapshot: { title: 'Remote' },
+    };
+
+    const state = normalizeGoogleTaskSyncState({
+      googleTaskId: 'task_1',
+      googleTaskListId: 'list_1',
+      googleUpdatedAt: '2026-03-15T09:00:00.000Z',
+      googleSyncedAt: '2026-03-15T08:00:00.000Z',
+      googlePulledAt: '2026-03-15T08:10:00.000Z',
+      googleLocalUpdatedAt: '2026-03-15T08:30:00.000Z',
+      googleSyncStatus: 'conflict',
+      googleSyncConflict: conflict,
+    });
+
+    expect(state).toEqual({
+      provider: 'google_tasks',
+      taskId: 'task_1',
+      taskListId: 'list_1',
+      remoteUpdatedAt: '2026-03-15T09:00:00.000Z',
+      syncedAt: '2026-03-15T08:00:00.000Z',
+      pulledAt: '2026-03-15T08:10:00.000Z',
+      localUpdatedAt: '2026-03-15T08:30:00.000Z',
+      status: 'conflict',
+      conflict,
+    });
+  });
+
+  test('prefers nested Google Task sync state over legacy aliases', () => {
+    const nestedConflict = {
+      detectedAt: '2026-03-16T10:00:00.000Z',
+      localSnapshot: { title: 'Nested local' },
+    };
+    const task = {
+      googleSync: {
+        provider: 'google_tasks',
+        taskId: 'nested_task',
+        taskListId: 'nested_list',
+        status: 'local_changes',
+        conflict: nestedConflict,
+      },
+      googleSyncStatus: 'synced',
+      googleSyncConflict: null,
+    };
+
+    expect(getGoogleTaskSyncStatus(task)).toBe('local_changes');
+    expect(getGoogleTaskSyncConflict(task)).toBe(nestedConflict);
   });
 });

--- a/src/lib/googleSync.ts
+++ b/src/lib/googleSync.ts
@@ -20,6 +20,61 @@ function toTimestamp(value) {
   return Number.isFinite(timestamp) ? timestamp : 0;
 }
 
+const GOOGLE_TASK_SYNC_PROVIDER = 'google_tasks';
+
+function cleanSyncStatus(value) {
+  const status = cleanText(value);
+  return ['synced', 'local_changes', 'conflict', 'error', 'pending'].includes(status) ? status : '';
+}
+
+export function normalizeGoogleTaskSyncState(taskLike: any, overrides: any = {}) {
+  const nested: any =
+    taskLike?.googleSync && typeof taskLike.googleSync === 'object' ? taskLike.googleSync : {};
+  const taskId = cleanText(overrides.taskId || nested.taskId || taskLike?.googleTaskId);
+  const taskListId = cleanText(
+    overrides.taskListId || nested.taskListId || taskLike?.googleTaskListId
+  );
+  const status =
+    cleanSyncStatus(overrides.status) ||
+    cleanSyncStatus(nested.status) ||
+    cleanSyncStatus(taskLike?.googleSyncStatus) ||
+    (taskId ? 'synced' : '');
+  const conflict =
+    overrides.conflict !== undefined
+      ? overrides.conflict
+      : nested.conflict !== undefined
+        ? nested.conflict
+        : taskLike?.googleSyncConflict || null;
+
+  if (!taskId && !taskListId && !status && !conflict) {
+    return null;
+  }
+
+  return {
+    provider: GOOGLE_TASK_SYNC_PROVIDER,
+    taskId,
+    taskListId,
+    remoteUpdatedAt: toIsoOrEmpty(
+      overrides.remoteUpdatedAt || nested.remoteUpdatedAt || taskLike?.googleUpdatedAt
+    ),
+    syncedAt: toIsoOrEmpty(overrides.syncedAt || nested.syncedAt || taskLike?.googleSyncedAt),
+    pulledAt: toIsoOrEmpty(overrides.pulledAt || nested.pulledAt || taskLike?.googlePulledAt),
+    localUpdatedAt: toIsoOrEmpty(
+      overrides.localUpdatedAt || nested.localUpdatedAt || taskLike?.googleLocalUpdatedAt
+    ),
+    status,
+    conflict: conflict || null,
+  };
+}
+
+export function getGoogleTaskSyncStatus(taskLike: any) {
+  return normalizeGoogleTaskSyncState(taskLike)?.status || '';
+}
+
+export function getGoogleTaskSyncConflict(taskLike: any) {
+  return normalizeGoogleTaskSyncState(taskLike)?.conflict || null;
+}
+
 function computeDurationMinutes(startsAt, endsAt, fallbackMinutes = 30) {
   const start = new Date(startsAt || 0);
   const end = new Date(endsAt || 0);
@@ -49,19 +104,31 @@ export function areGoogleTaskSnapshotsEqual(left, right) {
 }
 
 export function detectGoogleTaskConflict(existingTask, importedTask) {
+  const existingSync = normalizeGoogleTaskSyncState(existingTask);
   const localSnapshot = buildGoogleTaskSnapshot(existingTask);
   const remoteSnapshot = buildGoogleTaskSnapshot(importedTask);
   const lastSyncedAt =
+    existingSync?.syncedAt ||
+    existingSync?.pulledAt ||
     existingTask?.googleSyncedAt ||
     existingTask?.googlePulledAt ||
     existingTask?.createdAt ||
     importedTask?.createdAt ||
     '';
   const localUpdatedAt =
-    existingTask?.googleLocalUpdatedAt || existingTask?.updatedAt || existingTask?.createdAt || '';
+    existingSync?.localUpdatedAt ||
+    existingTask?.googleLocalUpdatedAt ||
+    existingTask?.updatedAt ||
+    existingTask?.createdAt ||
+    '';
   const remoteUpdatedAt =
-    importedTask?.googleUpdatedAt || importedTask?.updatedAt || importedTask?.createdAt || '';
+    importedTask?.googleSync?.remoteUpdatedAt ||
+    importedTask?.googleUpdatedAt ||
+    importedTask?.updatedAt ||
+    importedTask?.createdAt ||
+    '';
   const localChanged =
+    existingSync?.status === 'local_changes' ||
     existingTask?.googleSyncStatus === 'local_changes' ||
     toTimestamp(localUpdatedAt) > toTimestamp(lastSyncedAt);
   const remoteChanged = toTimestamp(remoteUpdatedAt) > toTimestamp(lastSyncedAt);

--- a/src/lib/tasks.coverage.test.ts
+++ b/src/lib/tasks.coverage.test.ts
@@ -204,6 +204,16 @@ describe('tasks extra coverage', () => {
     expect(task.group).toBe('Moj list');
     expect(task.googleSyncedAt).toBe('2026-03-10T09:00:00.000Z');
     expect(task.googleSyncStatus).toBe('synced');
+    expect(task.googleSync).toEqual(
+      expect.objectContaining({
+        provider: 'google_tasks',
+        taskId: 'google_1',
+        taskListId: 'list_1',
+        status: 'synced',
+        syncedAt: '2026-03-10T09:00:00.000Z',
+        pulledAt: '2026-03-10T09:00:00.000Z',
+      })
+    );
   });
 
   test('createRecurringTaskFromTask creates a new cycle task', () => {
@@ -315,6 +325,16 @@ describe('tasks extra coverage', () => {
     expect(mergedResult.merged[0].title).toBe('New');
     expect(mergedResult.merged[0].googleSyncStatus).toBe('synced');
     expect(mergedResult.merged[0].googleSyncedAt).toBe('2026-03-12T08:00:00.000Z');
+    expect(mergedResult.merged[0].googleSync).toEqual(
+      expect.objectContaining({
+        provider: 'google_tasks',
+        taskId: 'g1',
+        taskListId: 'l1',
+        status: 'synced',
+        syncedAt: '2026-03-12T08:00:00.000Z',
+        pulledAt: '2026-03-12T08:00:00.000Z',
+      })
+    );
 
     const conflictExisting = [
       {
@@ -337,6 +357,34 @@ describe('tasks extra coverage', () => {
     expect(conflictResult.conflictCount).toBe(1);
     expect(conflictResult.merged[0].googleSyncStatus).toBe('conflict');
     expect(conflictResult.merged[0].googleSyncConflict).not.toBeNull();
+    expect(conflictResult.merged[0].googleSync).toEqual(
+      expect.objectContaining({
+        provider: 'google_tasks',
+        taskId: 'g1',
+        taskListId: 'l1',
+        status: 'conflict',
+        conflict: conflictResult.merged[0].googleSyncConflict,
+      })
+    );
+  });
+
+  test('Google sync conflict lifecycle can read the nested sync state', () => {
+    const lifecycle = getTaskLifecycleStatus(
+      {
+        id: 'nested-conflict',
+        status: 'todo',
+        completed: false,
+        googleSync: {
+          provider: 'google_tasks',
+          status: 'conflict',
+          conflict: { detectedAt: '2026-03-12T08:00:00.000Z' },
+        },
+      },
+      DEFAULT_TASK_COLUMNS,
+      []
+    );
+
+    expect(lifecycle).toBe(TASK_LIFECYCLE_STATUSES.CONFLICT);
   });
 
   test('extractMeetingTasks uses analysis tasks or action items', () => {

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -1,6 +1,11 @@
 // @ts-nocheck
 import { createId } from './storage';
-import { createGoogleTaskConflictState } from './googleSync';
+import {
+  createGoogleTaskConflictState,
+  getGoogleTaskSyncConflict,
+  getGoogleTaskSyncStatus,
+  normalizeGoogleTaskSyncState,
+} from './googleSync';
 
 const ORDER_GAP = 1024;
 const ORDER_REBALANCE_MIN_GAP = 1;
@@ -603,7 +608,7 @@ export function getTaskLifecycleStatus(
     return TASK_LIFECYCLE_STATUSES.ARCHIVED;
   }
 
-  if (task.googleSyncConflict || task.googleSyncStatus === 'conflict') {
+  if (getGoogleTaskSyncConflict(task) || getGoogleTaskSyncStatus(task) === 'conflict') {
     return TASK_LIFECYCLE_STATUSES.CONFLICT;
   }
 
@@ -1231,6 +1236,16 @@ export function createTaskFromGoogle(
   const completed = googleTask.status === 'completed';
   const owner = currentUser?.name || currentUser?.email || 'Ja';
   const syncedAt = new Date().toISOString();
+  const googleUpdatedAt = googleTask.updated || googleTask.completed || dueDate;
+  const googleSync = normalizeGoogleTaskSyncState({
+    googleTaskId: googleTask.id,
+    googleTaskListId: taskList.id,
+    googleUpdatedAt,
+    googleSyncedAt: syncedAt,
+    googlePulledAt: syncedAt,
+    googleSyncStatus: 'synced',
+    googleSyncConflict: null,
+  });
 
   return {
     id: createId('google_task'),
@@ -1268,11 +1283,12 @@ export function createTaskFromGoogle(
     subtasks: [],
     links: [],
     order: -new Date(googleTask.updated || new Date().toISOString()).getTime(),
-    googleUpdatedAt: googleTask.updated || googleTask.completed || dueDate,
+    googleUpdatedAt,
     googleSyncedAt: syncedAt,
     googlePulledAt: syncedAt,
     googleSyncStatus: 'synced',
     googleSyncConflict: null,
+    googleSync,
   };
 }
 
@@ -1350,17 +1366,25 @@ export function upsertGoogleImportedTasks(existingTasks, importedTasks, userId) 
       const existingTask = merged[index];
       const conflict = createGoogleTaskConflictState(existingTask, task);
       if (conflict) {
+        const googleUpdatedAt =
+          task.googleUpdatedAt || task.updatedAt || existingTask.googleUpdatedAt || '';
         merged[index] = {
           ...existingTask,
-          googleUpdatedAt:
-            task.googleUpdatedAt || task.updatedAt || existingTask.googleUpdatedAt || '',
+          googleUpdatedAt,
           googlePulledAt: syncedAt,
           googleSyncStatus: 'conflict',
           googleSyncConflict: conflict,
+          googleSync: normalizeGoogleTaskSyncState(existingTask, {
+            remoteUpdatedAt: googleUpdatedAt,
+            pulledAt: syncedAt,
+            status: 'conflict',
+            conflict,
+          }),
         };
         return;
       }
 
+      const googleUpdatedAt = task.googleUpdatedAt || task.updatedAt || '';
       merged[index] = {
         ...existingTask,
         title: task.title,
@@ -1374,26 +1398,45 @@ export function upsertGoogleImportedTasks(existingTasks, importedTasks, userId) 
         group: task.group,
         owner: task.owner || existingTask.owner,
         assignedTo: task.assignedTo?.length ? task.assignedTo : existingTask.assignedTo,
-        googleUpdatedAt: task.googleUpdatedAt || task.updatedAt || '',
+        googleUpdatedAt,
         googleSyncedAt: syncedAt,
         googlePulledAt: syncedAt,
         googleSyncStatus: 'synced',
         googleSyncConflict: null,
+        googleSync: normalizeGoogleTaskSyncState(existingTask, {
+          taskId: task.googleTaskId || existingTask.googleTaskId,
+          taskListId: task.googleTaskListId || existingTask.googleTaskListId,
+          remoteUpdatedAt: googleUpdatedAt,
+          syncedAt,
+          pulledAt: syncedAt,
+          status: 'synced',
+          conflict: null,
+        }),
         id: existingTask.id,
       };
       return;
     }
 
+    const googleUpdatedAt = task.googleUpdatedAt || task.updatedAt || '';
     merged.unshift({
       ...task,
       googleSyncedAt: syncedAt,
       googlePulledAt: syncedAt,
       googleSyncStatus: 'synced',
       googleSyncConflict: null,
+      googleSync: normalizeGoogleTaskSyncState(task, {
+        remoteUpdatedAt: googleUpdatedAt,
+        syncedAt,
+        pulledAt: syncedAt,
+        status: 'synced',
+        conflict: null,
+      }),
     });
   });
 
-  const conflictCount = merged.filter((task) => task.googleSyncStatus === 'conflict').length;
+  const conflictCount = merged.filter(
+    (task) => getGoogleTaskSyncStatus(task) === 'conflict'
+  ).length;
   return { merged, conflictCount };
 }
 
@@ -1611,7 +1654,8 @@ export function buildTaskDiagnosticsReport(tasks, options = {}) {
     archivedTasks: scopedTasks.filter((task) => task.archived).length,
     deletePendingTasks: scopedTasks.filter(isDeletePendingTask).length,
     conflicts: scopedTasks.filter(
-      (task) => task.googleSyncStatus === 'conflict' || Boolean(task.googleSyncConflict)
+      (task) =>
+        getGoogleTaskSyncStatus(task) === 'conflict' || Boolean(getGoogleTaskSyncConflict(task))
     ).length,
     missingWorkspaceId: missingWorkspaceId.length,
     missingTitle: missingTitle.length,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -320,6 +320,18 @@ export interface GoogleTaskSyncConflict {
   remoteSnapshot?: Record<string, unknown>;
 }
 
+export interface GoogleTaskSyncState {
+  provider: 'google_tasks';
+  taskId?: string;
+  taskListId?: string;
+  remoteUpdatedAt?: string;
+  syncedAt?: string;
+  pulledAt?: string;
+  localUpdatedAt?: string;
+  status?: GoogleTaskSyncStatus;
+  conflict?: GoogleTaskSyncConflict | null;
+}
+
 // Persisted task entity stored in WorkspaceState.manualTasks for manual and external tasks.
 export interface TaskRecord {
   id: string;
@@ -346,6 +358,7 @@ export interface TaskRecord {
   googleLocalUpdatedAt?: string;
   googleSyncStatus?: GoogleTaskSyncStatus;
   googleSyncConflict?: GoogleTaskSyncConflict | null;
+  googleSync?: GoogleTaskSyncState | null;
   group: string;
   description: string;
   notes: string;
@@ -398,6 +411,7 @@ export type TaskStatePatch = Partial<
     | 'googleLocalUpdatedAt'
     | 'googleSyncStatus'
     | 'googleSyncConflict'
+    | 'googleSync'
     | 'updatedAt'
     | 'archived'
   >

--- a/src/tasks/TaskDetailsPanel.test.tsx
+++ b/src/tasks/TaskDetailsPanel.test.tsx
@@ -218,6 +218,23 @@ describe('TaskDetailsPanel', () => {
       expect(screen.getByText('Finalna wersja')).toBeInTheDocument();
     });
 
+    it('renders conflict resolution panel from nested googleSync state', () => {
+      const taskWithConflict = {
+        ...mockSelectedTask,
+        googleSyncConflict: null,
+        googleSync: {
+          provider: 'google_tasks',
+          status: 'conflict',
+          conflict: mockConflict,
+        },
+      };
+      render(<TaskDetailsPanel {...mockProps} selectedTask={taskWithConflict} />);
+
+      expect(screen.getByText('Konflikt synchronizacji Google')).toBeInTheDocument();
+      expect(screen.getByText('Local Task')).toBeInTheDocument();
+      expect(screen.getByText('Remote Task')).toBeInTheDocument();
+    });
+
     it('does not render conflict panel when no conflict', () => {
       render(<TaskDetailsPanel {...mockProps} />);
 

--- a/src/tasks/TaskDetailsPanel.tsx
+++ b/src/tasks/TaskDetailsPanel.tsx
@@ -2,6 +2,7 @@ import { memo, useEffect, useState } from 'react';
 import { AlignLeft, History, Link, Trash2 } from 'lucide-react';
 import { formatDateTime } from '../lib/storage';
 import { getTaskLifecycleStatus, TASK_LIFECYCLE_STATUSES } from '../lib/tasks';
+import { getGoogleTaskSyncConflict } from '../lib/googleSync';
 import { toInputDateTime } from './taskViewUtils';
 import { Input } from '../ui/Input';
 import MentionTextarea from '../shared/MentionTextarea';
@@ -75,15 +76,16 @@ function TaskDetailsPanel(props: any) {
     onResolveGoogleTaskConflict,
     presentation = 'panel',
   } = props;
+  const selectedTaskGoogleConflict = getGoogleTaskSyncConflict(selectedTask);
   const [conflictDraft, setConflictDraft] = useState(
-    buildConflictDraft(selectedTask?.googleSyncConflict)
+    buildConflictDraft(selectedTaskGoogleConflict)
   );
   const [historyExpanded, setHistoryExpanded] = useState(false);
 
   useEffect(() => {
-    setConflictDraft(buildConflictDraft(selectedTask?.googleSyncConflict));
+    setConflictDraft(buildConflictDraft(selectedTaskGoogleConflict));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [selectedTask?.googleSyncConflict?.detectedAt, selectedTask?.id]);
+  }, [selectedTaskGoogleConflict?.detectedAt, selectedTask?.id]);
 
   if (!selectedTask) {
     return (
@@ -97,7 +99,7 @@ function TaskDetailsPanel(props: any) {
   }
 
   async function resolveConflict(mode) {
-    if (typeof onResolveGoogleTaskConflict !== 'function' || !selectedTask.googleSyncConflict) {
+    if (typeof onResolveGoogleTaskConflict !== 'function' || !selectedTaskGoogleConflict) {
       return;
     }
 
@@ -184,36 +186,36 @@ function TaskDetailsPanel(props: any) {
           </div>
         </div>
 
-        {selectedTask.googleSyncConflict ? (
+        {selectedTaskGoogleConflict ? (
           <section className="todo-detail-section todo-conflict-resolution">
             <div className="todo-section-head">
               <strong>Konflikt synchronizacji Google</strong>
-              <span>{selectedTask.googleSyncConflict.sourceLabel || 'Google Tasks'}</span>
+              <span>{selectedTaskGoogleConflict.sourceLabel || 'Google Tasks'}</span>
             </div>
 
             <div className="todo-conflict-grid">
               <article className="todo-conflict-panel">
                 <span className="todo-card-eyebrow">Lokalne</span>
-                <strong>{selectedTask.googleSyncConflict.localSnapshot?.title || 'Brak'}</strong>
+                <strong>{selectedTaskGoogleConflict.localSnapshot?.title || 'Brak'}</strong>
                 <small>
                   Termin:{' '}
-                  {selectedTask.googleSyncConflict.localSnapshot?.dueDate
-                    ? formatDateTime(selectedTask.googleSyncConflict.localSnapshot.dueDate)
+                  {selectedTaskGoogleConflict.localSnapshot?.dueDate
+                    ? formatDateTime(selectedTaskGoogleConflict.localSnapshot.dueDate)
                     : 'Brak'}
                 </small>
-                <p>{selectedTask.googleSyncConflict.localSnapshot?.notes || 'Brak notatek.'}</p>
+                <p>{selectedTaskGoogleConflict.localSnapshot?.notes || 'Brak notatek.'}</p>
               </article>
 
               <article className="todo-conflict-panel">
                 <span className="todo-card-eyebrow">Google</span>
-                <strong>{selectedTask.googleSyncConflict.remoteSnapshot?.title || 'Brak'}</strong>
+                <strong>{selectedTaskGoogleConflict.remoteSnapshot?.title || 'Brak'}</strong>
                 <small>
                   Termin:{' '}
-                  {selectedTask.googleSyncConflict.remoteSnapshot?.dueDate
-                    ? formatDateTime(selectedTask.googleSyncConflict.remoteSnapshot.dueDate)
+                  {selectedTaskGoogleConflict.remoteSnapshot?.dueDate
+                    ? formatDateTime(selectedTaskGoogleConflict.remoteSnapshot.dueDate)
                     : 'Brak'}
                 </small>
-                <p>{selectedTask.googleSyncConflict.remoteSnapshot?.notes || 'Brak notatek.'}</p>
+                <p>{selectedTaskGoogleConflict.remoteSnapshot?.notes || 'Brak notatek.'}</p>
               </article>
 
               <article className="todo-conflict-panel editable">


### PR DESCRIPTION
## Summary\n- Introduces nested googleSync state for Google Tasks while keeping legacy flat aliases for stored data compatibility.\n- Updates import/upsert, local edits, auto-sync and conflict resolution to keep task lifecycle status separate from Google sync status.\n- Updates task conflict lifecycle/UI to read from the nested sync model first.\n\n## Validation\n- corepack pnpm run typecheck: pass\n- node_modules\\.bin\\vitest.cmd run src\\lib\\googleSync.test.ts src\\hooks\\useTaskOperations.test.ts --coverage.enabled=false: pass, 24 tests\n- node_modules\\.bin\\vitest.cmd run src\\lib\\googleSync.test.ts src\\lib\\tasks.coverage.test.ts src\\hooks\\useTaskOperations.test.ts src\\tasks\\TaskDetailsPanel.test.tsx --coverage.enabled=false: pass, 78 tests\n- git diff --check: pass\n- pre-push release guard: pass (server retry 1471 passed / 82 skipped, focused frontend 82 passed, build warning audit/build passed)\n\n## Notes\n- Local corepack pnpm exec vitest did not resolve the vitest binary in this Windows shell, so the exact test target was run through node_modules\\.bin\\vitest.cmd.\n- Legacy googleTaskId/googleSyncStatus/googleSyncConflict fields remain populated as compatibility aliases.\n\nCloses #1384