### PR TITLE
fix(auth): prevent duplicate pending submissions

### DIFF
--- a/docs/testing/ui-action-contracts.json
+++ b/docs/testing/ui-action-contracts.json
@@ -5,9 +5,13 @@
       "screen": "Auth",
       "file": "src/components/auth/AuthCredentialsForm.tsx",
       "expectedActionCount": 11,
-      "fingerprint": "61136dc0d155d1a4",
+      "fingerprint": "9ed3623fe7c84c28",
       "contractStatus": "covered",
-      "testFiles": ["src/AuthScreen.test.tsx", "src/AuthScreen.a11y.test.tsx"],
+      "testFiles": [
+        "src/AuthScreen.test.tsx",
+        "src/AuthScreen.a11y.test.tsx",
+        "src/components/auth/AuthCredentialsForm.test.tsx"
+      ],
       "testEvidence": ["Zapomnia", "Dołącz z kodu", "Wejd[zź]"],
       "owner": "frontend-auth"
     },

--- a/src/AppShellModern.tsx
+++ b/src/AppShellModern.tsx
@@ -70,6 +70,7 @@ export default function AppShellModern({ calendarMonth, setCalendarMonth }: AppS
         authMode={auth.authMode}
         authDraft={auth.authDraft}
         authError={auth.authError}
+        isSubmitting={auth.isSubmitting}
         setAuthMode={auth.setAuthMode}
         setAuthDraft={auth.setAuthDraft}
         submitAuth={auth.submitAuth}

--- a/src/AuthScreen.tsx
+++ b/src/AuthScreen.tsx
@@ -18,6 +18,7 @@ interface AuthScreenProps {
   authMode: AuthMode;
   authDraft?: AuthDraftLike | null;
   authError?: string;
+  isSubmitting?: boolean;
   setAuthMode: (mode: AuthMode) => void;
   setAuthDraft: (updater: (previous: AuthDraftLike) => AuthDraftLike) => void;
   submitAuth: (event: FormEvent<HTMLFormElement>) => void;
@@ -55,6 +56,7 @@ export default function AuthScreen({
   authMode,
   authDraft,
   authError,
+  isSubmitting,
   setAuthMode,
   setAuthDraft,
   submitAuth,
@@ -109,6 +111,7 @@ export default function AuthScreen({
               authMode={authMode}
               authValues={authValues}
               authError={authError}
+              isSubmitting={isSubmitting}
               setAuthDraft={setAuthDraft}
               setAuthMode={setAuthMode}
               onSubmit={internalSubmit}

--- a/src/components/auth/AuthCredentialsForm.test.tsx
+++ b/src/components/auth/AuthCredentialsForm.test.tsx
@@ -42,6 +42,14 @@ describe('AuthCredentialsForm', () => {
     expect(props.setAuthMode).toHaveBeenCalledWith('forgot');
   });
 
+  test('disables the visible submit action while authentication is pending', () => {
+    renderForm({ isSubmitting: true });
+
+    const submit = screen.getByRole('button', { name: /Zaloguj/i });
+    expect(submit).toBeDisabled();
+    expect(submit).toHaveAttribute('aria-busy', 'true');
+  });
+
   test('renders registration-only workspace controls', () => {
     renderForm({ authMode: 'register', authValues: normalizeAuthDraft({}) });
 

--- a/src/components/auth/AuthCredentialsForm.tsx
+++ b/src/components/auth/AuthCredentialsForm.tsx
@@ -6,6 +6,7 @@ interface AuthCredentialsFormProps {
   authMode: AuthMode;
   authValues: AuthValues;
   authError?: string;
+  isSubmitting?: boolean;
   setAuthDraft: (updater: (previous: AuthDraftLike) => AuthDraftLike) => void;
   setAuthMode: (mode: AuthMode) => void;
   onSubmit: (event: FormEvent<HTMLFormElement>) => void;
@@ -15,6 +16,7 @@ export default function AuthCredentialsForm({
   authMode,
   authValues,
   authError,
+  isSubmitting = false,
   setAuthDraft,
   setAuthMode,
   onSubmit,
@@ -185,7 +187,12 @@ export default function AuthCredentialsForm({
         </>
       ) : null}
 
-      <button type="submit" className="auth-submit-btn">
+      <button
+        type="submit"
+        className="auth-submit-btn"
+        disabled={isSubmitting}
+        aria-busy={isSubmitting || undefined}
+      >
         {isRegister ? 'Wejdź do aplikacji' : 'Zaloguj się'}
         <ArrowRight size={18} />
       </button>

--- a/src/store/authStore.test.ts
+++ b/src/store/authStore.test.ts
@@ -38,6 +38,7 @@ describe('authStore', () => {
         workspaceCode: '',
       },
       authError: '',
+      isSubmitting: false,
       googleAuthMessage: '',
       resetDraft: { email: '', code: '', newPassword: '', confirmPassword: '' },
       resetMessage: '',
@@ -92,6 +93,40 @@ describe('authStore', () => {
       'Logowanie jest chwilowo niedostępne. Spróbuj ponownie za chwilę.'
     );
     expect(useAuthStore.getState().authError).not.toMatch(/ENOTFOUND|postgres|tenant/i);
+    expect(useAuthStore.getState().isSubmitting).toBe(false);
+  });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Issue #1547 — prevent duplicate authentication requests
+  // Date: 2026-07-22
+  // Bug: concurrent submitAuth calls started multiple login requests.
+  // Fix: keep a submission lock until the original request settles.
+  // ─────────────────────────────────────────────────────────────────
+  test('Regression: Issue #1547 — ignores a second login while the first is pending', async () => {
+    let resolveLogin: (value: unknown) => void = () => {};
+    mocks.login.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveLogin = resolve;
+        })
+    );
+    useAuthStore.getState().setAuthMode('login');
+    useAuthStore.getState().setAuthDraft({ email: 'a@example.com', password: 'pass123' });
+
+    const firstSubmission = useAuthStore.getState().submitAuth();
+    const secondSubmission = useAuthStore.getState().submitAuth();
+
+    expect(mocks.login).toHaveBeenCalledTimes(1);
+    expect(useAuthStore.getState().isSubmitting).toBe(true);
+
+    resolveLogin({
+      user: { id: 'u1', email: 'a@example.com' },
+      workspaceId: 'ws1',
+      token: 'token-1',
+    });
+    await Promise.all([firstSubmission, secondSubmission]);
+
+    expect(useAuthStore.getState().isSubmitting).toBe(false);
   });
 
   test('submitAuth rejects remote auth responses without backend token', async () => {

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -41,6 +41,7 @@ export const useAuthStore = create<any>((set, get) => ({
   authMode: 'register',
   authDraft: EMPTY_AUTH_DRAFT,
   authError: '',
+  isSubmitting: false,
   googleAuthMessage: '',
   resetDraft: EMPTY_RESET_DRAFT,
   resetMessage: '',
@@ -81,7 +82,9 @@ export const useAuthStore = create<any>((set, get) => ({
     })),
 
   submitAuth: async () => {
-    set({ authError: '', resetMessage: '' });
+    if (get().isSubmitting) return;
+
+    set({ authError: '', resetMessage: '', isSubmitting: true });
     const { authMode, authDraft } = get();
     const { users, workspaces, setUsers, setWorkspaces, setSession } = useWorkspaceStore.getState();
 
@@ -107,6 +110,8 @@ export const useAuthStore = create<any>((set, get) => ({
       });
     } catch (error: any) {
       set({ authError: normalizeAuthErrorMessage(error) });
+    } finally {
+      set({ isSubmitting: false });
     }
   },
 

--- a/tests/e2e/auth-session.spec.ts
+++ b/tests/e2e/auth-session.spec.ts
@@ -1,0 +1,72 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Authentication session scenarios', () => {
+  // ─────────────────────────────────────────────────────────────────
+  // Issue #1547 — AUTH-001: prevent duplicate login submissions
+  // Date: 2026-07-22
+  // Bug: the login action remains enabled while the remote request is pending.
+  // Expected: one visible submission enters a non-interactive pending state.
+  // ─────────────────────────────────────────────────────────────────
+  test('AUTH-001 blocks a duplicate visible login submission while authentication is pending', async ({
+    page,
+  }) => {
+    let loginRequests = 0;
+    let resolveLogin: (() => void) | undefined;
+    const loginPending = new Promise<void>((resolve) => {
+      resolveLogin = resolve;
+    });
+
+    await page.route('**/auth/login', async (route) => {
+      loginRequests += 1;
+      await loginPending;
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          token: 'e2e-session-token',
+          user: { id: 'e2e-user', email: 'owner@example.test', name: 'QA Owner' },
+          workspaceId: 'e2e-workspace',
+        }),
+      });
+    });
+    await page.route('**/state/bootstrap?*', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          workspaceId: 'e2e-workspace',
+          users: [
+            {
+              id: 'e2e-user',
+              email: 'owner@example.test',
+              name: 'QA Owner',
+              workspaceMemberRole: 'owner',
+            },
+          ],
+          workspaces: [
+            {
+              id: 'e2e-workspace',
+              name: 'QA Workspace',
+              memberIds: ['e2e-user'],
+              memberRoles: { 'e2e-user': 'owner' },
+            },
+          ],
+        }),
+      });
+    });
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Logowanie' }).click();
+    await page.getByLabel('Adres email').fill('owner@example.test');
+    await page.getByLabel(/Has/i).fill('safe-e2e-password');
+
+    const submit = page.getByRole('button', { name: /Zaloguj/i });
+    await submit.click();
+    await expect.poll(() => loginRequests).toBe(1);
+    await expect(submit).toBeDisabled();
+    await expect.poll(() => loginRequests).toBe(1);
+
+    resolveLogin?.();
+    await expect(page.locator('.auth-shell')).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
Closes #1547

## Summary

- Add a store-level submission lock for login and registration requests.
- Disable the visible authentication action while a request is pending and expose `aria-busy`.
- Add unit, component, and deterministic remote-mode Playwright regression coverage for AUTH-001.

## Evidence

- RED: Chromium reproduced the enabled pending login control; the store test reproduced two login calls.
- GREEN: `src/store/authStore.test.ts`, `src/components/auth/AuthCredentialsForm.test.tsx`, `src/AuthScreen.test.tsx`, and `src/AuthScreen.a11y.test.tsx` — 22 passed.
- `PLAYWRIGHT_BASE_URL=http://localhost:3012 PLAYWRIGHT_API_BASE_URL=http://localhost:3012 PLAYWRIGHT_SKIP_WEB_SERVER=true PLAYWRIGHT_DATA_PROVIDER=remote pnpm exec playwright test tests/e2e/auth-session.spec.ts --project=chromium` — 1 passed.
- `pnpm run typecheck:all`, `pnpm run lint:all`, `pnpm run audit:mojibake` — passed.

## Risk / follow-up

The browser test uses only an intercepted synthetic auth response and does not send credentials or payloads to a remote service. #1538 remains blocked pending this fix and its remaining AUTH-002 through AUTH-004 coverage.