### PR TITLE
fix(consent): enforce recording consent in production

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,6 +6,7 @@ build
 dist
 dist-server
 src
+!src/lib/
 !src/shared/
 public
 .env

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,6 +30,7 @@ FROM deps AS build
 ENV NODE_OPTIONS="--max-old-space-size=1536"
 
 COPY --link server/ ./server/
+COPY --link src/lib/ ./src/lib/
 COPY --link src/shared/ ./src/shared/
 
 RUN pnpm exec esbuild server/index.ts server/sqliteWorker.ts \

--- a/docs/VENDOR_DATA_RESIDENCY_MATRIX.md
+++ b/docs/VENDOR_DATA_RESIDENCY_MATRIX.md
@@ -68,6 +68,24 @@ Capability identifiers used by `/api/capabilities`:
 | Local Whisper              | Audio chunks                                           | Offline STT fallback                                 | `USE_LOCAL_WHISPER`, `WHISPER_CPP_PATH`, `WHISPER_MODEL_PATH`, `WHISPER_THREADS` | Audio remains on the application host during processing. Model files are local artifacts.                            | Disable `USE_LOCAL_WHISPER` and configure OpenAI or Groq.                                  |
 | Browser speech recognition | Microphone audio handled by the browser implementation | Live transcription                                   | Browser support and microphone permission                                        | Residency depends on the browser implementation and user device/browser vendor behavior.                             | Disable live transcription in product configuration or do not grant microphone permission. |
 
+## Recording consent enforcement
+
+The browser disclosure is only a user-interface prompt; it is not the production security
+boundary. For every production `POST /media/recordings/:recordingId/transcribe` request, the
+backend requires the versioned `recording-consent-v1` metadata with a current acceptance time,
+the recording workspace, disclosure title, provider notice, and enabled STT category. The
+authenticated user is recorded by the server, not trusted from the request body.
+
+The accepted consent and original actor are stored with the recording. A retry reads that stored
+consent; legacy/imported recordings without a valid stored consent return
+`recording_consent_invalid` and cannot start or retry transcription until a new consent is
+captured. The audit event stores only policy version, timestamp, and provider category IDs—never
+audio, transcript text, prompts, or provider payloads.
+
+Development and test environments keep the local workflow compatible with fixtures and do not
+enforce the production request gate. They must still exercise the same contract in route tests;
+production/Railway is the enforcement boundary.
+
 ## Manual Review Checklist
 
 - Confirm every configured provider in Railway/Vercel secrets appears in the Provider Register.

