### PR TITLE
fix(capabilities): report workspace storage readiness

### DIFF
--- a/server/http/capabilities.ts
+++ b/server/http/capabilities.ts
@@ -325,7 +325,7 @@ export function resolveProductionCapabilities(
   };
 }
 
-async function defaultStorageReadiness() {
+export async function resolveStorageReadiness() {
   if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE_KEY) {
     return DEFAULT_STORAGE_READINESS;
   }
@@ -343,7 +343,7 @@ async function defaultStorageReadiness() {
 
 export function registerCapabilitiesRoute(app: Hono<any>, options: RegisterOptions = {}) {
   app.get('/api/capabilities', async (c) => {
-    const storageReadiness = await (options.resolveStorageReadiness || defaultStorageReadiness)();
+    const storageReadiness = await (options.resolveStorageReadiness || resolveStorageReadiness)();
     const payload = resolveProductionCapabilities({ storageReadiness });
 
     for (const capabilityId of payload.telemetry.fallbackModeCapabilities) {

--- a/server/routes/workspaces.ts
+++ b/server/routes/workspaces.ts
@@ -6,7 +6,7 @@ import { AppServices, AppMiddlewares } from './middleware.ts';
 import { applyWorkspaceStateDelta, normalizeWorkspaceState } from '../../src/shared/contracts.ts';
 import { workspaceMembershipCan } from '../../src/shared/workspacePermissions.ts';
 import type { VoiceProfileSummary, VoiceProfilesListPayload } from '../../src/shared/types.ts';
-import { resolveProductionCapabilities } from '../http/capabilities.ts';
+import { resolveProductionCapabilities, resolveStorageReadiness } from '../http/capabilities.ts';
 import { buildFallbackRagAnswer, generateRagAnswer } from '../lib/ragAnswer.ts';
 import {
   createVoiceProfileEmbeddingFailure,
@@ -236,10 +236,14 @@ export function createWorkspacesRoutes(services: AppServices, middlewares: AppMi
   router.get('/workspaces/:workspaceId/capabilities', async (c) => {
     const workspaceId = c.req.param('workspaceId');
     await ensureWorkspaceAccess(c, workspaceId);
-    const state = await workspaceService.getWorkspaceState(workspaceId);
+    const [state, storageReadiness] = await Promise.all([
+      workspaceService.getWorkspaceState(workspaceId),
+      resolveStorageReadiness(),
+    ]);
     return c.json(
       resolveProductionCapabilities({
         workspaceFeatureFlags: state.featureFlags,
+        storageReadiness,
       }),
       200
     );

--- a/server/tests/regression/regression.test.ts
+++ b/server/tests/regression/regression.test.ts
@@ -141,6 +141,88 @@ describe('Regression: Issue #341 - supabaseStorage null handling', () => {
   });
 });
 
+// ─────────────────────────────────────────────────────────────────
+// Issue #0 — workspace capabilities report healthy audio storage as unavailable
+// Date: 2026-07-17
+// Bug: The authenticated workspace capabilities route skipped the Supabase
+//      readiness probe and always used the unavailable default.
+// Fix: Resolve the same storage readiness used by /api/capabilities.
+// ─────────────────────────────────────────────────────────────────
+describe('Regression: Issue #0 — workspace capabilities preserve storage readiness', () => {
+  const originalSupabaseUrl = process.env.SUPABASE_URL;
+  const originalSupabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  afterEach(() => {
+    if (originalSupabaseUrl === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = originalSupabaseUrl;
+    if (originalSupabaseServiceRoleKey === undefined) {
+      delete process.env.SUPABASE_SERVICE_ROLE_KEY;
+    } else {
+      process.env.SUPABASE_SERVICE_ROLE_KEY = originalSupabaseServiceRoleKey;
+    }
+    vi.doUnmock('../../lib/supabaseStorage.ts');
+    vi.resetModules();
+  });
+
+  test('does not show Supabase Storage as degraded when the production bucket is ready', async () => {
+    process.env.SUPABASE_URL = 'https://project.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'test-service-role-key';
+    const checkSupabaseStorageReadiness = vi.fn().mockResolvedValue({
+      configured: true,
+      ready: true,
+      bucket: 'recordings',
+      status: 'ready',
+    });
+    vi.doMock('../../lib/supabaseStorage.ts', () => ({ checkSupabaseStorageReadiness }));
+
+    const { createWorkspacesRoutes } = await import('../../routes/workspaces.ts');
+    const router = createWorkspacesRoutes(
+      {
+        authService: {},
+        workspaceService: {
+          getWorkspaceState: vi.fn().mockResolvedValue({
+            featureFlags: {
+              sttProvider: 'auto',
+              diarization: true,
+              meetingAnalysis: true,
+              embeddings: true,
+              imageGeneration: true,
+              liveTranscription: true,
+              retentionFeatures: true,
+              experimentalUi: false,
+            },
+          }),
+        },
+        transcriptionService: {},
+        db: {},
+        config: {},
+      },
+      {
+        authMiddleware: async (c: any, next: any) => {
+          c.set('session', { user_id: 'user-1', workspace_id: 'workspace-1' });
+          await next();
+        },
+        ensureWorkspaceAccess: vi.fn().mockResolvedValue({ member_role: 'owner' }),
+        applyRateLimit: () => async (_c: any, next: any) => next(),
+      } as any
+    );
+
+    const response = await router.request('/workspaces/workspace-1/capabilities');
+    const payload = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(checkSupabaseStorageReadiness).toHaveBeenCalledTimes(1);
+    expect(payload.capabilities.supabaseStorage).toMatchObject({
+      enabled: true,
+      status: 'available',
+      provider: 'supabase-storage',
+    });
+    expect(payload.degradedCapabilities).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ id: 'supabaseStorage' })])
+    );
+  });
+});
+
 // ─────────────────────────────────────────────────────────────────────────────
 // Issue #456 - Recording ID sanitization breaks with unicode characters
 // Date: 2026-03-28


### PR DESCRIPTION
## What changed

- reuse the production Supabase Storage readiness probe for authenticated workspace capabilities
- keep the global and workspace capability responses consistent
- add a regression test for healthy storage being reported as unavailable

## Root cause

`GET /workspaces/:workspaceId/capabilities` called `resolveProductionCapabilities()` without `storageReadiness`. The resolver therefore used its unavailable default even when the production `recordings` bucket was healthy. Logged-in users saw a false `Magazyn audio` warning while uploads used the correctly configured storage backend.

## Validation

- RED: regression test failed because the storage readiness probe was called 0 times
- GREEN: targeted routes/regression suite: 88 passed, 1 skipped
- server typecheck: passed
- full backend suite: 1472 passed, 82 skipped
- Prettier and `git diff --check`: passed

## Residual production state

The production backend currently reports Supabase Storage as ready. Diarization and provider-backed meeting analysis remain independently degraded because their provider configuration is missing; this PR does not hide those real warnings.
