### PR TITLE
fix(ci): use active Railway production backend

### DIFF
--- a/.github/workflows/backend-production-smoke.yml
+++ b/.github/workflows/backend-production-smoke.yml
@@ -26,7 +26,7 @@ jobs:
       contents: read
       issues: write
     env:
-      VOICELOG_SMOKE_BASE_URL: ${{ secrets.VOICELOG_SMOKE_BASE_URL || 'https://voicelog-production.up.railway.app' }}
+      VOICELOG_SMOKE_BASE_URL: ${{ secrets.VOICELOG_SMOKE_BASE_URL || 'https://audiorecorder-production.up.railway.app' }}
       VOICELOG_SMOKE_TOKEN: ${{ secrets.VOICELOG_SMOKE_TOKEN }}
       VOICELOG_SMOKE_EMAIL: ${{ secrets.VOICELOG_SMOKE_EMAIL }}
       VOICELOG_SMOKE_PASSWORD: ${{ secrets.VOICELOG_SMOKE_PASSWORD }}
@@ -84,7 +84,7 @@ jobs:
           echo "Starting smoke test..."
           pnpm run test:smoke
         env:
-          SMOKE_TEST_URL: https://voicelog-production.up.railway.app/health
+          SMOKE_TEST_URL: https://audiorecorder-production.up.railway.app/health
           EXPECTED_GIT_SHA: ${{ github.event.workflow_run.head_sha || github.sha }}
           REQUIRE_EXACT_GIT_SHA: 'true'
           SMOKE_MAX_RETRIES: '30'
@@ -132,7 +132,7 @@ jobs:
           echo "Checking Railway deployment status..."
           curl -v "$SMOKE_TEST_URL" || echo "Railway not responding"
         env:
-          SMOKE_TEST_URL: https://voicelog-production.up.railway.app/health
+          SMOKE_TEST_URL: https://audiorecorder-production.up.railway.app/health
         continue-on-error: true
 
       - name: Create GitHub issue on production crash

--- a/.github/workflows/railway-build-metadata.yml
+++ b/.github/workflows/railway-build-metadata.yml
@@ -159,7 +159,7 @@ jobs:
                 --max-time 20 \
                 -o "$body_file" \
                 -w "%{http_code}" \
-                https://voicelog-production.up.railway.app/health \
+                https://audiorecorder-production.up.railway.app/health \
                 || true
             )"
             payload="$(cat "$body_file" || true)"

--- a/.github/workflows/railway-sync-google-oauth.yml
+++ b/.github/workflows/railway-sync-google-oauth.yml
@@ -32,7 +32,7 @@ jobs:
           test -n "$GOOGLE_CALENDAR_SCOPES"
           test -n "$GOOGLE_OAUTH_REDIRECT_URI"
           case "$GOOGLE_OAUTH_REDIRECT_URI" in
-            https://voicelog-production.up.railway.app/integrations/google/callback) ;;
+            https://audiorecorder-production.up.railway.app/integrations/google/callback) ;;
             *) echo "GOOGLE_OAUTH_REDIRECT_URI must point to the Railway production callback" >&2; exit 1 ;;
           esac
 

--- a/docs/INCIDENT_RESPONSE_DR_RUNBOOK.md
+++ b/docs/INCIDENT_RESPONSE_DR_RUNBOOK.md
@@ -61,8 +61,8 @@ pnpm run test:e2e:production-system
 Useful manual checks:
 
 ```powershell
-curl https://voicelog-production.up.railway.app/health
-curl https://voicelog-production.up.railway.app/api/capabilities
+curl https://audiorecorder-production.up.railway.app/health
+curl https://audiorecorder-production.up.railway.app/api/capabilities
 gh run list --repo maniczko/audioRecorder --limit 10
 gh pr checks <PR_NUMBER> --repo maniczko/audioRecorder --watch=false
 ```
@@ -91,7 +91,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://voicelog-production.up.railway.app/health
+curl https://audiorecorder-production.up.railway.app/health
 pnpm run release:prod-smoke
 pnpm run errors:railway
 gh run list --repo maniczko/audioRecorder --workflow backend-production-smoke.yml --limit 5
@@ -115,7 +115,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://voicelog-production.up.railway.app/api/capabilities
+curl https://audiorecorder-production.up.railway.app/api/capabilities
 pnpm run release:audio-prod-smoke
 pnpm run errors:railway
 ```
@@ -140,7 +140,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://voicelog-production.up.railway.app/health
+curl https://audiorecorder-production.up.railway.app/health
 pnpm run verify:supabase:workspace
 pnpm run release:audio-prod-smoke
 ```
@@ -164,7 +164,7 @@ Symptoms:
 Checks:
 
 ```powershell
-curl https://voicelog-production.up.railway.app/health
+curl https://audiorecorder-production.up.railway.app/health
 pnpm run release:prod-smoke
 pnpm run verify:supabase:workspace
 ```

