### PR TITLE
fix(database): require postgres in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,8 +40,11 @@ VOICELOG_ALLOW_VERCEL_PREVIEWS=false
 # Database
 # ─────────────────────────────────────────────────────────────────────────────
 # Use one of these options:
-# Option 1: External PostgreSQL (production)
-# VOICELOG_DATABASE_URL=postgresql://user:password@localhost:5432/voicelog
+# Option 1: External PostgreSQL (required in production/Railway)
+# Direct Supabase host: db.<project-ref>.supabase.co:5432
+# Pooler host: aws-<region>.pooler.supabase.com:6543
+# VOICELOG_DATABASE_URL=postgresql://user:password@db.<project-ref>.supabase.co:5432/postgres
+# Never use an incomplete host such as postgres.<project-ref>.
 # Option 2: Local SQLite (development)
 VOICELOG_DB_PATH=./server/data/voicelog.sqlite
 

--- a/scripts/validate-env.js
+++ b/scripts/validate-env.js
@@ -160,7 +160,7 @@ function evaluateDatabaseUrl(value, productionDeployment) {
     'Postgres database URL',
     value,
     /^postgres(ql)?:\/\//,
-    'warning'
+    productionDeployment ? 'error' : 'warning'
   );
 
   if (baseCheck.status !== STATUS_OK || !value) {

--- a/scripts/validate-env.test.ts
+++ b/scripts/validate-env.test.ts
@@ -66,6 +66,29 @@ describe('Regression: Issue #0 - validate-env should not fail on optional integr
     expect(report.errors.map((entry) => entry.name)).not.toContain('STT_PROVIDER');
   });
 
