### PR TITLE
[#1248] Add scheduled workspace consistency and retention maintenance jobs

### DIFF
--- a/.github/workflows/workspace-maintenance-report.yml
+++ b/.github/workflows/workspace-maintenance-report.yml
@@ -1,0 +1,89 @@
+name: Workspace Maintenance Report
+
+on:
+  schedule:
+    - cron: '23 3 * * 2'
+  workflow_dispatch:
+    inputs:
+      apply:
+        description: 'Apply the workspace consistency repair. Keep false for dry-run.'
+        required: true
+        default: 'false'
+        type: choice
+        options:
+          - 'false'
+          - 'true'
+      workspace_id:
+        description: 'Optional workspace id override. Empty uses PRODUCTION_SMOKE_WORKSPACE_ID.'
+        required: false
+        default: ''
+
+concurrency:
+  group: workspace-maintenance-report
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    env:
+      SUPABASE_URL: ${{ secrets.SUPABASE_URL }}
+      SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+      PRODUCTION_SMOKE_WORKSPACE_ID: ${{ secrets.PRODUCTION_SMOKE_WORKSPACE_ID }}
+      WORKSPACE_ID: ${{ github.event.inputs.workspace_id }}
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 22
+
+      - run: corepack enable
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate maintenance configuration
+        id: config
+        shell: bash
+        run: |
+          missing=()
+          for secret in SUPABASE_URL SUPABASE_SERVICE_ROLE_KEY; do
+            [[ -n "${!secret}" ]] || missing+=("${secret}")
+          done
+          if [[ -z "${WORKSPACE_ID}" && -z "${PRODUCTION_SMOKE_WORKSPACE_ID}" ]]; then
+            missing+=("WORKSPACE_ID or PRODUCTION_SMOKE_WORKSPACE_ID")
+          fi
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "## Workspace maintenance skipped" >> "$GITHUB_STEP_SUMMARY"
+            printf '%s\n' "${missing[@]}" | sed 's/^/- Missing: /' >> "$GITHUB_STEP_SUMMARY"
+            echo "ready=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          echo "ready=true" >> "$GITHUB_OUTPUT"
+
+      - name: Build dry-run maintenance report
+        if: ${{ steps.config.outputs.ready == 'true' && github.event.inputs.apply != 'true' }}
+        run: pnpm run repair:supabase:workspace -- --write-report
+
+      - name: Apply approved workspace repair
+        if: ${{ steps.config.outputs.ready == 'true' && github.event.inputs.apply == 'true' }}
+        run: pnpm run repair:supabase:workspace -- --apply --write-report
+
+      - name: Verify workspace consistency
+        if: ${{ steps.config.outputs.ready == 'true' }}
+        run: pnpm run verify:supabase:workspace
+
+      - name: Upload workspace maintenance reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: workspace-maintenance-reports
+          path: |
+            reports/supabase-workspace-repair/
+            reports/supabase-workspace-consistency/
+          if-no-files-found: ignore

--- a/scripts/validate-github-workflows.test.ts
+++ b/scripts/validate-github-workflows.test.ts
@@ -299,6 +299,21 @@ describe('GitHub workflows validation', () => {
     );
   });
 
+  it('keeps scheduled workspace maintenance dry-run by default with an explicit apply gate', () => {
+    const workflowPath = path.join(workflowDir, 'workspace-maintenance-report.yml');
+    const content = readFileSync(workflowPath, 'utf8');
+
+    expect(content).toContain('name: Workspace Maintenance Report');
+    expect(content).toContain('workflow_dispatch:');
+    expect(content).toContain("default: 'false'");
+    expect(content).toContain("github.event.inputs.apply == 'true'");
+    expect(content).toContain('pnpm run repair:supabase:workspace -- --apply');
+    expect(content).toContain('pnpm run repair:supabase:workspace -- --write-report');
+    expect(content).toContain('pnpm run verify:supabase:workspace');
+    expect(content).toContain('reports/supabase-workspace-repair/');
+    expect(content).toContain('reports/supabase-workspace-consistency/');
+  });
+
   it('keeps backend smoke dependency setup resilient and debugs only smoke failures', () => {
     const workflowPath = path.join(workflowDir, 'backend-production-smoke.yml');
     const content = readFileSync(workflowPath, 'utf8');


### PR DESCRIPTION
## Summary
- adds a separate scheduled workspace-maintenance reporting workflow
- keeps scheduled execution dry-run only
- requires explicit manual `apply=true` before any repair mutation
- uploads workspace-repair and consistency artifacts for operator review
- skips safely when production maintenance secrets are not configured

## Validation
- RED: workflow contract test failed before the workflow existed
- `pnpm exec vitest run -c vitest.scripts.config.ts scripts/validate-github-workflows.test.ts --coverage.enabled=false --reporter=dot` — 30 passed
- `node scripts/validate-github-workflows.mjs`
- `git diff --check`

## Risk and rollback
Scheduled runs do not mutate data. Apply remains manual and explicit. Revert this PR to remove the schedule and its reporting entry point.

Closes #1248