### PR TITLE
fix(deps): override vulnerable adm-zip

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,6 +272,7 @@
     "overrides": {
       "@babel/plugin-transform-modules-systemjs": "7.29.4",
       "@protobufjs/utf8": "1.1.1",
+      "adm-zip": "0.6.0",
       "axios": "1.16.1",
       "brace-expansion": "1.1.14",
       "express-rate-limit": "8.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   '@babel/plugin-transform-modules-systemjs': 7.29.4
   '@protobufjs/utf8': 1.1.1
+  adm-zip: 0.6.0
   axios: 1.16.1
   brace-expansion: 1.1.14
   express-rate-limit: 8.5.1
@@ -3676,9 +3677,9 @@ packages:
   add-stream@1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
 
-  adm-zip@0.5.16:
-    resolution: {integrity: sha512-TGw5yVi4saajsSEgz25grObGHEUaDrniwvA2qwSC060KfqGPdglhvPMA2lPIoxs3PQIItj2iag35fONcQqgUaQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@6.0.2:
     resolution: {integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==}
@@ -11963,7 +11964,7 @@ snapshots:
 
   add-stream@1.0.0: {}
 
-  adm-zip@0.5.16: {}
+  adm-zip@0.6.0: {}
 
   agent-base@6.0.2:
     dependencies:
@@ -15218,7 +15219,7 @@ snapshots:
 
   onnxruntime-node@1.27.0:
     dependencies:
-      adm-zip: 0.5.16
+      adm-zip: 0.6.0
       global-agent: 4.1.3
       onnxruntime-common: 1.27.0
 


### PR DESCRIPTION
## What changed

- override transitive `adm-zip` from vulnerable `0.5.16` to patched `0.6.0`
- update the pnpm lockfile without unrelated dependency changes

## Why

The post-merge `Security Audit` detected GHSA-xcpc-8h2w-3j85 (`adm-zip`: crafted ZIP can trigger a 4 GB memory allocation). The failure skipped the Railway and Vercel production workflows for the workspace storage-readiness fix.

## Security review

- trust boundary: ZIP parsing inside the transitive `onnxruntime-node` dependency
- vulnerable range: `<0.6.0`
- resolved path: `onnxruntime-node@1.27.0 -> adm-zip@0.6.0`
- no secrets, auth rules, RLS policies, or application data flows changed

## Validation

- RED: `pnpm audit --audit-level=high` reported `high=1`
- GREEN: audit reports 0 high/critical (1 low, 2 moderate remain)
- `onnxruntime-node` import smoke passed
- full frozen-lockfile install passed, including ONNX postinstall
- `pnpm run test:release:guard` passed on Node 24 and the pre-push Node 22 toolchain
- backend: 1474 passed, 82 skipped
- critical frontend/workflow tests: 83 passed
- production build warning audit passed