+  // ----------------------------------------------------------------
+  // Issue #1510 — production PostgreSQL is mandatory
+  // Date: 2026-07-21
+  // Bug: the standalone configuration validator only warned when the
+  //      production database URL was missing.
+  // Fix: missing production PostgreSQL configuration is a blocking error.
+  // ----------------------------------------------------------------
+  it('blocks production when PostgreSQL configuration is missing', () => {
+    const report = validateEnvironmentSnapshot(
+      createBaseEnv({
+        NODE_ENV: 'production',
+        VOICELOG_ALLOWED_ORIGINS: 'https://voicelog.example.com',
+        SUPABASE_URL: 'https://project-ref.supabase.co',
+        SUPABASE_SERVICE_ROLE_KEY: 'sb_secret_test_key',
+        DATABASE_URL: undefined,
+        VOICELOG_DATABASE_URL: undefined,
+      })
+    );
+
+    expect(report.blocking).toBe(true);
+    expect(report.errors.map((entry) => entry.name)).toContain('DATABASE_URL');
+  });
+
   it('accepts the default GitHub Actions token format', () => {
     const report = validateEnvironmentSnapshot(
       createBaseEnv({
@@ -120,6 +143,7 @@ describe('Regression: Issue #0 - validate-env should not fail on optional integr
         VOICELOG_ALLOWED_ORIGINS: 'https://voicelog.example.com',
         SUPABASE_URL: 'https://test.supabase.co',
         SUPABASE_SERVICE_ROLE_KEY: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.test',
+        DATABASE_URL: 'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres',
       })
     );
 
@@ -153,6 +177,7 @@ describe('Regression: Issue #0 - validate-env should not fail on optional integr
         VOICELOG_ALLOW_VERCEL_PREVIEWS: 'true',
         SUPABASE_URL: 'https://test.supabase.co',
         SUPABASE_SERVICE_ROLE_KEY: 'sb_secret_test_key',
+        DATABASE_URL: 'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres',
       })
     );
 
@@ -167,6 +192,7 @@ describe('Regression: Issue #0 - validate-env should not fail on optional integr
         VOICELOG_ALLOWED_ORIGINS: 'https://voicelog.example.com',
         SUPABASE_URL: 'https://test.supabase.co',
         SUPABASE_SERVICE_ROLE_KEY: 'sb_secret_test_key',
+        DATABASE_URL: 'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres',
       })
     );
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -130,6 +130,66 @@ if (!_env.success) {
 export const config = _env.data;
 export type Config = z.infer<typeof envSchema>;
 
+export interface DeploymentEnvironment {
+  NODE_ENV?: string;
+  RAILWAY_ENVIRONMENT_NAME?: string;
+  RAILWAY_PROJECT_ID?: string;
+  DATABASE_URL?: string;
+  VOICELOG_DATABASE_URL?: string;
+}
+
+export function isProductionDeployment(env: DeploymentEnvironment = process.env): boolean {
+  if (env.NODE_ENV === 'test') {
+    return false;
+  }
+  return Boolean(
+    env.NODE_ENV === 'production' || env.RAILWAY_ENVIRONMENT_NAME || env.RAILWAY_PROJECT_ID
+  );
+}
+
+export function getConfiguredDatabaseUrl(env: DeploymentEnvironment = process.env): string | null {
+  const value = env.VOICELOG_DATABASE_URL || env.DATABASE_URL;
+  const normalized = value?.trim();
+  return normalized || null;
+}
+
+function hasIncompleteSupabasePostgresHost(hostname: string): boolean {
+  const labels = hostname.split('.').filter(Boolean);
+  return labels.length === 2 && ['db', 'postgres'].includes(labels[0]);
+}
+
+export function validatePostgresDatabaseUrl(value: string | null | undefined): string | null {
+  if (!value) {
+    return 'Missing PostgreSQL database URL. Set VOICELOG_DATABASE_URL or DATABASE_URL.';
+  }
+
+  try {
+    const parsed = new URL(value);
+    if (!['postgres:', 'postgresql:'].includes(parsed.protocol)) {
+      return 'Database URL must use the postgres:// or postgresql:// protocol.';
+    }
+    if (!parsed.hostname) {
+      return 'PostgreSQL database URL must include a host.';
+    }
+    if (hasIncompleteSupabasePostgresHost(parsed.hostname)) {
+      return 'PostgreSQL database URL must include a complete resolvable Supabase host.';
+    }
+  } catch {
+    return 'PostgreSQL database URL is malformed.';
+  }
+
+  return null;
+}
+
+export function getProductionDatabaseConfigurationError(
+  env: DeploymentEnvironment = process.env
+): string | null {
+  if (!isProductionDeployment(env)) {
+    return null;
+  }
+  return validatePostgresDatabaseUrl(getConfiguredDatabaseUrl(env));
+}
+
 function isValidSupabaseProjectUrl(value?: string) {
   if (!value) return false;
   try {
@@ -177,14 +237,6 @@ function logCorsStartupConfig(allowedOrigins: string, allowVercelPreviews: boole
   });
 }
 
-function isProductionDeployment() {
-  return Boolean(
-    config.NODE_ENV === 'production' ||
-    process.env.RAILWAY_ENVIRONMENT_NAME ||
-    process.env.RAILWAY_PROJECT_ID
-  );
-}
-
 export function validateRequiredApiKeys() {
   const errors: string[] = [];
   const warnings: string[] = [];
@@ -194,6 +246,11 @@ export function validateRequiredApiKeys() {
   logCorsStartupConfig(allowedOrigins, allowVercelPreviews);
 
   if (isProductionDeployment()) {
+    const databaseConfigError = getProductionDatabaseConfigurationError();
+    if (databaseConfigError) {
+      errors.push(databaseConfigError);
+    }
+
     if (splitAllowedOrigins(allowedOrigins).includes('*')) {
       errors.push(
         'Production CORS cannot use VOICELOG_ALLOWED_ORIGINS=*.\n' +

--- a/server/database.ts
+++ b/server/database.ts
@@ -6,7 +6,12 @@ import { Pool } from 'pg';
 import { fileURLToPath } from 'node:url';
 import { Worker } from 'node:worker_threads';
 import { logger } from './logger.ts';
-import { config } from './config.ts';
+import {
+  config,
+  getConfiguredDatabaseUrl,
+  getProductionDatabaseConfigurationError,
+  validatePostgresDatabaseUrl,
+} from './config.ts';
 import { resolveBuildMetadata } from './runtime.ts';
 import { isCreatedAtExpiredByRetention } from './lib/retentionPolicy.ts';
 import { requireVoiceProfileEmbedding } from './lib/voiceProfileEmbedding.ts';
@@ -4456,6 +4461,33 @@ export function initDatabase(dbConfig?: any): Database {
   return defaultInstance;
 }
 
+export function resolveDatabaseAdapter({
+  isTest,
+  connectionString,
+  productionDatabaseError,
+}: {
+  isTest: boolean;
+  connectionString: string | null;
+  productionDatabaseError: string | null;
+}): 'postgres' | 'sqlite' {
+  if (productionDatabaseError) {
+    throw new Error(`[database] Production startup blocked: ${productionDatabaseError}`);
+  }
+
+  if (isTest) {
+    return 'sqlite';
+  }
+
+  const configuredDatabaseError = connectionString
+    ? validatePostgresDatabaseUrl(connectionString)
+    : null;
+  if (configuredDatabaseError) {
+    throw new Error(`[database] Invalid configured PostgreSQL URL: ${configuredDatabaseError}`);
+  }
+
+  return connectionString ? 'postgres' : 'sqlite';
+}
+
 export function getDatabase() {
   if (!defaultInstance) {
     const DATA_DIR = path.resolve(__dirname, 'data');
@@ -4467,10 +4499,16 @@ export function getDatabase() {
       : path.join(DATA_DIR, 'uploads');
     const SESSION_TTL_HOURS = Math.max(1, config.VOICELOG_SESSION_TTL_HOURS || 24 * 30);
     const IS_TEST = process.env.NODE_ENV === 'test' || config.NODE_ENV === 'test';
-    const CONNECTION_STRING = !IS_TEST ? config.VOICELOG_DATABASE_URL || config.DATABASE_URL : null;
+    const CONNECTION_STRING = !IS_TEST ? getConfiguredDatabaseUrl() : null;
+    const productionDatabaseError = getProductionDatabaseConfigurationError();
+    const adapter = resolveDatabaseAdapter({
+      isTest: IS_TEST,
+      connectionString: CONNECTION_STRING,
+      productionDatabaseError,
+    });
 
     return initDatabase({
-      type: CONNECTION_STRING ? 'postgres' : 'sqlite',
+      type: adapter,
       dbPath: IS_TEST ? ':memory:' : DB_PATH,
       uploadDir: UPLOAD_DIR,
       sessionTtlHours: SESSION_TTL_HOURS,

--- a/server/http/health.ts
+++ b/server/http/health.ts
@@ -63,6 +63,14 @@ export function registerHealthRoute(app: Hono<any>, db?: any) {
     });
 
     const memory = process.memoryUsage();
+    const databaseAdapter =
+      typeof dbStatus.type === 'string'
+        ? dbStatus.type
+        : typeof db?.type === 'string'
+          ? db.type
+          : db
+            ? 'unknown'
+            : 'none';
     const storageRequired =
       process.env.NODE_ENV === 'production' ||
       Boolean(process.env.RAILWAY_ENVIRONMENT_NAME || process.env.RAILWAY_PROJECT_ID);
@@ -75,6 +83,7 @@ export function registerHealthRoute(app: Hono<any>, db?: any) {
         ok: Boolean(dbStatus.ok),
         status: dbStatus.ok ? 'ok' : 'degraded',
         db: dbStatus.status,
+        databaseAdapter,
         supabaseRemote: Boolean((supabaseStorage as any).ready),
         supabaseStorage,
         readiness: {

--- a/server/tests/config.test.ts
+++ b/server/tests/config.test.ts
@@ -154,6 +154,58 @@ describe('config.ts — validateRequiredApiKeys', () => {
     expect(config).toHaveProperty('VOICELOG_PROCESSING_MODE_DEFAULT');
   });
 
+  // ----------------------------------------------------------------
+  // Issue #1510 — production must never fall back to SQLite
+  // Date: 2026-07-21
+  // Bug: a Railway deployment without a usable PostgreSQL URL could
+  //      initialize local SQLite and silently lose data on redeploy.
+  // Fix: one production predicate and a fail-closed URL validator are
+  //      shared by startup validation and database initialization.
+  // ----------------------------------------------------------------
+  test('rejects missing and malformed PostgreSQL configuration for production deployments', async () => {
+    const { getProductionDatabaseConfigurationError, isProductionDeployment } =
+      await import('../config.js');
+
+    expect(isProductionDeployment({ NODE_ENV: 'production' })).toBe(true);
+    expect(isProductionDeployment({ RAILWAY_PROJECT_ID: 'railway-project-test' })).toBe(true);
+    expect(
+      isProductionDeployment({ NODE_ENV: 'test', RAILWAY_PROJECT_ID: 'railway-project-test' })
+    ).toBe(false);
+    expect(getProductionDatabaseConfigurationError({ NODE_ENV: 'production' })).toContain(
+      'Missing PostgreSQL database URL'
+    );
+    expect(
+      getProductionDatabaseConfigurationError({
+        NODE_ENV: 'production',
+        DATABASE_URL: 'https://db.example.com/not-postgres',
+      })
+    ).toContain('postgresql://');
+    expect(
+      getProductionDatabaseConfigurationError({
+        NODE_ENV: 'production',
+        DATABASE_URL: 'postgresql://postgres:secret@postgres.project-ref:5432/postgres',
+      })
+    ).toContain('complete resolvable Supabase host');
+  });
+
+  test('accepts direct and pooler PostgreSQL URLs in production without exposing credentials', async () => {
+    const { getProductionDatabaseConfigurationError } = await import('../config.js');
+
+    expect(
+      getProductionDatabaseConfigurationError({
+        NODE_ENV: 'production',
+        DATABASE_URL: 'postgresql://postgres:super-secret@db.project-ref.supabase.co:5432/postgres',
+      })
+    ).toBeNull();
+    expect(
+      getProductionDatabaseConfigurationError({
+        RAILWAY_PROJECT_ID: 'railway-project-test',
+        VOICELOG_DATABASE_URL:
+          'postgresql://postgres.project-ref:super-secret@aws-0-eu-central-1.pooler.supabase.com:6543/postgres',
+      })
+    ).toBeNull();
+  });
+
   test('defaults production-quality STT to OpenAI premium mode', async () => {
     const previousProvider = process.env.VOICELOG_STT_PROVIDER;
     const previousPolicy = process.env.VOICELOG_STT_POLICY;

--- a/server/tests/database/production-adapter.test.ts
+++ b/server/tests/database/production-adapter.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+
+const originalEnvironment = { ...process.env };
+
+function restoreEnvironment() {
+  process.env = { ...originalEnvironment };
+}
+
+afterEach(() => {
+  restoreEnvironment();
+  vi.resetModules();
+});
+
+// ----------------------------------------------------------------
+// Issue #1510 — production database adapter must fail closed
+// Date: 2026-07-21
+// Bug: missing production PostgreSQL configuration selected SQLite.
+// Fix: getDatabase rejects production before it can construct SQLite.
+// ----------------------------------------------------------------
+describe('production database adapter', () => {
+  test('rejects missing PostgreSQL configuration before creating a database', async () => {
+    process.env.NODE_ENV = 'production';
+    delete process.env.DATABASE_URL;
+    delete process.env.VOICELOG_DATABASE_URL;
+    vi.resetModules();
+
+    const { getDatabase } = await import('../../database.ts');
+
+    expect(() => getDatabase()).toThrow('Production startup blocked');
+  });
+
+  test('rejects malformed production PostgreSQL configuration before creating a database', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DATABASE_URL = 'https://db.example.com/not-postgres';
+    delete process.env.VOICELOG_DATABASE_URL;
+    vi.resetModules();
+
+    const { getDatabase } = await import('../../database.ts');
+
+    expect(() => getDatabase()).toThrow('postgresql://');
+  });
+
+  test('selects the PostgreSQL adapter for a valid production connection string', async () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DATABASE_URL =
+      'postgresql://postgres:secret@db.project-ref.supabase.co:5432/postgres';
+    delete process.env.VOICELOG_DATABASE_URL;
+    vi.resetModules();
+
+    const { getDatabase } = await import('../../database.ts');
+    const db = getDatabase();
+
+    expect(db.type).toBe('postgres');
+    await db.shutdown();
+  });
+
+  test('keeps SQLite available for test execution', async () => {
+    const { resolveDatabaseAdapter } = await import('../../database.ts');
+
+    expect(
+      resolveDatabaseAdapter({
+        isTest: true,
+        connectionString: null,
+        productionDatabaseError: null,
+      })
+    ).toBe('sqlite');
+  });
+});

--- a/server/tests/routes/health.test.ts
+++ b/server/tests/routes/health.test.ts
@@ -100,7 +100,8 @@ describe('http/health.ts', () => {
   test('checks db health via checkHealth method', async () => {
     const app = makeHonoLike();
     const db = {
-      checkHealth: vi.fn().mockResolvedValue({ ok: true, status: 'healthy' }),
+      type: 'postgres',
+      checkHealth: vi.fn().mockResolvedValue({ ok: true, status: 'healthy', type: 'postgres' }),
     };
     registerHealthRoute(app, db);
     const route = app._routes.find((r: any) => r.path === '/health');
@@ -114,6 +115,7 @@ describe('http/health.ts', () => {
 
     expect(db.checkHealth).toHaveBeenCalled();
     expect(response.data.db).toBe('healthy');
+    expect(response.data.databaseAdapter).toBe('postgres');
     expect(response.status).toBe(200);
   });
 


### PR DESCRIPTION
## Summary\n\nCloses #1510. Production and Railway now fail before HTTP startup without a valid PostgreSQL URL; SQLite remains explicit for development and tests.\n\n## Changes\n\n- Shared exported production predicate and PostgreSQL URL validator.\n- Enforced the validator in startup configuration and getDatabase().\n- Added safe databaseAdapter metadata to /health and /ready.\n- Made the standalone environment validator block missing production DB configuration.\n- Documented direct and pooler Supabase connection-host forms.\n\n## Validation\n\n- pnpm run typecheck:server\n- targeted config/database/health tests (34 passed)\n- pnpm run test:server:retry (1,481 passed, 82 skipped)\n- pnpm run test:workflows (204 passed)\n- pnpm run test:release:guard through Node 22 + pnpm 9\n\n## Risk\n\nA Railway deployment with a missing or invalid DB URL will now intentionally refuse startup instead of silently using ephemeral SQLite. Configure the production secret before rollout.