### PR TITLE
docs(ops): add backup restore runbook and verification script

### DIFF
--- a/.github/workflows/production-data-maintenance.yml
+++ b/.github/workflows/production-data-maintenance.yml
@@ -1,6 +1,8 @@
 name: Production Data Maintenance
 
 on:
+  schedule:
+    - cron: '17 4 * * 1'
   workflow_dispatch:
     inputs:
       apply:
@@ -15,6 +17,30 @@ on:
         description: 'Optional workspace id override. Empty uses PRODUCTION_SMOKE_WORKSPACE_ID.'
         required: false
         default: ''
+      run_restore_verification:
+        description: 'Run staging/sandbox backup restore verification.'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      restore_workspace_id:
+        description: 'Optional restored staging workspace id. Empty uses RESTORE_VERIFY_WORKSPACE_ID.'
+        required: false
+        default: ''
+      restore_environment:
+        description: 'Restore verification target environment.'
+        required: true
+        default: 'staging'
+        type: choice
+        options:
+          - 'staging'
+          - 'sandbox'
+      expected_recording_ids:
+        description: 'Comma-separated restored recording ids to verify.'
+        required: false
+        default: ''
 
 concurrency:
   group: production-data-maintenance
@@ -22,6 +48,7 @@ concurrency:
 
 jobs:
   repair-workspace-consistency:
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     timeout-minutes: 20
     env:
@@ -84,4 +111,61 @@ jobs:
           path: |
             reports/supabase-workspace-repair/
             reports/supabase-workspace-consistency/
