### PR TITLE
fix(auth): clear active session after unauthorized response

### DIFF
--- a/src/context/WorkspaceContext.test.tsx
+++ b/src/context/WorkspaceContext.test.tsx
@@ -5,7 +5,7 @@
  * Tests for WorkspaceContext provider and hook
  */
 
-import { renderHook, render, screen } from '@testing-library/react';
+import { act, renderHook, render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 import { WorkspaceProvider, useWorkspaceCtx } from './WorkspaceContext';
@@ -39,11 +39,17 @@ const mockWorkspaceSelectors = vi.hoisted(() => ({
   useWorkspaceStore: () => mockWorkspaceStore,
 }));
 
+const httpClientMocks = vi.hoisted(() => ({
+  onUnauthorized: vi.fn(),
+}));
+
 vi.mock('../store/workspaceStore', () => mockWorkspaceSelectors);
+vi.mock('../services/httpClient', () => httpClientMocks);
 
 describe('WorkspaceContext', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    httpClientMocks.onUnauthorized.mockReturnValue(vi.fn());
   });
 
   afterEach(() => {
@@ -255,6 +261,33 @@ describe('WorkspaceContext', () => {
       result.current.workspace.logout();
 
       expect(mockWorkspaceStore.logout).toHaveBeenCalled();
+    });
+
+    it('logs out the active Zustand session when an API request returns 401', () => {
+      let handleUnauthorized: (() => void) | undefined;
+      const unsubscribe = vi.fn();
+      httpClientMocks.onUnauthorized.mockImplementation((handler: () => void) => {
+        handleUnauthorized = handler;
+        return unsubscribe;
+      });
+
+      const { unmount } = render(
+        <WorkspaceProvider>
+          <div>Child</div>
+        </WorkspaceProvider>
+      );
+
+      expect(httpClientMocks.onUnauthorized).toHaveBeenCalledOnce();
+
+      act(() => {
+        handleUnauthorized?.();
+      });
+
+      expect(mockWorkspaceStore.logout).toHaveBeenCalledOnce();
+
+      unmount();
+
+      expect(unsubscribe).toHaveBeenCalledOnce();
     });
   });
 

--- a/src/context/WorkspaceContext.tsx
+++ b/src/context/WorkspaceContext.tsx
@@ -1,5 +1,6 @@
-import { createContext, useContext } from 'react';
+import { createContext, useContext, useEffect } from 'react';
 import { useWorkspaceSelectors, useWorkspaceStore } from '../store/workspaceStore';
+import { onUnauthorized } from '../services/httpClient';
 
 const defaultWorkspaceCtx = {
   workspace: {
@@ -30,6 +31,14 @@ const WorkspaceContext = createContext(defaultWorkspaceCtx);
 export function WorkspaceProvider({ children }) {
   const selectors = useWorkspaceSelectors();
   const workspaceStore = useWorkspaceStore();
+  const { logout } = workspaceStore;
+
+  useEffect(() => {
+    const unsubscribe = onUnauthorized(logout);
+    return () => {
+      unsubscribe();
+    };
+  }, [logout]);
 
   const value = {
     workspace: {


### PR DESCRIPTION
## Summary
- clear the active workspace session when the HTTP client receives 401
- unsubscribe the unauthorized handler when WorkspaceProvider unmounts
- preserve the regression test for the exact 401 flow

## Validation
- pnpm exec vitest run src/context/WorkspaceContext.test.tsx --coverage.enabled=false (27 passed)
- pnpm run test:release:guard (passed: 1474 backend tests, 83 critical frontend/workflow tests, production build audit)

## Notes
- rebased by cherry-picking the verified local commit onto origin/main f62153b
- local attachment and Playwright directories are untracked and excluded