### PR TITLE
feat(tasks): add structured audit events (#1382)

### DIFF
--- a/src/hooks/useTaskOperations.test.ts
+++ b/src/hooks/useTaskOperations.test.ts
@@ -53,6 +53,12 @@ describe('useTaskOperations', () => {
     });
 
     expect(created).toEqual(expect.objectContaining({ title: 'New Task' }));
+    expect(created.events).toEqual([
+      expect.objectContaining({
+        type: 'create',
+        summary: 'Utworzono zadanie.',
+      }),
+    ]);
     expect(mockSetManualTasks).toHaveBeenCalledTimes(1);
 
     const updater = mockSetManualTasks.mock.calls[0][0];
@@ -87,6 +93,13 @@ describe('useTaskOperations', () => {
     const next = updater(prev);
     expect(next.find((t: any) => t.id === 't1').title).toBe('Updated T1');
     expect(next.find((t: any) => t.id === 'other').title).toBe('Other');
+    expect(next.find((t: any) => t.id === 't1').events).toEqual([
+      expect.objectContaining({
+        type: 'update',
+        field: 'title',
+        summary: 'Zmieniono tytul na "Updated T1".',
+      }),
+    ]);
   });
 
   test('updateTask auto merges payload into taskState', () => {
@@ -100,6 +113,42 @@ describe('useTaskOperations', () => {
     const updater = mockSetTaskState.mock.calls[0][0];
     const next = updater({});
     expect(next.t2.title).toBe('Updated T2');
+    expect(next.t2.events).toEqual([
+      expect.objectContaining({
+        type: 'update',
+        field: 'title',
+      }),
+    ]);
+  });
+
+  test('updateTask deduplicates structured events on retry', () => {
+    const taskWithExistingEvent = {
+      ...baseProps.meetingTasks[0],
+      updatedAt: '2026-03-20T10:00:00.000Z',
+      events: [
+        {
+          id: 'event-existing',
+          type: 'update',
+          taskId: 't1',
+          actor: 'User',
+          summary: 'Zmieniono tytul na "Updated T1".',
+          field: 'title',
+          createdAt: '2026-03-20T10:01:00.000Z',
+          dedupeKey: 'task:t1:update:title:2026-03-20T10:00:00.000Z:"Updated T1"',
+        },
+      ],
+    };
+    const { result } = renderHook(() =>
+      useTaskOperations({ ...baseProps, meetingTasks: [taskWithExistingEvent] })
+    );
+
+    act(() => {
+      result.current.updateTask('t1', { title: 'Updated T1' });
+    });
+
+    const updater = mockSetManualTasks.mock.calls[0][0];
+    const next = updater([taskWithExistingEvent]);
+    expect(next[0].events).toHaveLength(1);
   });
 
   test('local edit of a Google task updates nested sync state separately from task status', () => {
@@ -504,6 +553,12 @@ describe('useTaskOperations', () => {
     const next = updater({});
     expect(next.t2.archived).toBe(true);
     expect(next.t2.updatedAt).toBeDefined();
+    expect(next.t2.events).toEqual([
+      expect.objectContaining({
+        type: 'delete',
+        summary: 'Usunieto zadanie.',
+      }),
+    ]);
   });
 
   test('bulkDeleteTasks calls deleteTask for each unique id', () => {

--- a/src/hooks/useTaskOperations.ts
+++ b/src/hooks/useTaskOperations.ts
@@ -1,6 +1,9 @@
 import {
+  appendUniqueTaskEvents,
   buildTaskChangeHistory,
+  buildTaskEventsFromHistory,
   buildTaskReorderUpdate,
+  createTaskEvent,
   createManualTask,
   createRecurringTaskFromTask,
   getNextTaskOrderTop,
@@ -147,14 +150,18 @@ export default function useTaskOperations({
       ...googleSyncPatch,
       updatedAt,
     };
-    const nextHistory = [
-      ...(normalizedUpdates.history || task.history || []),
-      ...buildTaskChangeHistory(task, nextTask, actor, taskColumns),
-    ];
+    const taskHistory = normalizedUpdates.history || task.history || [];
+    const changeHistory = buildTaskChangeHistory(task, nextTask, actor, taskColumns);
+    const nextHistory = [...taskHistory, ...changeHistory];
+    const nextEvents = appendUniqueTaskEvents(
+      task.events,
+      buildTaskEventsFromHistory(task, nextTask, changeHistory, actor, updatedAt)
+    );
     const nextPayload = {
       ...normalizedUpdates,
       ...googleSyncPatch,
       history: nextHistory,
+      events: nextEvents,
       updatedAt,
     };
     const shouldCreateRecurringFollowUp =
@@ -456,6 +463,17 @@ export default function useTaskOperations({
     const task = meetingTasks.find((item) => item.id === taskId);
     if (!task) return;
 
+    const updatedAt = new Date().toISOString();
+    const actor = currentUser?.name || currentUser?.email || 'Ty';
+    const deleteEvent = createTaskEvent('delete', task, 'Usunieto zadanie.', actor, {
+      field: 'archived',
+      from: Boolean(task.archived),
+      to: true,
+      previousUpdatedAt: task.updatedAt || task.createdAt,
+      createdAt: updatedAt,
+    });
+    const events = appendUniqueTaskEvents(task.events, [deleteEvent]);
+
     if (task.sourceType === 'manual') {
       setManualTasks((previous) => previous.filter((item) => item.id !== taskId));
       return;
@@ -466,7 +484,8 @@ export default function useTaskOperations({
       [taskId]: {
         ...(previous[taskId] || {}),
         archived: true,
-        updatedAt: new Date().toISOString(),
+        events,
+        updatedAt,
       },
     }));
   }

--- a/src/lib/appState.ts
+++ b/src/lib/appState.ts
@@ -1,6 +1,7 @@
 import {
   normalizeTaskComments,
   normalizeTaskDependencies,
+  normalizeTaskEvents,
   normalizeTaskHistory,
   normalizeTaskLinks,
   normalizeTaskPeopleList,
@@ -104,6 +105,8 @@ export function normalizeTaskUpdatePayload(
         : normalizeTaskComments(updates.comments),
     history:
       updates.history === undefined ? previousTask.history : normalizeTaskHistory(updates.history),
+    events:
+      updates.events === undefined ? previousTask.events : normalizeTaskEvents(updates.events),
     dependencies:
       updates.dependencies === undefined
         ? previousTask.dependencies

--- a/src/lib/tasks.ts
+++ b/src/lib/tasks.ts
@@ -351,6 +351,35 @@ function normalizeTaskHistoryEntry(item, index = 0) {
   };
 }
 
+function normalizeTaskEvent(item, index = 0) {
+  const summary = normalizeWhitespace(item?.summary ?? item?.message ?? item);
+  if (!summary) {
+    return null;
+  }
+
+  const type = normalizeWhitespace(item?.type) || 'update';
+  const taskId = normalizeWhitespace(item?.taskId);
+  const field = normalizeWhitespace(item?.field);
+  const createdAt = item?.createdAt || new Date().toISOString();
+  const dedupeKey =
+    normalizeWhitespace(item?.dedupeKey) ||
+    ['task', taskId, type, field, summary].filter(Boolean).join(':');
+
+  return {
+    id: normalizeWhitespace(item?.id) || createId(`event_${index}`),
+    type,
+    taskId,
+    actor: normalizeWhitespace(item?.actor) || 'System',
+    summary,
+    field,
+    from: item?.from,
+    to: item?.to,
+    metadata: item?.metadata && typeof item.metadata === 'object' ? item.metadata : {},
+    dedupeKey,
+    createdAt,
+  };
+}
+
 function normalizeTaskSubtask(item, index = 0) {
   const title = normalizeWhitespace(item?.title ?? item);
   if (!title) {
@@ -520,6 +549,10 @@ export function normalizeTaskHistory(value) {
   return normalizeTaskArray(value, normalizeTaskHistoryEntry);
 }
 
+export function normalizeTaskEvents(value) {
+  return normalizeTaskArray(value, normalizeTaskEvent);
+}
+
 export function normalizeTaskSubtasks(value) {
   return normalizeTaskArray(value, normalizeTaskSubtask);
 }
@@ -574,6 +607,118 @@ export function createTaskHistoryEntry(message, actor = 'System', type = 'update
     type,
     message,
     createdAt: new Date().toISOString(),
+  });
+}
+
+function taskEventTypeFromHistory(entry, previousTask, nextTask) {
+  const type = normalizeWhitespace(entry?.type);
+  if (type === 'created') return 'create';
+  if (type === 'import') return 'import';
+  if (type === 'status' || type === 'group') return 'status_change';
+  if (type === 'completed') return nextTask?.completed ? 'complete' : 'reopen';
+  if (type === 'comment') return 'comment';
+  if (type === 'dependencies') return 'dependency';
+  if (type === 'recurrence') return 'recurrence';
+  if (type === 'order') return 'order';
+  if ((previousTask?.archived || false) !== (nextTask?.archived || false)) {
+    return nextTask?.archived ? 'delete' : 'restore';
+  }
+  return 'update';
+}
+
+function taskEventFieldFromHistory(entry) {
+  const type = normalizeWhitespace(entry?.type);
+  if (!type || ['created', 'import', 'updated'].includes(type)) {
+    return '';
+  }
+  if (type === 'dependencies') {
+    return 'dependencies';
+  }
+  return type;
+}
+
+function taskEventValueForField(task, field) {
+  if (!field || !task) {
+    return undefined;
+  }
+  if (field === 'status') {
+    return task.status;
+  }
+  if (field === 'completed') {
+    return Boolean(task.completed);
+  }
+  if (field === 'dependencies') {
+    return normalizeTaskDependencies(task.dependencies);
+  }
+  return task[field];
+}
+
+export function createTaskEvent(type, task, summary, actor = 'System', options = {}) {
+  const taskId = normalizeWhitespace(options.taskId) || normalizeWhitespace(task?.id);
+  const field = normalizeWhitespace(options.field);
+  const createdAt = options.createdAt || new Date().toISOString();
+  const previousUpdatedAt =
+    normalizeWhitespace(options.previousUpdatedAt) ||
+    normalizeWhitespace(task?.updatedAt) ||
+    normalizeWhitespace(task?.createdAt);
+  const toValue = options.to !== undefined ? options.to : taskEventValueForField(task, field);
+  const dedupeKey =
+    normalizeWhitespace(options.dedupeKey) ||
+    ['task', taskId, type, field, previousUpdatedAt, JSON.stringify(toValue ?? '')]
+      .filter(Boolean)
+      .join(':');
+
+  return normalizeTaskEvent({
+    id: createId('event'),
+    type,
+    taskId,
+    actor,
+    summary,
+    field,
+    from: options.from,
+    to: toValue,
+    metadata: options.metadata || {},
+    dedupeKey,
+    createdAt,
+  });
+}
+
+export function appendUniqueTaskEvents(existingEvents, newEvents) {
+  const normalizedExisting = normalizeTaskEvents(existingEvents);
+  const seen = new Set(normalizedExisting.map((event) => event.dedupeKey || event.id));
+  const additions = normalizeTaskEvents(newEvents).filter((event) => {
+    const key = event.dedupeKey || event.id;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+    return true;
+  });
+  return [...normalizedExisting, ...additions];
+}
+
+export function buildTaskEventsFromHistory(
+  previousTask,
+  nextTask,
+  historyEntries,
+  actor,
+  createdAt
+) {
+  return normalizeTaskHistory(historyEntries).map((entry) => {
+    const field = taskEventFieldFromHistory(entry);
+    return createTaskEvent(
+      taskEventTypeFromHistory(entry, previousTask, nextTask),
+      nextTask,
+      entry.message,
+      actor,
+      {
+        field,
+        from: taskEventValueForField(previousTask, field),
+        to: taskEventValueForField(nextTask, field),
+        previousUpdatedAt: previousTask?.updatedAt || previousTask?.createdAt,
+        createdAt: entry.createdAt || createdAt,
+      }
+    );
   });
 }
 
@@ -828,7 +973,7 @@ export function buildTaskChangeHistory(previousTask, nextTask, actor, columns) {
   const entries = [];
 
   if ((previousTask.title || '') !== (nextTask.title || '')) {
-    entries.push(createTaskHistoryEntry(`Zmieniono tytul na "${nextTask.title}".`, actor));
+    entries.push(createTaskHistoryEntry(`Zmieniono tytul na "${nextTask.title}".`, actor, 'title'));
   }
 
   if ((previousTask.status || '') !== (nextTask.status || '')) {
@@ -851,7 +996,9 @@ export function buildTaskChangeHistory(previousTask, nextTask, actor, columns) {
     );
   }
 
-  if ((previousTask.owner || '') !== (nextTask.owner || '')) {
+  const previousOwner = normalizeWhitespace(previousTask.owner) || 'Nieprzypisane';
+  const nextOwner = normalizeWhitespace(nextTask.owner) || 'Nieprzypisane';
+  if (previousOwner !== nextOwner) {
     entries.push(
       createTaskHistoryEntry(
         nextTask.owner
@@ -1005,6 +1152,7 @@ function taskFromCandidate(candidate, meeting, index, columns) {
     group: normalizeGroup(candidate.group),
     comments: [],
     history: [],
+    events: [],
     dependencies: [],
     recurrence: null,
     subtasks: [],
@@ -1065,6 +1213,9 @@ function mergeTaskState(task, state, currentUser, columns) {
     history: hasOwn(state, 'history')
       ? normalizeTaskHistory(state.history)
       : normalizeTaskHistory(task.history),
+    events: hasOwn(state, 'events')
+      ? appendUniqueTaskEvents(task.events, state.events)
+      : normalizeTaskEvents(task.events),
     dependencies: hasOwn(state, 'dependencies')
       ? normalizeTaskDependencies(state.dependencies)
       : normalizeTaskDependencies(task.dependencies),
@@ -1168,6 +1319,7 @@ export function buildTaskGroups(tasks) {
 
 export function createManualTask(userId, draft, columns, workspaceId) {
   const now = new Date().toISOString();
+  const id = createId('task');
   const title = titleCase(draft.title);
   if (!title) {
     throw new Error('Dodaj tytul zadania.');
@@ -1178,9 +1330,14 @@ export function createManualTask(userId, draft, columns, workspaceId) {
     draft.assignedTo?.length ? draft.assignedTo : draft.owner
   );
   const owner = assignedTo[0] || normalizeWhitespace(draft.owner) || 'Nieprzypisane';
+  const history = normalizeTaskHistory(
+    draft.history?.length
+      ? draft.history
+      : [createTaskHistoryEntry('Utworzono zadanie.', 'System', 'created')]
+  );
 
   return {
-    id: createId('task'),
+    id,
     userId,
     workspaceId: workspaceId || draft.workspaceId || '',
     createdByUserId: userId,
@@ -1207,10 +1364,17 @@ export function createManualTask(userId, draft, columns, workspaceId) {
     tags: Array.isArray(draft.tags) ? draft.tags : parseTagInput(draft.tags),
     group: normalizeGroup(draft.group),
     comments: normalizeTaskComments(draft.comments),
-    history: normalizeTaskHistory(
-      draft.history?.length
-        ? draft.history
-        : [createTaskHistoryEntry('Utworzono zadanie.', 'System', 'created')]
+    history,
+    events: normalizeTaskEvents(
+      draft.events?.length
+        ? draft.events
+        : buildTaskEventsFromHistory(
+            null,
+            { id, sourceType: 'manual', updatedAt: now },
+            history,
+            'System',
+            now
+          )
     ),
     dependencies: normalizeTaskDependencies(draft.dependencies),
     recurrence: normalizeTaskRecurrence(draft.recurrence),
@@ -1237,6 +1401,8 @@ export function createTaskFromGoogle(
   const owner = currentUser?.name || currentUser?.email || 'Ja';
   const syncedAt = new Date().toISOString();
   const googleUpdatedAt = googleTask.updated || googleTask.completed || dueDate;
+  const id = createId('google_task');
+  const history = [createTaskHistoryEntry('Zaimportowano z Google Tasks.', 'System', 'import')];
   const googleSync = normalizeGoogleTaskSyncState({
     googleTaskId: googleTask.id,
     googleTaskListId: taskList.id,
@@ -1248,7 +1414,7 @@ export function createTaskFromGoogle(
   });
 
   return {
-    id: createId('google_task'),
+    id,
     userId,
     workspaceId: workspaceId || '',
     createdByUserId: userId,
@@ -1277,7 +1443,14 @@ export function createTaskFromGoogle(
     tags: [],
     group: normalizeGroup(taskList.title || ''),
     comments: [],
-    history: [createTaskHistoryEntry('Zaimportowano z Google Tasks.', 'System', 'import')],
+    history,
+    events: buildTaskEventsFromHistory(
+      null,
+      { id, sourceType: 'google', updatedAt: syncedAt },
+      history,
+      'System',
+      syncedAt
+    ),
     dependencies: [],
     recurrence: null,
     subtasks: [],

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -288,6 +288,34 @@ export interface TaskHistoryEntry {
   createdAt: string;
 }
 
+export type TaskEventType =
+  | 'create'
+  | 'update'
+  | 'status_change'
+  | 'complete'
+  | 'reopen'
+  | 'delete'
+  | 'restore'
+  | 'comment'
+  | 'dependency'
+  | 'recurrence'
+  | 'order'
+  | 'import';
+
+export interface TaskEvent {
+  id: string;
+  type: TaskEventType | (string & {});
+  taskId?: string;
+  actor?: string;
+  summary: string;
+  field?: string;
+  from?: unknown;
+  to?: unknown;
+  metadata?: Record<string, unknown>;
+  dedupeKey?: string;
+  createdAt: string;
+}
+
 export interface TaskDependency {
   taskId: string;
   type?: 'blocks' | 'blocked_by' | string;
@@ -370,6 +398,7 @@ export interface TaskRecord {
   tags: string[];
   comments: TaskComment[];
   history: TaskHistoryEntry[];
+  events: TaskEvent[];
   dependencies: Array<string | TaskDependency>;
   recurrence: TaskRecurrence | null;
   subtasks: TaskSubtask[];
@@ -400,6 +429,7 @@ export type TaskStatePatch = Partial<
     | 'tags'
     | 'comments'
     | 'history'
+    | 'events'
     | 'dependencies'
     | 'recurrence'
     | 'subtasks'

--- a/src/tasks/TaskDetailsPanel.test.tsx
+++ b/src/tasks/TaskDetailsPanel.test.tsx
@@ -110,6 +110,29 @@ describe('TaskDetailsPanel', () => {
     expect(screen.getByText('Status changed to todo')).toBeInTheDocument();
   });
 
+  it('renders structured task events before legacy history entries', async () => {
+    const taskWithEvents = {
+      ...mockSelectedTask,
+      events: [
+        {
+          id: 'event-1',
+          type: 'status_change',
+          actor: 'User',
+          summary: 'Przeniesiono do W toku.',
+          createdAt: '2026-03-26T10:00:00Z',
+        },
+      ],
+    };
+    const { container } = render(<TaskDetailsPanel {...mockProps} selectedTask={taskWithEvents} />);
+
+    fireEvent.click(container.querySelector('.todo-history-toggle') as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(screen.getByText('Przeniesiono do W toku.')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Created task')).not.toBeInTheDocument();
+  });
+
   it('collapses history when expanded', async () => {
     render(<TaskDetailsPanel {...mockProps} />);
 

--- a/src/tasks/TaskDetailsPanel.tsx
+++ b/src/tasks/TaskDetailsPanel.tsx
@@ -124,6 +124,17 @@ function TaskDetailsPanel(props: any) {
     ? 'Oznacz jako nieukonczone'
     : 'Oznacz jako ukonczone';
   const peopleSuggestions = normalizePeopleSuggestions(peopleOptions);
+  const structuredEvents = Array.isArray(selectedTask.events) ? selectedTask.events : [];
+  const legacyHistory = Array.isArray(selectedTask.history) ? selectedTask.history : [];
+  const auditEntries = structuredEvents.length
+    ? structuredEvents.map((event) => ({
+        id: event.id,
+        actor: event.actor || 'System',
+        message: event.summary || event.message,
+        createdAt: event.createdAt,
+        type: event.type,
+      }))
+    : legacyHistory;
   const sharedTaskForm = (
     <TaskCreateForm
       key={selectedTask.id}
@@ -322,8 +333,8 @@ function TaskDetailsPanel(props: any) {
                 Historia zmian
               </strong>
               <div className="todo-section-head-row">
-                <span>{(selectedTask.history || []).length}</span>
-                {(selectedTask.history || []).length > 0 && (
+                <span>{auditEntries.length}</span>
+                {auditEntries.length > 0 && (
                   <button
                     type="button"
                     className="todo-history-toggle"
@@ -352,7 +363,7 @@ function TaskDetailsPanel(props: any) {
           </div>
           {historyExpanded && (
             <div className="todo-history-list">
-              {[...selectedTask.history].reverse().map((entry) => (
+              {[...auditEntries].reverse().map((entry) => (
                 <article key={entry.id} className="todo-history-row">
                   <strong>{entry.actor || 'System'}</strong>
                   <p>{entry.message}</p>
@@ -361,7 +372,7 @@ function TaskDetailsPanel(props: any) {
               ))}
             </div>
           )}
-          {!historyExpanded && (selectedTask.history || []).length === 0 && (
+          {!historyExpanded && auditEntries.length === 0 && (
             <p className="todo-section-empty">Historia pojawi się po pierwszych zmianach.</p>
           )}
         </section>


### PR DESCRIPTION
## Summary
- Add structured TaskEvent records alongside legacy task.history.
- Generate events for create/import/update/complete/reopen/comment/dependency/recurrence/order/delete-style operations.
- Deduplicate events by stable mutation keys to avoid retry duplicates.
- Render structured events in task details with legacy history fallback.

Closes #1382

## Validation
- corepack pnpm run typecheck: passed (Node 24 engine warning only).
- node_modules\\.bin\\vitest.cmd run src\\hooks\\useTaskOperations.test.ts src\\tasks\\TaskDetailsPanel.test.tsx --coverage.enabled=false: passed, 51 tests.
- git diff --check: passed.
- pre-push release guard: passed, including server retry suite, focused frontend suite, and build warning audit.

## Notes
- Existing task.history remains intact for backward compatibility.
- Manual delete keeps existing product behavior of removing the manual task; structured delete events are persisted for archived/derived task paths without changing that flow.