+          if-no-files-found: ignore
+
+  backup-restore-verification:
+    if: ${{ github.event_name == 'schedule' || inputs.run_restore_verification == 'true' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SUPABASE_URL: ${{ secrets.STAGING_SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}
+      WORKSPACE_ID: ${{ inputs.restore_workspace_id || secrets.RESTORE_VERIFY_WORKSPACE_ID }}
+      RESTORE_VERIFY_ENVIRONMENT: ${{ inputs.restore_environment || 'staging' }}
+      RESTORE_VERIFY_EXPECTED_RECORDING_IDS: ${{ inputs.expected_recording_ids || secrets.RESTORE_VERIFY_EXPECTED_RECORDING_IDS }}
+      SUPABASE_STORAGE_BUCKET: ${{ secrets.RESTORE_VERIFY_STORAGE_BUCKET || 'recordings' }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate restore verification secrets
+        shell: bash
+        run: |
+          missing=()
+          for secret in SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY WORKSPACE_ID; do
+            [[ -n "${!secret}" ]] || missing+=("${secret}")
+          done
+
+          if [ "${RESTORE_VERIFY_ENVIRONMENT}" = "production" ]; then
+            missing+=("RESTORE_VERIFY_ENVIRONMENT must be staging or sandbox")
+          fi
+
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "## Missing backup restore verification secrets" >> "$GITHUB_STEP_SUMMARY"
+            for secret in "${missing[@]}"; do
+              echo "- ${secret}" >> "$GITHUB_STEP_SUMMARY"
+              echo "::error::Missing required restore verification setting: ${secret}"
+            done
+            exit 1
+          fi
+
+      - name: Verify restored staging workspace
+        run: pnpm run verify:backup-restore
+
+      - name: Upload restore verification report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: backup-restore-verification-report
+          path: reports/backup-restore-verification/
           if-no-files-found: ignore

--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,7 @@ Root stays intentionally small:
 
 - `adr/` - architecture decision records
 - `ops/` - deployment, runtime, monitoring, APM, disk, and Node setup notes
+  - `ops/BACKUP_RESTORE_RUNBOOK.md` - backup sources, restore drill checklist, and restore verification workflow
   - `ops/TRANSCRIPTION_JOB_OPERATIONS.md` - operator workflow for durable transcription jobs
   - `ops/PROVIDER_QUOTAS.md` - cost controls for AI, STT, live transcription, images, and embeddings
 - `automation/` - automation workflows, task runners, and historical automation notes

--- a/docs/ops/BACKUP_RESTORE_RUNBOOK.md
+++ b/docs/ops/BACKUP_RESTORE_RUNBOOK.md
@@ -1,0 +1,86 @@
+# Backup And Restore Runbook
+
+Issue #1247 establishes the minimum business-continuity path for VoiceLog data. The restore drill must use staging or sandbox resources by default; production restore verification is break-glass only.
+
+## Backup Sources
+
+| Source                       | What to capture                                                                                                   | Minimum frequency                                         | Owner            | Restore evidence                                             |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- | ---------------- | ------------------------------------------------------------ |
+| Postgres / Supabase database | `workspace_state`, `media_assets`, auth-linked workspace metadata, audit logs, task data, transcription job state | Daily automated backup plus pre-migration snapshot        | Platform owner   | Restored workspace id, row counts, schema migration version  |
+| Supabase Storage             | Recording objects in the `recordings` bucket or configured bucket                                                 | Daily object backup or provider-managed storage retention | Platform owner   | Signed URL or object existence check for restored recordings |
+| Environment configuration    | Railway, Vercel, Supabase, Google, AI provider, Sentry, and scheduled job variables                               | On every config change and before release                 | Release owner    | Redacted env export checksum and change ticket               |
+| Deployment metadata          | Git SHA, Railway deploy id, Vercel deployment id, migration set, build id                                         | Every deployment                                          | Release owner    | Matching Git SHA and deployment links                        |
+| Operational docs             | Runbooks, incident contacts, restore checklist, decision log                                                      | On every process change                                   | Engineering lead | PR link and runbook version                                  |
+
+Never store secrets, service-role keys, raw audio, transcripts, or database dumps in GitHub issues, PRs, or artifacts. Artifacts from restore verification should contain only structured health results and identifiers needed for follow-up.
+
+## Restore Drill Checklist
+
+Use this checklist for monthly drills and after any backup tooling change.
+
+1. Create or refresh an isolated staging/sandbox Supabase project.
+2. Restore the latest approved Postgres backup into the staging/sandbox database.
+3. Restore the matching Supabase Storage objects into the staging/sandbox storage bucket.
+4. Apply any pending migrations that are part of the target release.
+5. Configure staging app secrets from the redacted environment manifest.
+6. Set these GitHub secrets for the restore verification workflow:
+   - `STAGING_SUPABASE_URL`
+   - `STAGING_SUPABASE_SERVICE_ROLE_KEY`
+   - `RESTORE_VERIFY_WORKSPACE_ID`
+   - optional `RESTORE_VERIFY_EXPECTED_RECORDING_IDS`
+   - optional `RESTORE_VERIFY_STORAGE_BUCKET`
+7. Run **Production Data Maintenance** with `run_restore_verification=true` or wait for the scheduled weekly verification.
+8. Confirm the report artifact under `reports/backup-restore-verification/`.
+9. Record the restore id, backup id, workspace id, Git SHA, and any limitations in the incident or drill ticket.
+10. If any P0 or P1 issue appears, do not mark the restore drill complete until the data or process gap is fixed.
+
+## Automated Verification
+
+Run locally against staging or sandbox:
+
+```bash
+RESTORE_VERIFY_ENVIRONMENT=staging \
+SUPABASE_URL=https://project.supabase.co \
+SUPABASE_SERVICE_ROLE_KEY=... \
+RESTORE_VERIFY_WORKSPACE_ID=workspace_restore \
+RESTORE_VERIFY_EXPECTED_RECORDING_IDS=recording_1,recording_2 \
+pnpm run verify:backup-restore
+```
+
+The verifier is read-only. It checks:
+
+- the restored `workspace_state` row exists;
+- restored meetings still reference valid recordings;
+- expected recordings exist in `media_assets`;
+- completed recordings still have transcript metadata;
+- restored audio objects are available in Supabase Storage;
+- workspace consistency checks from `verify-supabase-workspace-consistency.mjs` remain green.
+
+By default the verifier refuses `RESTORE_VERIFY_ENVIRONMENT=production`. A production verification requires an explicit break-glass override:
+
+```bash
+RESTORE_VERIFY_ALLOW_PRODUCTION=true RESTORE_VERIFY_ENVIRONMENT=production pnpm run verify:backup-restore
+```
+
+Use this only during an approved incident response, and include the approver in the incident record.
+
+## Rollback Decision Points
+
+Stop and roll back to the previous known-good restore point when any of these are true:
+
+- restored workspace data has P0 consistency issues;
+- expected recording ids are missing;
+- restored audio objects are unavailable;
+- transcript metadata is missing for completed recordings;
+- schema migrations cannot be replayed cleanly;
+- app smoke tests cannot authenticate or load the restored workspace.
+
+Continue with limited release only when issues are P2, documented, and accepted by the release owner.
+
+## Known Limitations
+
+- The verifier proves a restored sample workspace, not every workspace in the database.
+- Supabase Storage object checks use signed URL creation as an availability proxy.
+- Environment config verification is evidence-based; secrets are never printed or uploaded.
+- Provider-specific backup retention settings still need to be reviewed outside this repository.
+- A successful restore drill does not replace production smoke tests after deployment.

--- a/package.json
+++ b/package.json
@@ -181,6 +181,7 @@
     "release:prod-gate:strict": "node scripts/release-prod-gate-strict.mjs",
     "verify:supabase:workspace": "node scripts/verify-supabase-workspace-consistency.mjs --strict --write-report",
     "repair:supabase:workspace": "node scripts/repair-supabase-workspace-consistency.mjs --write-report",
+    "verify:backup-restore": "node scripts/verify-backup-restore.mjs --write-report",
     "sentry:release-health": "node scripts/sentry-release-health.mjs",
     "preview": "vite preview",
     "typecheck": "tsc --noEmit",

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -240,6 +240,52 @@ describe('GitHub workflows validation', () => {
     expect(content).not.toContain('steps.scope.outputs.require_exact_git_sha');
   });
 
+  it('keeps backup restore verification staging-safe in production data maintenance', () => {
+    const workflowPath = path.join(workflowDir, 'production-data-maintenance.yml');
+    const content = readFileSync(workflowPath, 'utf8');
+    const parsed = parse(content) as {
+      on?: {
+        workflow_dispatch?: { inputs?: Record<string, unknown> };
+        schedule?: unknown[];
+      };
+      jobs?: {
+        'repair-workspace-consistency'?: {
+          if?: string;
+        };
+        'backup-restore-verification'?: {
+          if?: string;
+          env?: Record<string, unknown>;
+          steps?: Array<{
+            name?: string;
+            run?: string;
+            uses?: string;
+            with?: Record<string, unknown>;
+          }>;
+        };
+      };
+    } | null;
+    const repairJob = parsed?.jobs?.['repair-workspace-consistency'];
+    const job = parsed?.jobs?.['backup-restore-verification'];
+    const steps = job?.steps ?? [];
+
+    expect(parsed?.on?.schedule).toBeTruthy();
+    expect(parsed?.on?.workflow_dispatch?.inputs).toHaveProperty('run_restore_verification');
+    expect(parsed?.on?.workflow_dispatch?.inputs).toHaveProperty('restore_workspace_id');
+    expect(repairJob?.if).toBe("${{ github.event_name == 'workflow_dispatch' }}");
+    expect(job?.if).toContain("github.event_name == 'schedule'");
+    expect(job?.if).toContain("inputs.run_restore_verification == 'true'");
+    expect(job?.env?.SUPABASE_URL).toBe('${{ secrets.STAGING_SUPABASE_URL }}');
+    expect(job?.env?.SUPABASE_SERVICE_ROLE_KEY).toBe(
+      '${{ secrets.STAGING_SUPABASE_SERVICE_ROLE_KEY }}'
+    );
+    expect(job?.env?.RESTORE_VERIFY_ENVIRONMENT).toContain('staging');
+    expect(content).toContain('RESTORE_VERIFY_ENVIRONMENT must be staging or sandbox');
+    expect(steps.some((step) => step.run === 'pnpm run verify:backup-restore')).toBe(true);
+    expect(steps.some((step) => step.with?.path === 'reports/backup-restore-verification/')).toBe(
+      true
+    );
+  });
+
   it('keeps backend smoke dependency setup resilient and debugs only smoke failures', () => {
     const workflowPath = path.join(workflowDir, 'backend-production-smoke.yml');
     const content = readFileSync(workflowPath, 'utf8');

--- a/scripts/verify-backup-restore.mjs
+++ b/scripts/verify-backup-restore.mjs
@@ -1,0 +1,403 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import {
+  buildWorkspaceConsistencyReport,
+  fetchWorkspaceConsistencyInputs,
+} from './verify-supabase-workspace-consistency.mjs';
+
+const rootDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_BUCKET = 'recordings';
+
+function readArg(name, fallback = '') {
+  const prefix = `--${name}=`;
+  const directIndex = process.argv.indexOf(`--${name}`);
+  if (directIndex >= 0 && process.argv[directIndex + 1]) {
+    return process.argv[directIndex + 1];
+  }
+  return process.argv.find((arg) => arg.startsWith(prefix))?.slice(prefix.length) || fallback;
+}
+
+function clean(value) {
+  return String(value || '').trim();
+}
+
+function normalizeStoragePath(value) {
+  return clean(value).replace(/^recordings\//, '');
+}
+
+function isLikelyLocalAudioPath(value) {
+  const raw = clean(value);
+  if (!raw) return false;
+  return (
+    /^[a-z]:\\/i.test(raw) ||
+    raw.includes('\\') ||
+    raw.startsWith('/') ||
+    raw.startsWith('./') ||
+    raw.startsWith('../')
+  );
+}
+
+function safeJsonParse(value, fallback) {
+  if (value === null || value === undefined || value === '') return fallback;
+  if (typeof value === 'object') return value;
+  try {
+    return JSON.parse(String(value));
+  } catch {
+    return fallback;
+  }
+}
+
+function parseList(value) {
+  return clean(value)
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function transcriptTextLength(value) {
+  const segments = Array.isArray(value) ? value : [];
+  return segments.reduce(
+    (sum, segment) => sum + clean(segment?.text || segment?.transcript).length,
+    0
+  );
+}
+
+function assetTranscriptLength(asset) {
+  return transcriptTextLength(safeJsonParse(asset?.transcript_json, []));
+}
+
+function issue(severity, code, message, details = {}) {
+  return { severity, code, message, details };
+}
+
+function toStorageStatusMap(storageStatusByPath = {}) {
+  return storageStatusByPath instanceof Map
+    ? storageStatusByPath
+    : new Map(Object.entries(storageStatusByPath || {}));
+}
+
+function severityCounts(issues) {
+  return issues.reduce(
+    (counts, item) => {
+      counts[item.severity] = (counts[item.severity] || 0) + 1;
+      return counts;
+    },
+    { P0: 0, P1: 0, P2: 0 }
+  );
+}
+
+function hasBlockingIssues(issues) {
+  return issues.some((item) => item.severity === 'P0' || item.severity === 'P1');
+}
+
+export function validateBackupRestoreVerifierEnv(env = process.env) {
+  const missing = [];
+  for (const key of ['SUPABASE_URL', 'SUPABASE_SERVICE_ROLE_KEY']) {
+    if (!clean(env[key])) missing.push(key);
+  }
+  const workspaceId = clean(env.WORKSPACE_ID || env.RESTORE_VERIFY_WORKSPACE_ID);
+  if (!workspaceId) missing.push('WORKSPACE_ID or RESTORE_VERIFY_WORKSPACE_ID');
+
+  if (missing.length > 0) {
+    throw new Error(`Backup restore verification missing env: ${missing.join(', ')}`);
+  }
+
+  const environment = clean(env.RESTORE_VERIFY_ENVIRONMENT || 'staging').toLowerCase();
+  if (environment === 'production' && env.RESTORE_VERIFY_ALLOW_PRODUCTION !== 'true') {
+    throw new Error(
+      'Backup restore verification refuses production targets by default. Use staging/sandbox data or set RESTORE_VERIFY_ALLOW_PRODUCTION=true for an explicit break-glass run.'
+    );
+  }
+
+  try {
+    const parsed = new URL(clean(env.SUPABASE_URL));
+    if (parsed.protocol !== 'https:' || !parsed.hostname.endsWith('.supabase.co')) {
+      throw new Error('invalid Supabase project URL');
+    }
+  } catch {
+    throw new Error(
+      'Backup restore verification requires SUPABASE_URL to be the Supabase project API URL.'
+    );
+  }
+}
+
+export function buildBackupRestoreVerificationReport({
+  workspaceId,
+  workspaceRow,
+  mediaAssets = [],
+  storageStatusByPath = {},
+  storageChecked = false,
+  bucket = DEFAULT_BUCKET,
+  expectedRecordingIds = [],
+  minCompletedRecordings = 1,
+  restoreEnvironment = 'staging',
+  backupMetadata = {},
+} = {}) {
+  const assets = Array.isArray(mediaAssets) ? mediaAssets : [];
+  const expectedIds = Array.isArray(expectedRecordingIds)
+    ? expectedRecordingIds.map(clean).filter(Boolean)
+    : parseList(expectedRecordingIds);
+  const storageStatus = toStorageStatusMap(storageStatusByPath);
+  const issues = [];
+  const consistencyReport = buildWorkspaceConsistencyReport({
+    workspaceId,
+    workspaceRow,
+    mediaAssets: assets,
+    storageStatusByPath: storageStatus,
+    storageChecked,
+    bucket,
+  });
+
+  issues.push(
+    ...consistencyReport.issues.map((item) => ({
+      ...item,
+      details: { ...(item.details || {}), source: 'workspace-consistency' },
+    }))
+  );
+
+  if (clean(restoreEnvironment).toLowerCase() === 'production') {
+    issues.push(
+      issue(
+        'P0',
+        'restore_verification_targets_production',
+        'Restore verification must run against staging or sandbox data by default.',
+        { workspaceId }
+      )
+    );
+  }
+
+  if (!workspaceRow) {
+    issues.push(
+      issue('P0', 'restore_workspace_missing', 'Restored workspace row is missing.', {
+        workspaceId,
+      })
+    );
+  }
+
+  if (assets.length === 0) {
+    issues.push(
+      issue('P1', 'restore_media_assets_missing', 'Restored workspace has no media assets.', {
+        workspaceId,
+      })
+    );
+  }
+
+  const completedWithTranscript = assets.filter(
+    (asset) =>
+      clean(asset?.transcription_status) === 'completed' && assetTranscriptLength(asset) > 0
+  );
+  const minimum = Number.isFinite(Number(minCompletedRecordings))
+    ? Math.max(0, Number(minCompletedRecordings))
+    : 1;
+  if (completedWithTranscript.length < minimum) {
+    issues.push(
+      issue(
+        'P1',
+        'restore_completed_transcripts_below_threshold',
+        'Restored workspace has fewer completed transcript-bearing recordings than expected.',
+        {
+          workspaceId,
+          expectedAtLeast: minimum,
+          actual: completedWithTranscript.length,
+        }
+      )
+    );
+  }
+
+  const assetsById = new Map(assets.map((asset) => [clean(asset?.id), asset]));
+  for (const recordingId of expectedIds) {
+    const asset = assetsById.get(recordingId);
+    if (!asset) {
+      issues.push(
+        issue(
+          'P0',
+          'restore_expected_recording_missing',
+          'Expected restored recording is missing.',
+          {
+            workspaceId,
+            recordingId,
+          }
+        )
+      );
+      continue;
+    }
+
+    if (assetTranscriptLength(asset) === 0) {
+      issues.push(
+        issue(
+          'P1',
+          'restore_expected_recording_missing_transcript',
+          'Expected restored recording has no transcript metadata.',
+          { workspaceId, recordingId }
+        )
+      );
+    }
+  }
+
+  if (!storageChecked) {
+    issues.push(
+      issue(
+        'P1',
+        'restore_audio_storage_not_checked',
+        'Restore verification did not check Supabase Storage audio availability.',
+        { workspaceId, bucket }
+      )
+    );
+  } else {
+    const assetsToCheck =
+      expectedIds.length > 0 ? expectedIds.map((id) => assetsById.get(id)).filter(Boolean) : assets;
+    for (const asset of assetsToCheck) {
+      const filePath = clean(asset?.file_path);
+      if (!filePath || isLikelyLocalAudioPath(filePath)) continue;
+      const storagePath = normalizeStoragePath(filePath);
+      const status = storageStatus.get(storagePath);
+      if (!status) {
+        issues.push(
+          issue(
+            'P1',
+            'restore_audio_storage_status_missing',
+            'Restore verification did not receive storage status for an audio object.',
+            { workspaceId, recordingId: clean(asset?.id), storagePath }
+          )
+        );
+      } else if (!status.exists) {
+        issues.push(
+          issue(
+            'P0',
+            'restore_audio_object_missing',
+            'Restored media asset points to an unavailable Supabase Storage object.',
+            {
+              workspaceId,
+              recordingId: clean(asset?.id),
+              storagePath,
+              error: status.error || '',
+            }
+          )
+        );
+      }
+    }
+  }
+
+  if (!clean(backupMetadata.backupId || backupMetadata.restoreId)) {
+    issues.push(
+      issue(
+        'P2',
+        'restore_backup_metadata_missing',
+        'Backup or restore identifier was not supplied; keep the manual runbook evidence with this report.',
+        { workspaceId }
+      )
+    );
+  }
+
+  const counts = severityCounts(issues);
+  return {
+    ok: !hasBlockingIssues(issues),
+    workspaceId: clean(workspaceId),
+    restoreEnvironment: clean(restoreEnvironment) || 'staging',
+    bucket,
+    checkedAt: new Date().toISOString(),
+    backupMetadata,
+    summary: {
+      mediaAssetCount: assets.length,
+      expectedRecordingCount: expectedIds.length,
+      completedTranscriptCount: completedWithTranscript.length,
+      storageChecked,
+      severityCounts: counts,
+    },
+    issues,
+  };
+}
+
+function writeReport(report) {
+  const dir = path.join(rootDir, 'reports', 'backup-restore-verification');
+  fs.mkdirSync(dir, { recursive: true });
+  const file = path.join(
+    dir,
+    `${new Date().toISOString().replace(/[:.]/g, '-')}-${report.workspaceId || 'workspace'}.json`
+  );
+  fs.writeFileSync(file, `${JSON.stringify(report, null, 2)}\n`);
+  return file;
+}
+
+export async function runBackupRestoreVerification({
+  env = process.env,
+  workspaceId = readArg('workspace') || env.WORKSPACE_ID || env.RESTORE_VERIFY_WORKSPACE_ID,
+  bucket = readArg('bucket') || env.SUPABASE_STORAGE_BUCKET || DEFAULT_BUCKET,
+  restoreEnvironment = readArg('environment') || env.RESTORE_VERIFY_ENVIRONMENT || 'staging',
+  expectedRecordingIds = parseList(
+    readArg('expected-recordings') || env.RESTORE_VERIFY_EXPECTED_RECORDING_IDS
+  ),
+  minCompletedRecordings = readArg('min-completed-recordings') ||
+    env.RESTORE_VERIFY_MIN_COMPLETED_RECORDINGS ||
+    1,
+  backupMetadata = {
+    backupId: readArg('backup-id') || env.RESTORE_VERIFY_BACKUP_ID || '',
+    restoreId: readArg('restore-id') || env.RESTORE_VERIFY_RESTORE_ID || '',
+  },
+  checkStorage = !process.argv.includes('--skip-storage'),
+  writeReportFile = process.argv.includes('--write-report') || env.CI === 'true',
+  fetchInputs,
+  createClientFactory,
+} = {}) {
+  validateBackupRestoreVerifierEnv({
+    ...env,
+    WORKSPACE_ID: workspaceId,
+    RESTORE_VERIFY_ENVIRONMENT: restoreEnvironment,
+  });
+
+  let inputs;
+  if (typeof fetchInputs === 'function') {
+    inputs = await fetchInputs({
+      workspaceId: clean(workspaceId),
+      bucket,
+      checkStorage,
+    });
+  } else {
+    const createClient =
+      createClientFactory || (await import('@supabase/supabase-js')).createClient;
+    const supabase = createClient(clean(env.SUPABASE_URL), clean(env.SUPABASE_SERVICE_ROLE_KEY), {
+      auth: { autoRefreshToken: false, persistSession: false },
+    });
+    inputs = await fetchWorkspaceConsistencyInputs({
+      supabase,
+      workspaceId: clean(workspaceId),
+      bucket,
+      checkStorage,
+    });
+  }
+
+  const report = buildBackupRestoreVerificationReport({
+    workspaceId: clean(workspaceId),
+    bucket,
+    restoreEnvironment,
+    expectedRecordingIds,
+    minCompletedRecordings,
+    backupMetadata,
+    ...inputs,
+  });
+  const reportPath = writeReportFile ? writeReport(report) : '';
+
+  return {
+    ...report,
+    reportPath,
+  };
+}
+
+const entrypointPath = process.argv[1] ? path.resolve(process.argv[1]) : null;
+const isMainModule = entrypointPath === path.resolve(rootDir, 'scripts/verify-backup-restore.mjs');
+
+if (isMainModule) {
+  runBackupRestoreVerification()
+    .then((report) => {
+      console.log(JSON.stringify(report, null, 2));
+      if (!report.ok) {
+        process.exitCode = 1;
+      }
+    })
+    .catch((error) => {
+      console.error(error.message);
+      process.exitCode = 1;
+    });
+}

--- a/scripts/verify-backup-restore.test.ts
+++ b/scripts/verify-backup-restore.test.ts
@@ -1,0 +1,175 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  buildBackupRestoreVerificationReport,
+  runBackupRestoreVerification,
+  validateBackupRestoreVerifierEnv,
+} from './verify-backup-restore.mjs';
+
+const validEnv = {
+  SUPABASE_URL: 'https://project.supabase.co',
+  SUPABASE_SERVICE_ROLE_KEY: 'service-role',
+  RESTORE_VERIFY_WORKSPACE_ID: 'workspace_restore',
+  RESTORE_VERIFY_ENVIRONMENT: 'staging',
+};
+
+describe('backup restore verifier', () => {
+  it('reports a healthy staging restore with transcript metadata and audio availability', () => {
+    const report = buildBackupRestoreVerificationReport({
+      workspaceId: 'workspace_restore',
+      restoreEnvironment: 'staging',
+      storageChecked: true,
+      expectedRecordingIds: ['recording_restore_1'],
+      backupMetadata: { backupId: 'backup-2026-07-04' },
+      storageStatusByPath: {
+        'recording_restore_1.webm': { exists: true },
+      },
+      workspaceRow: {
+        workspace_id: 'workspace_restore',
+        calendar_meta_json: '{}',
+        meetings_json: JSON.stringify([
+          {
+            id: 'meeting_restore_1',
+            latestRecordingId: 'recording_restore_1',
+            recordings: [
+              {
+                id: 'recording_restore_1',
+                transcript: [{ text: 'Restored transcript visible in workspace state' }],
+              },
+            ],
+          },
+        ]),
+      },
+      mediaAssets: [
+        {
+          id: 'recording_restore_1',
+          workspace_id: 'workspace_restore',
+          meeting_id: 'meeting_restore_1',
+          file_path: 'recording_restore_1.webm',
+          transcription_status: 'completed',
+          transcript_json: JSON.stringify([{ text: 'Restored transcript visible in media asset' }]),
+        },
+      ],
+    });
+
+    expect(report.ok).toBe(true);
+    expect(report.summary).toMatchObject({
+      mediaAssetCount: 1,
+      expectedRecordingCount: 1,
+      completedTranscriptCount: 1,
+      storageChecked: true,
+    });
+    expect(report.issues).toEqual([]);
+  });
+
+  it('detects missing expected recordings, transcript metadata, and audio objects', () => {
+    const report = buildBackupRestoreVerificationReport({
+      workspaceId: 'workspace_restore',
+      restoreEnvironment: 'staging',
+      storageChecked: true,
+      expectedRecordingIds: ['recording_restore_1', 'recording_restore_missing'],
+      backupMetadata: { restoreId: 'restore-drill-1' },
+      storageStatusByPath: {
+        'recording_restore_1.webm': { exists: false, error: 'Object not found' },
+      },
+      workspaceRow: {
+        workspace_id: 'workspace_restore',
+        calendar_meta_json: '{}',
+        meetings_json: JSON.stringify([
+          {
+            id: 'meeting_restore_1',
+            latestRecordingId: 'recording_restore_1',
+            recordings: [{ id: 'recording_restore_1', transcript: [] }],
+          },
+        ]),
+      },
+      mediaAssets: [
+        {
+          id: 'recording_restore_1',
+          workspace_id: 'workspace_restore',
+          meeting_id: 'meeting_restore_1',
+          file_path: 'recording_restore_1.webm',
+          transcription_status: 'completed',
+          transcript_json: '[]',
+        },
+      ],
+    });
+
+    expect(report.ok).toBe(false);
+    expect(report.issues).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ code: 'restore_expected_recording_missing', severity: 'P0' }),
+        expect.objectContaining({
+          code: 'restore_expected_recording_missing_transcript',
+          severity: 'P1',
+        }),
+        expect.objectContaining({ code: 'restore_audio_object_missing', severity: 'P0' }),
+      ])
+    );
+  });
+
+  it('rejects missing configuration and production targets unless break-glass is explicit', () => {
+    expect(() => validateBackupRestoreVerifierEnv({})).toThrow(
+      'SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY'
+    );
+    expect(() =>
+      validateBackupRestoreVerifierEnv({
+        ...validEnv,
+        RESTORE_VERIFY_ENVIRONMENT: 'production',
+      })
+    ).toThrow('refuses production targets');
+    expect(() =>
+      validateBackupRestoreVerifierEnv({
+        ...validEnv,
+        RESTORE_VERIFY_ENVIRONMENT: 'production',
+        RESTORE_VERIFY_ALLOW_PRODUCTION: 'true',
+      })
+    ).not.toThrow();
+  });
+
+  it('runs against mocked restored DB and storage inputs without touching production', async () => {
+    const fetchInputs = vi.fn().mockResolvedValue({
+      storageChecked: true,
+      storageStatusByPath: {
+        'recording_restore_1.webm': { exists: true },
+      },
+      workspaceRow: {
+        workspace_id: 'workspace_restore',
+        calendar_meta_json: '{}',
+        meetings_json: JSON.stringify([
+          {
+            id: 'meeting_restore_1',
+            latestRecordingId: 'recording_restore_1',
+            recordings: [{ id: 'recording_restore_1', transcript: [{ text: 'ok' }] }],
+          },
+        ]),
+      },
+      mediaAssets: [
+        {
+          id: 'recording_restore_1',
+          workspace_id: 'workspace_restore',
+          meeting_id: 'meeting_restore_1',
+          file_path: 'recording_restore_1.webm',
+          transcription_status: 'completed',
+          transcript_json: JSON.stringify([{ text: 'ok' }]),
+        },
+      ],
+    });
+
+    const report = await runBackupRestoreVerification({
+      env: validEnv,
+      workspaceId: 'workspace_restore',
+      expectedRecordingIds: ['recording_restore_1'],
+      backupMetadata: { backupId: 'backup-2026-07-04' },
+      fetchInputs,
+      writeReportFile: false,
+    });
+
+    expect(report.ok).toBe(true);
+    expect(fetchInputs).toHaveBeenCalledWith({
+      workspaceId: 'workspace_restore',
+      bucket: 'recordings',
+      checkStorage: true,
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- adds a backup and restore runbook for PostgreSQL/Supabase Storage, configuration, and deployment metadata
- adds a staging-safe verification script with machine-readable results
- adds a manually dispatched backup/restore verification workflow
- adds fixture-based regression tests for verification outcomes

## Dependency
This PR is intentionally based on #1480 because it updates the shared Railway workflow URL contract. Merge #1480 first; this PR will then be retargeted to `main` if GitHub does not do so automatically.

## Validation
- `pnpm exec vitest run -c vitest.scripts.config.ts scripts/verify-backup-restore.test.ts scripts/validate-github-workflows.test.ts --coverage.enabled=false --reporter=dot` — 32 passed
- `node scripts/validate-github-workflows.mjs`
- `node --check scripts/verify-backup-restore.mjs`
- `git diff --check codex/issue-1453-railway-health-url...HEAD`

## Risk and rollback
The workflow is manual and verification-only; it does not restore or alter production data. Revert this PR to remove the operator entry point and documentation.

Closes #1247