--- a/server/database.ts
+++ b/server/database.ts
@@ -3740,6 +3740,7 @@ export class Database {
             acceptedAt: this._clean(updates.recordingConsent.acceptedAt),
             workspaceId: this._clean(updates.recordingConsent.workspaceId),
             policyVersion: this._clean(updates.recordingConsent.policyVersion),
+            actorUserId: this._clean(updates.recordingConsent.actorUserId),
             disclosureTitle: this._clean(updates.recordingConsent.disclosureTitle),
             providerNotice: this._clean(updates.recordingConsent.providerNotice),
             providers: Array.isArray(updates.recordingConsent.providers)
@@ -3761,7 +3762,12 @@ export class Database {
       typeof existingDiarization.qualityMetrics === 'object'
         ? { qualityMetrics: this._normalizeQualityMetrics(existingDiarization.qualityMetrics) }
         : {}),
-      ...(recordingConsent ? { recordingConsent } : {}),
+      ...(recordingConsent
+        ? { recordingConsent }
+        : existingDiarization?.recordingConsent &&
+            typeof existingDiarization.recordingConsent === 'object'
+          ? { recordingConsent: existingDiarization.recordingConsent }
+          : {}),
     };
     await this._execute(
       "UPDATE media_assets SET workspace_id = ?, meeting_id = ?, content_type = ?, transcription_status = 'queued', transcript_json = '[]', diarization_json = ?, updated_at = ? WHERE id = ?",

--- a/server/lib/recordingConsent.ts
+++ b/server/lib/recordingConsent.ts
@@ -1,0 +1,121 @@
+import {
+  RECORDING_CONSENT_POLICY_VERSION,
+  type RecordingConsentProviderDisclosure,
+} from '../../src/lib/recordingConsent.ts';
+import type { RecordingConsentAuditMetadata } from './types.ts';
+
+export const RECORDING_CONSENT_MAX_AGE_MS = 366 * 24 * 60 * 60 * 1000;
+
+const SUPPORTED_PROVIDER_CATEGORIES = new Set([
+  'stt',
+  'diarization',
+  'llm-analysis',
+  'embeddings',
+  'image-generation',
+]);
+
+export interface ValidatedRecordingConsent extends RecordingConsentAuditMetadata {
+  acceptedAt: string;
+  workspaceId: string;
+  policyVersion: typeof RECORDING_CONSENT_POLICY_VERSION;
+  disclosureTitle: string;
+  providerNotice: string;
+  providers: RecordingConsentProviderDisclosure[];
+  actorUserId: string;
+}
+
+export interface RecordingConsentValidationOptions {
+  workspaceId: string;
+  actorUserId: string;
+  preserveRecordedActor?: boolean;
+  now?: number;
+}
+
+export type RecordingConsentValidationResult =
+  { valid: true; consent: ValidatedRecordingConsent } | { valid: false; reason: string };
+
+function requiredString(value: unknown, maxLength: number): string | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.trim();
+  return normalized.length > 0 && normalized.length <= maxLength ? normalized : null;
+}
+
+function normalizeProviders(value: unknown): RecordingConsentProviderDisclosure[] | null {
+  if (!Array.isArray(value) || value.length === 0 || value.length > 10) return null;
+  const providerIds = new Set<string>();
+  const providers: RecordingConsentProviderDisclosure[] = [];
+
+  for (const candidate of value) {
+    if (!candidate || typeof candidate !== 'object') return null;
+    const provider = candidate as Record<string, unknown>;
+    const id = requiredString(provider.id, 80);
+    const label = requiredString(provider.label, 240);
+    if (!id || !label || typeof provider.enabled !== 'boolean') return null;
+    if (!SUPPORTED_PROVIDER_CATEGORIES.has(id) || providerIds.has(id)) return null;
+    providerIds.add(id);
+    providers.push({ id, label, enabled: provider.enabled });
+  }
+
+  return providers.some((provider) => provider.id === 'stt' && provider.enabled) ? providers : null;
+}
+
+export function validateRecordingConsent(
+  value: unknown,
+  options: RecordingConsentValidationOptions
+): RecordingConsentValidationResult {
+  if (!value || typeof value !== 'object') {
+    return { valid: false, reason: 'missing' };
+  }
+
+  const consent = value as Record<string, unknown>;
+  const acceptedAt = requiredString(consent.acceptedAt, 80);
+  const workspaceId = requiredString(consent.workspaceId, 160);
+  const policyVersion = requiredString(consent.policyVersion, 80);
+  const disclosureTitle = requiredString(consent.disclosureTitle, 240);
+  const providerNotice = requiredString(consent.providerNotice, 1000);
+  const actorUserId = requiredString(
+    options.preserveRecordedActor ? consent.actorUserId : options.actorUserId,
+    160
+  );
+  const providers = normalizeProviders(consent.providers);
+  const acceptedAtMs = acceptedAt ? Date.parse(acceptedAt) : Number.NaN;
+  const now = options.now ?? Date.now();
+
+  if (!acceptedAt || !Number.isFinite(acceptedAtMs) || acceptedAtMs > now) {
+    return { valid: false, reason: 'timestamp_invalid' };
+  }
+  if (now - acceptedAtMs > RECORDING_CONSENT_MAX_AGE_MS) {
+    return { valid: false, reason: 'expired' };
+  }
+  if (!workspaceId || workspaceId !== options.workspaceId) {
+    return { valid: false, reason: 'workspace_mismatch' };
+  }
+  if (policyVersion !== RECORDING_CONSENT_POLICY_VERSION) {
+    return { valid: false, reason: 'policy_unsupported' };
+  }
+  if (!disclosureTitle || !providerNotice || !providers || !actorUserId) {
+    return { valid: false, reason: 'disclosure_invalid' };
+  }
+
+  return {
+    valid: true,
+    consent: {
+      acceptedAt: new Date(acceptedAtMs).toISOString(),
+      workspaceId,
+      policyVersion: RECORDING_CONSENT_POLICY_VERSION,
+      disclosureTitle,
+      providerNotice,
+      providers,
+      actorUserId,
+    },
+  };
+}
+
+export function readRecordingConsentFromAsset(asset: { diarization_json?: unknown }): unknown {
+  try {
+    const diarization = JSON.parse(String(asset?.diarization_json || '{}'));
+    return diarization?.recordingConsent;
+  } catch {
+    return null;
+  }
+}