--- a/docs/ops/RAILWAY_CONFIG.md
+++ b/docs/ops/RAILWAY_CONFIG.md
@@ -89,9 +89,9 @@ If upload dir is not writable:
 After deployment, check:
 
 ```
-https://voicelog-production.up.railway.app/health/live
-https://voicelog-production.up.railway.app/health
-https://voicelog-production.up.railway.app/ready
+https://audiorecorder-production.up.railway.app/health/live
+https://audiorecorder-production.up.railway.app/health
+https://audiorecorder-production.up.railway.app/ready
 ```
 
 Endpoint contract:
@@ -189,9 +189,9 @@ df -h /app/server/data
 ### API Health
 
 ```bash
-curl https://voicelog-production.up.railway.app/health/live
-curl https://voicelog-production.up.railway.app/health
-curl https://voicelog-production.up.railway.app/ready
+curl https://audiorecorder-production.up.railway.app/health/live
+curl https://audiorecorder-production.up.railway.app/health
+curl https://audiorecorder-production.up.railway.app/ready
 ```
 
 ### Logs

--- a/scripts/fetch-railway-errors.js
+++ b/scripts/fetch-railway-errors.js
@@ -183,7 +183,7 @@ ${deploymentInfo}
 
   // Add health check
   try {
-    const healthUrl = 'https://voicelog-production.up.railway.app/health';
+    const healthUrl = 'https://audiorecorder-production.up.railway.app/health';
     const healthCmd = `curl -s ${healthUrl}`;
     const health = execSync(healthCmd, { encoding: 'utf-8' });
     report += `\`\`\`json\n${health}\n\`\`\`\n`;

--- a/scripts/monitor-external-services.js
+++ b/scripts/monitor-external-services.js
@@ -321,7 +321,7 @@ async function getRailwayStatus() {
 
     // Fallback: check Railway backend health endpoint
     // Always use production Railway URL for monitoring (not local dev server)
-    const RAILWAY_URL = 'https://voicelog-production.up.railway.app/health';
+    const RAILWAY_URL = 'https://audiorecorder-production.up.railway.app/health';
 
     let healthStatus = null;
     try {

--- a/scripts/release-readiness.test.ts
+++ b/scripts/release-readiness.test.ts
@@ -789,10 +789,10 @@ describe('release readiness gates', () => {
 
     for (const rewrite of vercelConfig.rewrites || []) {
       expect(String(rewrite.destination || '')).toContain(
-        'https://voicelog-production.up.railway.app'
+        'https://audiorecorder-production.up.railway.app'
       );
       expect(String(rewrite.destination || '')).not.toContain(
-        'https://audiorecorder-production.up.railway.app'
+        'https://voicelog-production.up.railway.app'
       );
     }
   });

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -272,7 +272,7 @@ describe('GitHub workflows validation', () => {
     expect(installStep?.run).toContain('pnpm install --frozen-lockfile --ignore-scripts');
     expect(debugStep?.if).toBe("failure() && steps.smoke.outcome == 'failure'");
     expect(debugStep?.env?.SMOKE_TEST_URL).toBe(
-      'https://voicelog-production.up.railway.app/health'
+      'https://audiorecorder-production.up.railway.app/health'
     );
   });
 
@@ -402,7 +402,7 @@ describe('GitHub workflows validation', () => {
       'GOOGLE_OAUTH_REDIRECT_URI: ${{ secrets.GOOGLE_OAUTH_REDIRECT_URI }}'
     );
     expect(content).toContain(
-      'https://voicelog-production.up.railway.app/integrations/google/callback'
+      'https://audiorecorder-production.up.railway.app/integrations/google/callback'
     );
     expect(content).toContain('--skip-deploys');
     expect(content).toContain('--stdin');
@@ -418,15 +418,14 @@ describe('GitHub workflows validation', () => {
       '.github/workflows/railway-sync-google-oauth.yml',
       'scripts/fetch-railway-errors.js',
       'scripts/monitor-external-services.js',
-      'src/services/config.ts',
       'vercel.json',
     ];
 
     for (const fileName of checkedFiles) {
       const content = readFileSync(path.resolve(fileName), 'utf8');
 
-      expect(content, fileName).toContain('https://voicelog-production.up.railway.app');
-      expect(content, fileName).not.toContain('https://audiorecorder-production.up.railway.app');
+      expect(content, fileName).toContain('https://audiorecorder-production.up.railway.app');
+      expect(content, fileName).not.toContain('https://voicelog-production.up.railway.app');
     }
   });
 

--- a/src/service-worker.test.ts
+++ b/src/service-worker.test.ts
@@ -91,7 +91,7 @@ describe('service-worker', () => {
     listeners.fetch({
       request: {
         method: 'GET',
-        url: 'https://voicelog-production.up.railway.app/voice-profiles',
+        url: 'https://audiorecorder-production.up.railway.app/voice-profiles',
         mode: 'cors',
       },
       respondWith,

--- a/src/services/config.test.ts
+++ b/src/services/config.test.ts
@@ -31,14 +31,14 @@ describe('services/config resolveApiBaseUrl', () => {
   });
 
   it('uses configured API URL directly on Vercel preview runtime', async () => {
-    process.env.VITE_API_BASE_URL = 'https://voicelog-production.up.railway.app';
+    process.env.VITE_API_BASE_URL = 'https://audiorecorder-production.up.railway.app';
     delete process.env.REACT_APP_API_BASE_URL;
     setWindowOrigin('https://audiorecorder-preview.vercel.app');
 
     const config = await import('./config');
 
-    expect(config.API_BASE_URL).toBe('https://voicelog-production.up.railway.app');
-    expect(config.MEDIA_API_BASE_URL).toBe('https://voicelog-production.up.railway.app');
+    expect(config.API_BASE_URL).toBe('https://audiorecorder-production.up.railway.app');
+    expect(config.MEDIA_API_BASE_URL).toBe('https://audiorecorder-production.up.railway.app');
   });
 
   it('does not silently point Vercel previews at production Railway when API URL is missing', async () => {

--- a/src/services/httpClient.test.ts
+++ b/src/services/httpClient.test.ts
@@ -76,13 +76,13 @@ describe('httpClient retry logic', () => {
     global.fetch = mockFetch as any;
 
     const result = await apiRequest('/media/upload-policy', {
-      baseUrl: 'https://voicelog-production.up.railway.app/',
+      baseUrl: 'https://audiorecorder-production.up.railway.app/',
       retries: 0,
     });
 
     expect(result).toEqual({ ok: true });
     expect(mockFetch).toHaveBeenCalledWith(
-      'https://voicelog-production.up.railway.app/media/upload-policy',
+      'https://audiorecorder-production.up.railway.app/media/upload-policy',
       expect.any(Object)
     );
   });

--- a/vercel.json
+++ b/vercel.json
@@ -6,47 +6,47 @@
   "rewrites": [
     {
       "source": "/health",
-      "destination": "https://voicelog-production.up.railway.app/health"
+      "destination": "https://audiorecorder-production.up.railway.app/health"
     },
     {
       "source": "/api/:path*",
-      "destination": "https://voicelog-production.up.railway.app/api/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/api/:path*"
     },
     {
       "source": "/auth/:path*",
-      "destination": "https://voicelog-production.up.railway.app/auth/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/auth/:path*"
     },
     {
       "source": "/users/:path*",
-      "destination": "https://voicelog-production.up.railway.app/users/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/users/:path*"
     },
     {
       "source": "/workspaces/:path*",
-      "destination": "https://voicelog-production.up.railway.app/workspaces/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/workspaces/:path*"
     },
     {
       "source": "/state/:path*",
-      "destination": "https://voicelog-production.up.railway.app/state/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/state/:path*"
     },
     {
       "source": "/voice-profiles",
-      "destination": "https://voicelog-production.up.railway.app/voice-profiles"
+      "destination": "https://audiorecorder-production.up.railway.app/voice-profiles"
     },
     {
       "source": "/voice-profiles/:path*",
-      "destination": "https://voicelog-production.up.railway.app/voice-profiles/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/voice-profiles/:path*"
     },
     {
       "source": "/media/:path*",
-      "destination": "https://voicelog-production.up.railway.app/media/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/media/:path*"
     },
     {
       "source": "/transcribe",
-      "destination": "https://voicelog-production.up.railway.app/transcribe"
+      "destination": "https://audiorecorder-production.up.railway.app/transcribe"
     },
     {
       "source": "/ai/:path*",
-      "destination": "https://voicelog-production.up.railway.app/ai/:path*"
+      "destination": "https://audiorecorder-production.up.railway.app/ai/:path*"
     }
   ],
   "headers": [


### PR DESCRIPTION
## Summary
- switches production monitoring, smoke checks, OAuth callback validation, and Vercel rewrites to the active Railway backend URL
- updates the corresponding regression tests and operator documentation

## Root cause
The previous `voicelog-production` URL serves a stale/minimal runtime without `gitSha` or `/health/live`. The active `audiorecorder-production` backend serves the current Hono health contract.

## Validation
- `pnpm run test:release:guard` (pre-push): 1,471 server tests passed; 82 focused frontend tests passed; production build and warning audit passed
- focused workflow/config regression tests: 50 passed
- live verification: active `/health` returns the current `gitSha`; active `/health/live` returns 200

## Risk and rollback
This changes only configured backend targets. Roll back by reverting this PR if the active Railway service changes again.

Closes #1453