### PR TITLE
fix(auth): prevent PostgreSQL registration transaction abort

### DIFF
--- a/server/database.ts
+++ b/server/database.ts
@@ -1277,40 +1277,6 @@ export class Database {
   }
 
   async ensureWorkspaceState(workspaceId: string, executor: QueryExecutor = this): Promise<void> {
-    try {
-      await executor._execute(
-        "ALTER TABLE workspace_state ADD COLUMN manual_people_json TEXT NOT NULL DEFAULT '[]'"
-      );
-    } catch (error) {
-      if (
-        !isAddColumnAlreadyAppliedMigrationError('ALTER TABLE workspace_state ADD COLUMN', error)
-      ) {
-        throw error;
-      }
-    }
-    try {
-      await executor._execute(
-        `ALTER TABLE workspace_state ADD COLUMN retention_days INTEGER NOT NULL DEFAULT ${DEFAULT_RETENTION_DAYS}`
-      );
-    } catch (error) {
-      if (
-        !isAddColumnAlreadyAppliedMigrationError('ALTER TABLE workspace_state ADD COLUMN', error)
-      ) {
-        throw error;
-      }
-    }
-    try {
-      await this._execute(
-        "ALTER TABLE workspace_state ADD COLUMN feature_flags_json TEXT NOT NULL DEFAULT '{}'"
-      );
-    } catch (error) {
-      if (
-        !isAddColumnAlreadyAppliedMigrationError('ALTER TABLE workspace_state ADD COLUMN', error)
-      ) {
-        throw error;
-      }
-    }
-
     const existing = await executor._get(
       'SELECT workspace_id FROM workspace_state WHERE workspace_id = ?',
       [workspaceId]

--- a/server/migrations/20260716_workspace_state_manual_people.sql
+++ b/server/migrations/20260716_workspace_state_manual_people.sql
@@ -1,0 +1,1 @@
+ALTER TABLE workspace_state ADD COLUMN manual_people_json TEXT NOT NULL DEFAULT '[]';

--- a/server/tests/database/migration-contract.test.ts
+++ b/server/tests/database/migration-contract.test.ts
@@ -35,6 +35,8 @@ const retentionHoldIndexes = [
   'idx_recording_retention_holds_active',
 ] as const;
 
+const manualPeopleMigration = '20260716_workspace_state_manual_people.sql';
+
 function readMigration(fileName: string) {
   return fs.readFileSync(path.join(migrationsDir, fileName), 'utf8');
 }
@@ -160,5 +162,12 @@ describe('Database migration contracts', () => {
     expect(migration).toContain('alter table workspace_state');
     expect(migration).toContain('add column feature_flags_json text not null default');
     expect(initialSchema).toContain('feature_flags_json text not null default');
+  });
+
+  test('Issue #1506 - manual people state is migrated before registration transactions', () => {
+    const migration = readMigration(manualPeopleMigration).replace(/\s+/g, ' ').toLowerCase();
+
+    expect(migration).toContain('alter table workspace_state');
+    expect(migration).toContain("add column manual_people_json text not null default '[]'");
   });
 });