--- a/server/lib/types.ts
+++ b/server/lib/types.ts
@@ -32,6 +32,7 @@ export interface RecordingConsentAuditMetadata {
   acceptedAt?: string;
   workspaceId?: string;
   policyVersion?: string;
+  actorUserId?: string;
   disclosureTitle?: string;
   providerNotice?: string;
   providers?: Array<{

--- a/server/routes/media.ts
+++ b/server/routes/media.ts
@@ -57,6 +57,12 @@ import { addPipelineBreadcrumb, capturePipelineException } from '../sentry.ts';
 import { withAudioSpan } from '../tracing.ts';
 import { logger } from '../logger.ts';
 import { MetricsService } from '../services/MetricsService.ts';
+import { isProductionDeployment } from '../config.ts';
+import {
+  readRecordingConsentFromAsset,
+  validateRecordingConsent,
+  type ValidatedRecordingConsent,
+} from '../lib/recordingConsent.ts';
 
 const AUDIO_CONTENT_TYPE_EXTENSIONS: Record<string, string[]> = {
   'audio/webm': ['.webm'],
@@ -826,6 +832,48 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
     });
   }
 
+  function getSessionActorUserId(c: any): string {
+    const session = c.get('session') as any;
+    return String(session?.user_id || session?.userId || '').trim();
+  }
+
+  function recordingConsentInvalidResponse(c: any, recordingId: string) {
+    return c.json(
+      {
+        code: 'recording_consent_invalid',
+        message: 'Brak aktualnej zgody na przetwarzanie nagrania.',
+        recordingId,
+      },
+      422
+    );
+  }
+
+  function validateProductionRecordingConsent(
+    c: any,
+    recordingId: string,
+    workspaceId: string,
+    input: unknown,
+    preserveRecordedActor = false
+  ): ValidatedRecordingConsent | null | Response {
+    if (!isProductionDeployment()) return null;
+    const validation = validateRecordingConsent(input, {
+      workspaceId,
+      actorUserId: getSessionActorUserId(c),
+      preserveRecordedActor,
+    });
+    return validation.valid ? validation.consent : recordingConsentInvalidResponse(c, recordingId);
+  }
+
+  async function recordConsentAuditEvent(c: any, asset: any, consent: ValidatedRecordingConsent) {
+    await writeRecordingAuditEvent(c, asset, 'recording.transcription.consent_recorded', {
+      policyVersion: consent.policyVersion,
+      acceptedAt: consent.acceptedAt,
+      providerCategories: consent.providers
+        .filter((provider) => provider.enabled)
+        .map((provider) => provider.id),
+    });
+  }
+
   function resolveProcessingMode(input: any) {
     return input === 'full' || input === 'fast'
       ? input
@@ -1483,7 +1531,10 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       const body = bodyValidation.data;
       const asset = await transcriptionService.getMediaAsset(recordingId);
       if (!asset) return c.json({ message: 'Nie znaleziono nagrania.' }, 404);
-      const workspaceId = body.workspaceId || asset.workspace_id;
+      const workspaceId = asset.workspace_id;
+      if (body.workspaceId && body.workspaceId !== workspaceId) {
+        return recordingConsentInvalidResponse(c, recordingId);
+      }
       const membership = await ensureWorkspaceAccess(c, workspaceId);
       if (!workspaceMembershipCan(membership, 'recordings:process')) {
         return c.json({ message: 'Nie masz uprawnien do przetwarzania nagran.' }, 403);
@@ -1510,6 +1561,14 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
           202
         );
       }
