### PR TITLE
feat(tasks): improve dependency blocker UX (#1383)

### DIFF
--- a/docs/testing/ui-action-contracts.json
+++ b/docs/testing/ui-action-contracts.json
@@ -88,7 +88,7 @@
       "screen": "Tasks",
       "file": "src/TasksTab.tsx",
       "expectedActionCount": 3,
-      "fingerprint": "d77070c727c5105c",
+      "fingerprint": "12112b603ef37025",
       "contractStatus": "covered",
       "testFiles": ["src/TasksTab.test.tsx"],
       "testEvidence": [

--- a/src/TasksTab.tsx
+++ b/src/TasksTab.tsx
@@ -972,6 +972,7 @@ export default function TasksTab({
                 onMoveTaskToColumn={safeMoveTaskToColumn}
                 onDeleteTask={safeDeleteTask}
                 onOpenMeeting={onOpenMeeting}
+                onOpenTask={setSelectedTaskId}
                 currentUserName={currentUserName}
                 onResolveGoogleTaskConflict={onResolveGoogleTaskConflict}
               />

--- a/src/hooks/useTaskOperations.test.ts
+++ b/src/hooks/useTaskOperations.test.ts
@@ -102,6 +102,37 @@ describe('useTaskOperations', () => {
     expect(next.t2.title).toBe('Updated T2');
   });
 
+  test('completing a blocked task names the unresolved blocker', () => {
+    const blocker = {
+      id: 'blocker',
+      title: 'Approve budget',
+      status: 'c1',
+      sourceType: 'manual',
+      history: [],
+      completed: false,
+      tags: [],
+      assignedTo: [],
+    };
+    const blockedTask = {
+      id: 'blocked',
+      title: 'Send offer',
+      status: 'c1',
+      sourceType: 'manual',
+      history: [],
+      completed: false,
+      tags: [],
+      assignedTo: [],
+      dependencies: ['blocker'],
+    };
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: [blockedTask, blocker] })
+    );
+
+    expect(() => {
+      result.current.updateTask('blocked', { completed: true });
+    }).toThrow(/Approve budget/);
+  });
+
   test('local edit of a Google task updates nested sync state separately from task status', () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-03-20T10:00:00.000Z'));

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -591,6 +591,22 @@ export function getTaskDependencyDetails(task, tasks) {
   };
 }
 
+export function getTaskBlockingDetails(task, tasks) {
+  const taskId = normalizeWhitespace(task?.id);
+  if (!taskId) {
+    return { blocking: [], unresolved: [] };
+  }
+
+  const blocking = safeArray(tasks).filter((candidate) =>
+    normalizeTaskDependencies(candidate?.dependencies).includes(taskId)
+  );
+
+  return {
+    blocking,
+    unresolved: blocking.filter((candidate) => !candidate.completed),
+  };
+}
+
 export function getTaskLifecycleStatus(
   task: any,
   columns: any[] = DEFAULT_TASK_COLUMNS,

--- a/src/styles/tasks.css
+++ b/src/styles/tasks.css
@@ -5914,6 +5914,12 @@
   line-height: 1;
 }
 
+.tasks-layout.ms-todo .todo-metadata-badge.warning {
+  border-color: rgba(217, 119, 6, 0.28);
+  background: rgba(217, 119, 6, 0.1);
+  color: #b45309;
+}
+
 .tasks-layout.ms-todo .todo-date-stack {
   display: flex;
   flex-direction: column;

--- a/src/tasks/TaskDetailsPanel.test.tsx
+++ b/src/tasks/TaskDetailsPanel.test.tsx
@@ -176,6 +176,36 @@ describe('TaskDetailsPanel', () => {
     expect(screen.getByText('Google Tasks')).toBeInTheDocument();
   });
 
+  it('opens a blocker task from the dependency section', () => {
+    const onOpenTask = vi.fn();
+    const blocker = {
+      ...mockSelectedTask,
+      id: 'task-blocker',
+      title: 'Approve budget',
+      completed: false,
+      dependencies: [],
+    };
+    const blockedTask = {
+      ...mockSelectedTask,
+      id: 'task-blocked',
+      title: 'Send offer',
+      dependencies: ['task-blocker'],
+    };
+
+    render(
+      <TaskDetailsPanel
+        {...mockProps}
+        selectedTask={blockedTask}
+        tasks={[blockedTask, blocker]}
+        onOpenTask={onOpenTask}
+        presentation="modal"
+      />
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /Approve budget/i }));
+    expect(onOpenTask).toHaveBeenCalledWith('task-blocker');
+  });
+
   it('renders meeting eyebrow for meeting source type', () => {
     render(<TaskDetailsPanel {...mockProps} />);
 

--- a/src/tasks/TaskDetailsPanel.tsx
+++ b/src/tasks/TaskDetailsPanel.tsx
@@ -1,7 +1,12 @@
 import { memo, useEffect, useState } from 'react';
 import { AlignLeft, History, Link, Trash2 } from 'lucide-react';
 import { formatDateTime } from '../lib/storage';
-import { getTaskLifecycleStatus, TASK_LIFECYCLE_STATUSES } from '../lib/tasks';
+import {
+  getTaskBlockingDetails,
+  getTaskDependencyDetails,
+  getTaskLifecycleStatus,
+  TASK_LIFECYCLE_STATUSES,
+} from '../lib/tasks';
 import { getGoogleTaskSyncConflict } from '../lib/googleSync';
 import { toInputDateTime } from './taskViewUtils';
 import { Input } from '../ui/Input';
@@ -73,8 +78,10 @@ function TaskDetailsPanel(props: any) {
     onUpdateTask,
     onDeleteTask,
     onOpenMeeting,
+    onOpenTask,
     onResolveGoogleTaskConflict,
     presentation = 'panel',
+    tasks = [],
   } = props;
   const selectedTaskGoogleConflict = getGoogleTaskSyncConflict(selectedTask);
   const [conflictDraft, setConflictDraft] = useState(
@@ -118,12 +125,73 @@ function TaskDetailsPanel(props: any) {
   }
 
   const selectedTaskDraft = buildSelectedTaskDraft(selectedTask, boardColumns);
-  const selectedTaskLifecycle = getTaskLifecycleStatus(selectedTask, boardColumns, [selectedTask]);
+  const relatedTasks = tasks?.length ? tasks : [selectedTask];
+  const selectedTaskLifecycle = getTaskLifecycleStatus(selectedTask, boardColumns, relatedTasks);
   const selectedTaskDone = selectedTaskLifecycle === TASK_LIFECYCLE_STATUSES.DONE;
   const selectedTaskDoneLabel = selectedTaskDone
     ? 'Oznacz jako nieukonczone'
     : 'Oznacz jako ukonczone';
   const peopleSuggestions = normalizePeopleSuggestions(peopleOptions);
+  const dependencyState = getTaskDependencyDetails(selectedTask, relatedTasks);
+  const blockingState = getTaskBlockingDetails(selectedTask, relatedTasks);
+  const canOpenTask = typeof onOpenTask === 'function';
+  const dependencySection =
+    dependencyState.dependencies.length || blockingState.blocking.length ? (
+      <section className="todo-detail-section todo-dependency-section">
+        <div className="todo-section-head">
+          <strong>Zależności</strong>
+          {dependencyState.blocking ? <span>Zablokowane</span> : null}
+        </div>
+
+        {dependencyState.dependencies.length ? (
+          <div className="todo-dependency-group">
+            <span className="todo-card-eyebrow">Blokowane przez</span>
+            <div className="todo-dependency-list">
+              {dependencyState.dependencies.map((dependency) => (
+                <button
+                  key={dependency.id}
+                  type="button"
+                  className={
+                    dependency.completed
+                      ? 'todo-dependency-link completed'
+                      : 'todo-dependency-link blocked'
+                  }
+                  onClick={() => canOpenTask && onOpenTask(dependency.id)}
+                  disabled={!canOpenTask}
+                >
+                  <span>{dependency.title || 'Zadanie bez tytułu'}</span>
+                  <small>{dependency.completed ? 'Gotowe' : 'Blokuje ukończenie'}</small>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+
+        {blockingState.blocking.length ? (
+          <div className="todo-dependency-group">
+            <span className="todo-card-eyebrow">Blokuje</span>
+            <div className="todo-dependency-list">
+              {blockingState.blocking.map((blockedTask) => (
+                <button
+                  key={blockedTask.id}
+                  type="button"
+                  className={
+                    blockedTask.completed
+                      ? 'todo-dependency-link completed'
+                      : 'todo-dependency-link blocked'
+                  }
+                  onClick={() => canOpenTask && onOpenTask(blockedTask.id)}
+                  disabled={!canOpenTask}
+                >
+                  <span>{blockedTask.title || 'Zadanie bez tytułu'}</span>
+                  <small>{blockedTask.completed ? 'Gotowe' : 'Czeka na to zadanie'}</small>
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : null}
+      </section>
+    ) : null;
   const sharedTaskForm = (
     <TaskCreateForm
       key={selectedTask.id}
@@ -146,7 +214,12 @@ function TaskDetailsPanel(props: any) {
   );
 
   if (presentation === 'modal') {
-    return <div className="todo-details todo-details--modal-form">{sharedTaskForm}</div>;
+    return (
+      <div className="todo-details todo-details--modal-form">
+        {sharedTaskForm}
+        {dependencySection}
+      </div>
+    );
   }
 
   return (
@@ -293,6 +366,8 @@ function TaskDetailsPanel(props: any) {
         ) : null}
 
         {sharedTaskForm}
+
+        {dependencySection}
 
         <section className="todo-detail-section todo-detail-notes-section">
           <label className="todo-detail-row note-row">

--- a/src/tasks/TaskDetailsPanelStyles.css
+++ b/src/tasks/TaskDetailsPanelStyles.css
@@ -134,6 +134,73 @@
   background: rgba(117, 214, 196, 0.16);
 }
 
+.todo-dependency-section {
+  display: grid;
+  gap: 14px;
+}
+
+.todo-dependency-group {
+  display: grid;
+  gap: 8px;
+}
+
+.todo-dependency-list {
+  display: grid;
+  gap: 8px;
+}
+
+.todo-dependency-link {
+  display: flex;
+  width: 100%;
+  min-width: 0;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 10px 12px;
+  border: 1px solid rgba(117, 214, 196, 0.2);
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.todo-dependency-link:hover {
+  border-color: rgba(117, 214, 196, 0.4);
+  background: rgba(117, 214, 196, 0.1);
+}
+
+.todo-dependency-link:focus-visible {
+  outline: 2px solid rgba(117, 214, 196, 0.74);
+  outline-offset: 2px;
+}
+
+.todo-dependency-link:disabled {
+  cursor: default;
+  opacity: 0.7;
+}
+
+.todo-dependency-link.blocked {
+  border-color: rgba(243, 202, 114, 0.32);
+  background: rgba(243, 202, 114, 0.08);
+}
+
+.todo-dependency-link.completed {
+  opacity: 0.82;
+}
+
+.todo-dependency-link span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+  font-weight: 700;
+}
+
+.todo-dependency-link small {
+  flex: 0 0 auto;
+  color: var(--muted);
+  font-size: 0.75rem;
+}
+
 .todo-tag-dropdown {
   position: absolute;
   left: 0;

--- a/src/tasks/TaskKanbanView.test.tsx
+++ b/src/tasks/TaskKanbanView.test.tsx
@@ -81,6 +81,39 @@ describe('TaskKanbanView', () => {
     expect(screen.getByText('Task 1')).toBeInTheDocument();
   });
 
+  test('renders blocked badge for cards with unresolved dependencies', () => {
+    const blocker = {
+      ...defaultProps.allTasks[1],
+      id: 'blocker',
+      title: 'Approve budget',
+      completed: false,
+    };
+    const blockedTask = {
+      ...defaultProps.allTasks[0],
+      id: 'blocked',
+      title: 'Send offer',
+      dependencies: ['blocker'],
+    };
+    const kanbanColumns = [
+      {
+        ...defaultProps.kanbanColumns[0],
+        tasks: [blockedTask, blocker],
+      },
+      defaultProps.kanbanColumns[1],
+    ];
+
+    render(
+      <TaskKanbanView
+        {...defaultProps}
+        kanbanColumns={kanbanColumns}
+        allTasks={[blockedTask, blocker]}
+      />
+    );
+
+    expect(screen.getByText('Blokowane')).toBeInTheDocument();
+    expect(screen.getByTitle('Blokowane przez: Approve budget')).toBeInTheDocument();
+  });
+
   test('interactions with KanbanCard', async () => {
     render(<TaskKanbanView {...defaultProps} />);
 

--- a/src/tasks/TaskKanbanView.tsx
+++ b/src/tasks/TaskKanbanView.tsx
@@ -165,6 +165,7 @@ function KanbanCard({
   allTasks,
 }) {
   const dependencyState = getTaskDependencyDetails(task, allTasks);
+  const firstBlocker = dependencyState.unresolved[0]?.title || '';
   const taskLifecycle = getTaskLifecycleStatus(task, boardColumns, allTasks);
   const taskDone = taskLifecycle === TASK_LIFECYCLE_STATUSES.DONE;
   const subtasks = task.subtasks || [];
@@ -304,8 +305,11 @@ function KanbanCard({
               </span>
             ) : null}
             {dependencyState.blocking ? (
-              <span className="kanban-flag-icon tone-warning" title="Blokowane">
-                ⛔
+              <span
+                className="kanban-flag-icon tone-warning kanban-blocked-badge"
+                title={firstBlocker ? `Blokowane przez: ${firstBlocker}` : 'Blokowane'}
+              >
+                Blokowane
               </span>
             ) : null}
           </div>

--- a/src/tasks/TaskKanbanViewStyles.css
+++ b/src/tasks/TaskKanbanViewStyles.css
@@ -292,6 +292,17 @@
   color: #f17d72;
 }
 
+.kanban-blocked-badge {
+  min-height: 22px;
+  padding: 0 8px;
+  border: 1px solid rgba(241, 125, 114, 0.28);
+  border-radius: 999px;
+  background: rgba(241, 125, 114, 0.12);
+  font-size: 0.72rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
 .kanban-cover-bar {
   height: 6px;
   border-radius: 6px 6px 0 0;

--- a/src/tasks/TaskListView.test.tsx
+++ b/src/tasks/TaskListView.test.tsx
@@ -261,4 +261,34 @@ describe('TaskListView', () => {
 
     expect(screen.getByText('Brak zadań w tej sekcji.')).toBeInTheDocument();
   });
+
+  it('renders a blocked badge when task dependencies are unresolved', () => {
+    const baseTask = createBaseProps().groupedTasks[0].tasks[0];
+    const blocker = {
+      ...baseTask,
+      id: 'task-blocker',
+      title: 'Approve budget',
+      completed: false,
+      dependencies: [],
+    };
+    const blockedTask = {
+      ...baseTask,
+      id: 'task-blocked',
+      title: 'Send offer',
+      dependencies: ['task-blocker'],
+    };
+    const groupedTasks = [{ id: 'todo', label: 'Todo', tasks: [blockedTask] }];
+
+    render(
+      <TaskListView
+        {...createBaseProps({
+          groupedTasks,
+          allTasks: [blockedTask, blocker],
+        })}
+      />
+    );
+
+    expect(screen.getByText('Blokowane')).toBeInTheDocument();
+    expect(screen.getByTitle('Blokowane przez: Approve budget')).toBeInTheDocument();
+  });
 });

--- a/src/tasks/TaskListView.tsx
+++ b/src/tasks/TaskListView.tsx
@@ -20,6 +20,7 @@ import {
   writeDragTask,
 } from './taskViewUtils';
 import {
+  getTaskDependencyDetails,
   getTaskAssigneeSummary,
   getTaskLifecycleStatus,
   TASK_LIFECYCLE_STATUSES,
@@ -390,6 +391,8 @@ function TaskListView({
                 const SourceIcon = source.Icon;
                 const canOpenSource = Boolean(task.sourceMeetingId && openMeetingHandler);
                 const reminderLabel = formatReminderDateTime(task.reminderAt);
+                const dependencyState = getTaskDependencyDetails(task, allTasks);
+                const firstBlocker = dependencyState.unresolved[0]?.title || '';
 
                 return (
                   <div key={task.id} className="todo-list-row-shell">
@@ -427,6 +430,18 @@ function TaskListView({
                         {task.myDay ? (
                           <span className="todo-row-meta-badges">
                             <span className="todo-metadata-badge">Mój dzień</span>
+                          </span>
+                        ) : null}
+                        {dependencyState.blocking ? (
+                          <span className="todo-row-meta-badges">
+                            <span
+                              className="todo-metadata-badge warning"
+                              title={
+                                firstBlocker ? `Blokowane przez: ${firstBlocker}` : 'Blokowane'
+                              }
+                            >
+                              Blokowane
+                            </span>
                           </span>
                         ) : null}
                       </span>


### PR DESCRIPTION
## Summary
- Surface blocked-task badges in list and Kanban views.
- Add dependency sections in task details with keyboard-focusable links to blocker/blocking tasks.
- Keep completion validation naming unresolved blockers.

Closes #1383

## Validation
- corepack pnpm run typecheck: passed (Node 24 engine warning only).
- corepack pnpm run lint:css: passed (Node 24 engine warning only).
- node_modules\\.bin\\vitest.cmd run src\\tasks\\TaskListView.test.tsx src\\tasks\\TaskKanbanView.test.tsx src\\tasks\\TaskDetailsPanel.test.tsx src\\hooks\\useTaskOperations.test.ts --coverage.enabled=false: passed, 70 tests.
- git diff --check: passed.
- pre-push release guard: passed, including server retry suite, focused frontend suite, and build warning audit.

## Notes
- Local pnpm exec could not resolve vitest/prettier shims in this Windows shell, so equivalent repo-local node_modules\\.bin\\*.cmd commands were used for focused validation.