--- a/server/tests/lib/auth-registration-postgres-migration.test.ts
+++ b/server/tests/lib/auth-registration-postgres-migration.test.ts
@@ -1,0 +1,84 @@
+import path from 'node:path';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+// ─────────────────────────────────────────────────────────────────
+// Issue #1506 - registration aborts after workspace-state schema mutation
+// Date: 2026-07-16
+// Bug: a duplicate ADD COLUMN inside the registration transaction leaves PostgreSQL aborted.
+// Fix: workspace-state migrations run before registration; the transaction only writes data.
+// ─────────────────────────────────────────────────────────────────
+describe('Regression: Issue #1506 - PostgreSQL registration transaction', () => {
+  afterEach(() => {
+    vi.resetModules();
+    vi.doUnmock('pg');
+  });
+
+  test('registers a user without running schema mutations in the transaction', async () => {
+    const realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+    const realOs = await vi.importActual<typeof import('node:os')>('node:os');
+    const uploadDir = realFs.mkdtempSync(path.join(realOs.tmpdir(), 'voicelog-register-pg-'));
+    const clientQueries: Array<{ sql: string; params?: unknown[] }> = [];
+    let transactionAborted = false;
+
+    const client = {
+      query: vi.fn(async (sql: string, params?: unknown[]) => {
+        clientQueries.push({ sql, params });
+
+        if (transactionAborted && sql !== 'ROLLBACK') {
+          throw new Error(
+            'current transaction is aborted, commands ignored until end of transaction block'
+          );
+        }
+
+        if (/ALTER TABLE workspace_state ADD COLUMN retention_days/i.test(sql)) {
+          transactionAborted = true;
+          throw new Error('column "retention_days" of relation "workspace_state" already exists');
+        }
+
+        return { rows: [] };
+      }),
+      release: vi.fn(),
+    };
+    const pool = {
+      query: vi.fn(async () => ({ rows: [] })),
+      connect: vi.fn(async () => client),
+      end: vi.fn(),
+    };
+
+    const PoolMock = vi.fn(function Pool() {
+      return pool;
+    });
+    vi.doMock('pg', () => ({ Pool: PoolMock }));
+
+    const { initDatabase } = await import('../../database.ts');
+    const db = initDatabase({ connectionString: 'postgres://unit-test', uploadDir }) as any;
+    db.createSession = vi.fn(async () => ({
+      token: 'token',
+      expiresAt: '2026-07-16T00:00:00.000Z',
+    }));
+    db.buildSessionPayload = vi.fn(async (userId: string, workspaceId: string) => ({
+      user: { id: userId, email: 'new@example.test', name: 'New User' },
+      users: [],
+      workspaces: [{ id: workspaceId, name: 'Workspace' }],
+      workspaceId,
+      state: {},
+    }));
+
+    try {
+      const result = await db.registerUser({
+        email: 'new@example.test',
+        password: 'password123',
+        name: 'New User',
+        workspaceName: 'Workspace',
+        workspaceMode: 'create',
+      });
+
+      expect(result.workspaceId).toMatch(/^workspace_/);
+      expect(clientQueries.map((entry) => entry.sql)).toContain('COMMIT');
+      expect(clientQueries.some((entry) => /ALTER TABLE/i.test(entry.sql))).toBe(false);
+    } finally {
+      await db.shutdown();
+      realFs.rmSync(uploadDir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Fixes a production registration failure in PostgreSQL.

`ensureWorkspaceState()` previously ran `ALTER TABLE ... ADD COLUMN` inside the user-registration transaction. PostgreSQL preserves the duplicate-column error as transaction state, so subsequent workspace-state writes failed with SQLSTATE `25P02` and `/auth/register` returned 500.

The schema change for `manual_people_json` now runs as a numbered startup migration. Registration transactions only create user, workspace, membership, and workspace state records.

## Linked issue
Closes #1506

Production evidence: #1505

## Change Type

- [x] Fix
- [x] Test
- [x] Production readiness

## Verification

- [x] Regression was RED before the fix: simulated duplicate column caused `current transaction is aborted`.
- [x] Focused backend suite: 41 passed.
- [x] `pnpm run typecheck:server`
- [x] `pnpm run lint:all`
- [x] `pnpm run audit:mojibake`
- [x] `pnpm run test:release:guard` under the pre-push Node 22 toolchain:
  - server: 1,473 passed, 82 skipped
  - critical frontend/hook checks: 83 passed
  - production build-warning audit passed

## Regression Evidence

`server/tests/lib/auth-registration-postgres-migration.test.ts` simulates PostgreSQL receiving a duplicate `ADD COLUMN` in a transaction. The test proves that registration commits and emits no schema mutation after the fix.

## Risk Notes

The migration is additive and uses the existing duplicate-column handling for databases where the column was created by the historical runtime path. No auth payload or queue behavior changes.

## Rollback notes

If rollback is required, revert the application commit but leave `manual_people_json` in place. Do not drop the column: it may already contain workspace data, and the repository's migration policy is forward-fix rather than destructive rollback.