+
+      const validatedConsent = validateProductionRecordingConsent(
+        c,
+        recordingId,
+        workspaceId,
+        body.recordingConsent
+      );
+      if (validatedConsent instanceof Response) return validatedConsent;
 
       const quotaResponse = await enforceProviderQuota(c, {
         kind: 'stt',
@@ -1551,10 +1610,16 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
           () =>
             startTranscriptionPipeline(recordingId, asset, {
               ...body,
+              workspaceId,
+              recordingConsent: validatedConsent || body.recordingConsent,
               processingMode: resolveProcessingMode(body.processingMode),
               requestId: c.get('reqId'),
             })
         );
+
+        if (validatedConsent) {
+          await recordConsentAuditEvent(c, { ...asset, id: recordingId }, validatedConsent);
+        }
 
         return c.json(
           withIdempotencyMetadata(
@@ -1603,6 +1668,15 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
       const asset = await transcriptionService.getMediaAsset(recordingId);
       if (!asset) return c.json({ message: 'Nie znaleziono nagrania.' }, 404);
       await ensureWorkspaceAccess(c, asset.workspace_id);
+      const storedConsent = readRecordingConsentFromAsset(asset);
+      const validatedConsent = validateProductionRecordingConsent(
+        c,
+        recordingId,
+        asset.workspace_id,
+        storedConsent,
+        true
+      );
+      if (validatedConsent instanceof Response) return validatedConsent;
       const featureFlags = await getWorkspaceFeatureFlags(workspaceService, asset.workspace_id);
       if (featureFlags.sttProvider === 'disabled') {
         return c.json(
@@ -1656,6 +1730,7 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
             workspaceId: asset.workspace_id,
             meetingId: asset.meeting_id,
             contentType: asset.content_type,
+            recordingConsent: validatedConsent || storedConsent,
             processingMode,
             requestId: c.get('reqId'),
           }
@@ -1732,6 +1807,7 @@ export function createMediaRoutes(services: AppServices, middlewares: AppMiddlew
               workspaceId: asset.workspace_id,
               meetingId: asset.meeting_id,
               contentType: asset.content_type,
+              recordingConsent: validatedConsent || storedConsent,
               processingMode,
               requestId: c.get('reqId'),
             })

--- a/server/tests/database/transcriptionJobs.test.ts
+++ b/server/tests/database/transcriptionJobs.test.ts
@@ -113,6 +113,7 @@ describe('transcription_jobs durable queue', () => {
           acceptedAt: '2026-06-25T10:00:00.000Z',
           workspaceId: 'ws_consent',
           policyVersion: 'recording-consent-v1',
+          actorUserId: 'user_consent',
           disclosureTitle: 'Zgoda na nagrywanie i przetwarzanie AI',
           providerNotice: 'Dane moga byc przekazywane do dostawcow AI/audio.',
           providers: [
@@ -129,6 +130,7 @@ describe('transcription_jobs durable queue', () => {
         acceptedAt: '2026-06-25T10:00:00.000Z',
         workspaceId: 'ws_consent',
         policyVersion: 'recording-consent-v1',
+        actorUserId: 'user_consent',
       });
       expect(diarization.recordingConsent.providers).toEqual(
         expect.arrayContaining([
@@ -136,6 +138,18 @@ describe('transcription_jobs durable queue', () => {
           expect.objectContaining({ id: 'llm-analysis', enabled: true }),
         ])
       );
+
+      await db.queueTranscription('rec_consent', {
+        workspaceId: 'ws_consent',
+        meetingId: 'meeting_consent',
+        contentType: 'audio/webm',
+      });
+
+      const requeued = await db.getMediaAsset('rec_consent');
+      expect(JSON.parse(requeued.diarization_json || '{}').recordingConsent).toMatchObject({
+        actorUserId: 'user_consent',
+        policyVersion: 'recording-consent-v1',
+      });
     } finally {
       await db.shutdown();
     }

--- a/server/tests/dockerfile.test.ts
+++ b/server/tests/dockerfile.test.ts
@@ -1,10 +1,12 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
-// Note: This test reads the actual Dockerfile, so fs is not mocked here
-// The vi.mock in setup.ts is bypassed for this specific test file
+// This test validates files in the Docker build context, so it must bypass
+// the global node:fs mock from server/tests/setup.ts.
+vi.unmock('node:fs');
+vi.unmock('fs');
 
 const ROOT = process.cwd();
 const dockerfile = fs.readFileSync(path.join(ROOT, 'Dockerfile'), 'utf8');
@@ -49,6 +51,21 @@ describe('Dockerfile COPY sources not excluded by .dockerignore', () => {
     const patterns = buildIgnorePatterns(dockerignore);
     expect(isExcluded('src/shared', patterns)).toBe(false);
     expect(isExcluded('src/shared/meetingFeedback.ts', patterns)).toBe(false);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Issue #1511 — recording consent server adapter is bundled in Docker
+  // Date: 2026-07-22
+  // Bug: the adapter imports src/lib/recordingConsent.ts but the build stage
+  //      copied only src/shared/, so production image builds could not resolve it.
+  // Fix: include src/lib/ in the Docker build context before esbuild runs.
+  // ─────────────────────────────────────────────────────────────────
+  it('copies src/lib/ required by the recording consent server adapter', () => {
+    expect(dockerfile).toMatch(/COPY --link src\/lib\/ \.\/src\/lib\//);
+    expect(dockerignore).toMatch(/^!src\/lib\/$/m);
+    const patterns = buildIgnorePatterns(dockerignore);
+    expect(isExcluded('src/lib', patterns)).toBe(false);
+    expect(isExcluded('src/lib/recordingConsent.ts', patterns)).toBe(false);
   });
 
   it('all COPY source paths (non --from) are reachable in build context', () => {

--- a/server/tests/lib/recordingConsent.test.ts
+++ b/server/tests/lib/recordingConsent.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, test } from 'vitest';
+import {
+  RECORDING_CONSENT_MAX_AGE_MS,
+  readRecordingConsentFromAsset,
+  validateRecordingConsent,
+} from '../../lib/recordingConsent.ts';
+
+const now = Date.parse('2026-07-22T08:00:00.000Z');
+
+function consent(overrides: Record<string, unknown> = {}) {
+  return {
+    acceptedAt: '2026-07-21T08:00:00.000Z',
+    workspaceId: 'workspace_1',
+    policyVersion: 'recording-consent-v1',
+    disclosureTitle: 'Zgoda na nagrywanie i przetwarzanie AI',
+    providerNotice: 'Dane audio moga byc przetwarzane przez dostawcow AI.',
+    providers: [{ id: 'stt', label: 'Transkrypcja', enabled: true }],
+    ...overrides,
+  };
+}
+
+function validate(value: unknown, overrides: Record<string, unknown> = {}) {
+  return validateRecordingConsent(value, {
+    workspaceId: 'workspace_1',
+    actorUserId: 'actor_1',
+    now,
+    ...overrides,
+  });
+}
+
+describe('recording consent validation', () => {
+  test('accepts a current disclosure and stamps the authenticated actor', () => {
+    expect(validate(consent())).toEqual({
+      valid: true,
+      consent: expect.objectContaining({
+        actorUserId: 'actor_1',
+        workspaceId: 'workspace_1',
+        policyVersion: 'recording-consent-v1',
+      }),
+    });
+  });
+
+  test('rejects an absent disclosure', () => {
+    expect(validate(null)).toEqual({ valid: false, reason: 'missing' });
+  });
+
+  test('rejects a disclosure issued for another workspace', () => {
+    expect(validate(consent({ workspaceId: 'workspace_other' }))).toEqual({
+      valid: false,
+      reason: 'workspace_mismatch',
+    });
+  });
+
+  test('rejects a future or expired acceptance timestamp', () => {
+    expect(validate(consent({ acceptedAt: '2026-07-22T08:00:01.000Z' }))).toEqual({
+      valid: false,
+      reason: 'timestamp_invalid',
+    });
+    expect(
+      validate(
+        consent({ acceptedAt: new Date(now - RECORDING_CONSENT_MAX_AGE_MS - 1).toISOString() })
+      )
+    ).toEqual({ valid: false, reason: 'expired' });
+  });
+
+  test('rejects an unsupported policy version or malformed provider categories', () => {
+    expect(validate(consent({ policyVersion: 'recording-consent-v0' }))).toEqual({
+      valid: false,
+      reason: 'policy_unsupported',
+    });
+    expect(
+      validate(consent({ providers: [{ id: 'stt', label: 'Transkrypcja', enabled: false }] }))
+    ).toEqual({
+      valid: false,
+      reason: 'disclosure_invalid',
+    });
+  });
+
+  test('preserves the originally recorded actor during retry validation', () => {
+    const result = validate(consent({ actorUserId: 'actor_original' }), {
+      preserveRecordedActor: true,
+      actorUserId: 'actor_retrying',
+    });
+
+    expect(result).toEqual({
+      valid: true,
+      consent: expect.objectContaining({ actorUserId: 'actor_original' }),
+    });
+  });
+
+  test('reads consent only from valid diarization JSON', () => {
+    expect(
+      readRecordingConsentFromAsset({
+        diarization_json: JSON.stringify({ recordingConsent: consent() }),
+      })
+    ).toEqual(consent());
+    expect(readRecordingConsentFromAsset({ diarization_json: '{bad-json' })).toBeNull();
+  });
+});

--- a/server/tests/routes/media.test.ts
+++ b/server/tests/routes/media.test.ts
@@ -27,6 +27,18 @@ import { createApp } from '../../app.ts';
 import { MAX_RAW_UPLOAD_BYTES, buildSegmentedMediaManifest } from '../../lib/mediaStoragePolicy.ts';
 import { createProgressToken, resetProgressTokensForTests } from '../../lib/progressTokens.ts';
 
+function validRecordingConsent(overrides: Record<string, unknown> = {}) {
+  return {
+    acceptedAt: '2026-07-21T09:00:00.000Z',
+    workspaceId: 'ws_1',
+    policyVersion: 'recording-consent-v1',
+    disclosureTitle: 'Zgoda na nagrywanie i przetwarzanie AI',
+    providerNotice: 'Dane audio moga byc przekazywane do dostawcow AI/audio.',
+    providers: [{ id: 'stt', label: 'transkrypcja mowy na tekst', enabled: true }],
+    ...overrides,
+  };
+}
+
 // Helper to control fs mock state between tests
 function setFsState(overrides?: { existsSync?: boolean; statSyncSize?: number }) {
   (global as any).__TEST_FS_STATE__ = {
@@ -402,6 +414,180 @@ describe('Media Routes', () => {
       'rec_1',
       expect.objectContaining({ processingMode: 'fast' })
     );
+  });
+
+  // -----------------------------------------------------------------
+  // Issue #1511 — production transcription requires durable consent
+  // Date: 2026-07-22
+  // Bug: a direct API client could start transcription without the
+  //      consent disclosure accepted in the browser.
+  // Fix: production validates, persists, and audits the consent server-side.
+  // -----------------------------------------------------------------
+  it('Regression: Issue #1511 — rejects a production transcription without consent', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_consent_required',
+      workspace_id: 'ws_1',
+      file_path: '/tmp/fake.webm',
+      content_type: 'audio/webm',
+      size_bytes: 1024,
+      transcription_status: 'failed',
+    });
+
+    const res = await app.request('/media/recordings/rec_consent_required/transcribe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({ workspaceId: 'ws_1' }),
+    });
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({
+      code: 'recording_consent_invalid',
+      recordingId: 'rec_consent_required',
+    });
+    expect(mockTranscriptionService.queueTranscription).not.toHaveBeenCalled();
+    expect(mockTranscriptionService.ensureTranscriptionJob).not.toHaveBeenCalled();
+  });
+
+  it('Regression: Issue #1511 — rejects consent issued for another workspace', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_consent_workspace',
+      workspace_id: 'ws_1',
+      file_path: '/tmp/fake.webm',
+      content_type: 'audio/webm',
+      size_bytes: 1024,
+      transcription_status: 'failed',
+    });
+
+    const res = await app.request('/media/recordings/rec_consent_workspace/transcribe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        workspaceId: 'ws_1',
+        recordingConsent: validRecordingConsent({ workspaceId: 'ws_other' }),
+      }),
+    });
+
+    expect(res.status).toBe(422);
+    await expect(res.json()).resolves.toMatchObject({ code: 'recording_consent_invalid' });
+    expect(mockTranscriptionService.queueTranscription).not.toHaveBeenCalled();
+  });
+
+  it('Regression: Issue #1511 — persists and audits valid production consent without transcript data', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_consent_valid',
+      workspace_id: 'ws_1',
+      meeting_id: 'meeting_1',
+      file_path: '/tmp/fake.webm',
+      content_type: 'audio/webm',
+      size_bytes: 1024,
+      transcription_status: 'failed',
+    });
+    mockTranscriptionService.queueTranscription.mockResolvedValue(undefined);
+    mockTranscriptionService.ensureTranscriptionJob.mockResolvedValue({
+      id: 'rec_consent_valid',
+      transcription_status: 'queued',
+      transcript_json: '[]',
+      diarization_json: '{}',
+    });
+
+    const res = await app.request('/media/recordings/rec_consent_valid/transcribe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        workspaceId: 'ws_1',
+        recordingConsent: validRecordingConsent(),
+      }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(mockTranscriptionService.queueTranscription).toHaveBeenCalledWith(
+      'rec_consent_valid',
+      expect.objectContaining({
+        recordingConsent: expect.objectContaining({
+          workspaceId: 'ws_1',
+          actorUserId: 'user_1',
+          policyVersion: 'recording-consent-v1',
+        }),
+      })
+    );
+    expect(mockTranscriptionService.writeAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'recording.transcription.consent_recorded',
+        metadata: expect.objectContaining({
+          policyVersion: 'recording-consent-v1',
+          providerCategories: ['stt'],
+        }),
+      })
+    );
+    const auditMetadata = mockTranscriptionService.writeAuditLog.mock.calls[0][0].metadata;
+    expect(auditMetadata).not.toHaveProperty('transcript');
+    expect(auditMetadata).not.toHaveProperty('audioPath');
+    expect(JSON.stringify(auditMetadata)).not.toContain('audio/webm');
+  });
+
+  it('Regression: Issue #1511 — retry reuses the persisted consent and rejects legacy recordings', async () => {
+    vi.stubEnv('NODE_ENV', 'production');
+    const storedConsent = { ...validRecordingConsent(), actorUserId: 'user_original' };
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_retry_consent',
+      workspace_id: 'ws_1',
+      meeting_id: 'meeting_1',
+      file_path: '/tmp/retry-consent.webm',
+      content_type: 'audio/webm',
+      transcription_status: 'failed',
+      transcript_json: '[]',
+      diarization_json: JSON.stringify({ recordingConsent: storedConsent }),
+    });
+    mockTranscriptionService.queueTranscription.mockResolvedValue(undefined);
+    mockTranscriptionService.ensureTranscriptionJob.mockResolvedValue({
+      id: 'rec_retry_consent',
+      transcription_status: 'queued',
+      transcript_json: '[]',
+      diarization_json: '{}',
+    });
+
+    const retry = await app.request('/media/recordings/rec_retry_consent/retry-transcribe', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+
+    expect(retry.status).toBe(202);
+    expect(mockTranscriptionService.queueTranscription).toHaveBeenCalledWith(
+      'rec_retry_consent',
+      expect.objectContaining({
+        recordingConsent: expect.objectContaining({ actorUserId: 'user_original' }),
+      })
+    );
+
+    mockTranscriptionService.getMediaAsset.mockResolvedValue({
+      id: 'rec_legacy_without_consent',
+      workspace_id: 'ws_1',
+      meeting_id: 'meeting_1',
+      file_path: '/tmp/legacy.webm',
+      content_type: 'audio/webm',
+      transcription_status: 'failed',
+      transcript_json: '[]',
+      diarization_json: '{}',
+    });
+
+    const legacyRetry = await app.request(
+      '/media/recordings/rec_legacy_without_consent/retry-transcribe',
+      {
+        method: 'POST',
+        headers: { Authorization: 'Bearer fake_token', 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      }
+    );
+
+    expect(legacyRetry.status).toBe(422);
+    await expect(legacyRetry.json()).resolves.toMatchObject({
+      code: 'recording_consent_invalid',
+      recordingId: 'rec_legacy_without_consent',
+    });
   });
 
   it('Issue #1262 - blocks STT start before provider quota when workspace STT is disabled', async () => {


### PR DESCRIPTION
## Summary
- enforce the versioned recording-consent contract for production transcription requests
- persist the authenticated acceptance actor with the recording and reuse the original consent for retries
- reject missing, stale, malformed, or workspace-mismatched consent with `recording_consent_invalid`
- add redacted consent audit events and document the production/local behavior

## Validation
- `pnpm.cmd run typecheck:all`
- targeted server tests: 88 passed
- `pnpm.cmd run test:server:retry`: 1492 passed, 82 skipped
- `pnpm.cmd run audit:mojibake`

## Known limitation
- Local `pnpm.cmd run test:e2e:audio` timed out during the existing segmented upload smoke at 12%; it did not reach the consent or transcription assertion. CI must be green before merge.

Closes #1511