### PR TITLE
ci: preserve setup action across bundle checkout mutations

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -18,11 +18,22 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         if: github.event_name == 'pull_request'
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: Checkout code (dependabot)
         uses: actions/checkout@v7
         if: github.event_name == 'pull_request_target'
+
+      # A pull request may predate the repository-owned composite action. The
+      # default pull_request checkout uses the synthetic merge commit, so the
+      # current main-branch action is available without executing an explicit
+      # stale PR-head checkout.
+      - name: Preserve repository-owned setup action
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/setup-node-pnpm-action"
+          mkdir -p "$RUNNER_TEMP/setup-node-pnpm-action"
+          cp -R .github/actions/setup-node-pnpm/. "$RUNNER_TEMP/setup-node-pnpm-action/"
+
       - uses: ./.github/actions/setup-node-pnpm
         with:
           install-profile: native
@@ -141,9 +152,18 @@ jobs:
             }
 
       # compressed-size-action checks out main to compare bundle output. Restore
-      # the PR tree so the post step of the local setup action can load action.yml.
+      # the PR tree before the composite action's nested post steps run.
       - name: Restore pull request checkout for action cleanup
         if: always() && github.event_name == 'pull_request'
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Restore repository-owned setup action for post steps
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "$RUNNER_TEMP/setup-node-pnpm-action/action.yml"
+          mkdir -p .github/actions/setup-node-pnpm
+          cp -R "$RUNNER_TEMP/setup-node-pnpm-action/." .github/actions/setup-node-pnpm/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,11 @@ jobs:
       - name: Repo hygiene audit
         run: pnpm run audit:repo-hygiene
 
+      - name: Bundle workflow checkout regression
+        run: |
+          pnpm exec vitest run -c vitest.scripts.config.ts scripts/bundle-workflow-checkout-regression.test.ts --coverage.enabled=false
+          node scripts/validate-github-workflows.mjs
+
       - name: UI action contract audit
         run: pnpm run test:ui-actions:contract
 

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -46,6 +46,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+
+      - name: Preserve repository-owned setup action
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm -rf "$RUNNER_TEMP/setup-node-pnpm-action"
+          mkdir -p "$RUNNER_TEMP/setup-node-pnpm-action"
+          cp -R .github/actions/setup-node-pnpm/. "$RUNNER_TEMP/setup-node-pnpm-action/"
+
       - uses: ./.github/actions/setup-node-pnpm
         with:
           install-profile: native
@@ -57,12 +66,21 @@ jobs:
           build-script: 'pnpm run build'
 
       # compressed-size-action checks out main to compare bundle output. Restore
-      # the PR tree so the post step of the local setup action can load action.yml.
+      # the PR tree before the composite action's nested post steps run.
       - name: Restore pull request checkout for action cleanup
         if: always()
         uses: actions/checkout@v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Restore repository-owned setup action for post steps
+        if: always()
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -f "$RUNNER_TEMP/setup-node-pnpm-action/action.yml"
+          mkdir -p .github/actions/setup-node-pnpm
+          cp -R "$RUNNER_TEMP/setup-node-pnpm-action/." .github/actions/setup-node-pnpm/
 
   security-scan:
     runs-on: ubuntu-latest

--- a/scripts/bundle-workflow-checkout-regression.test.ts
+++ b/scripts/bundle-workflow-checkout-regression.test.ts
@@ -1,0 +1,100 @@
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+import { parse } from 'yaml';
+
+interface WorkflowStep {
+  name?: string;
+  if?: string;
+  run?: string;
+  uses?: string;
+  with?: Record<string, unknown>;
+}
+
+interface WorkflowDefinition {
+  jobs?: Record<string, { steps?: WorkflowStep[] }>;
+}
+
+const workflowDir = path.resolve('.github/workflows');
+const setupAction = './.github/actions/setup-node-pnpm';
+const compressedSizeActionPrefix = 'preactjs/compressed-size-action@';
+
+function readWorkflow(name: string): WorkflowDefinition {
+  return parse(readFileSync(path.join(workflowDir, name), 'utf8')) as WorkflowDefinition;
+}
+
+function expectPostSafeBundleSequence(workflowName: string, steps: WorkflowStep[]) {
+  const preserveIndex = steps.findIndex(
+    (step) => step.name === 'Preserve repository-owned setup action'
+  );
+  const setupIndex = steps.findIndex((step) => step.uses === setupAction);
+  const compressedSizeIndex = steps.findIndex((step) =>
+    step.uses?.startsWith(compressedSizeActionPrefix)
+  );
+  const restoreCheckoutIndex = steps.findIndex(
+    (step) => step.name === 'Restore pull request checkout for action cleanup'
+  );
+  const restoreActionIndex = steps.findIndex(
+    (step) => step.name === 'Restore repository-owned setup action for post steps'
+  );
+
+  expect(preserveIndex, `${workflowName} preserve action step`).toBeGreaterThanOrEqual(0);
+  expect(setupIndex, `${workflowName} canonical setup step`).toBeGreaterThan(preserveIndex);
+  expect(compressedSizeIndex, `${workflowName} compressed-size step`).toBeGreaterThan(setupIndex);
+  expect(restoreCheckoutIndex, `${workflowName} checkout restore step`).toBeGreaterThan(
+    compressedSizeIndex
+  );
+  expect(restoreActionIndex, `${workflowName} action restore step`).toBeGreaterThan(
+    restoreCheckoutIndex
+  );
+
+  expect(steps[preserveIndex]?.run, `${workflowName} preserve command`).toContain(
+    '$RUNNER_TEMP/setup-node-pnpm-action'
+  );
+  expect(steps[preserveIndex]?.run, `${workflowName} preserve source`).toContain(
+    'cp -R .github/actions/setup-node-pnpm/.'
+  );
+  expect(steps[restoreActionIndex]?.if, `${workflowName} action restore condition`).toBe('always()');
+  expect(steps[restoreActionIndex]?.run, `${workflowName} action restore guard`).toContain(
+    'test -f "$RUNNER_TEMP/setup-node-pnpm-action/action.yml"'
+  );
+  expect(steps[restoreActionIndex]?.run, `${workflowName} action restore target`).toContain(
+    'mkdir -p .github/actions/setup-node-pnpm'
+  );
+}
+
+describe('bundle workflow checkout regression', () => {
+  // -----------------------------------------------------------------
+  // Issue #1514 — stale pull-request heads and compressed-size checkout
+  // Date: 2026-07-22
+  // Bug: a PR created before the local setup action existed could not start
+  //      Bundle Size Monitor. After compressed-size-action changed checkout,
+  //      nested post steps could also lose the repository-owned action path.
+  // Fix: use the synthetic merge checkout and preserve the action in RUNNER_TEMP
+  //      before restoring it for post-step execution.
+  // -----------------------------------------------------------------
+  it('uses the merge checkout before running the local action on pull requests', () => {
+    const workflow = readWorkflow('bundle-size.yml');
+    const steps = workflow.jobs?.['bundle-size']?.steps ?? [];
+    const checkout = steps.find((step) => step.name === 'Checkout code');
+
+    expect(checkout?.uses).toBe('actions/checkout@v7');
+    expect(checkout?.if).toBe("github.event_name == 'pull_request'");
+    expect(checkout?.with?.ref).toBeUndefined();
+  });
+
+  it('keeps the setup action available through standalone bundle comparison checkout changes', () => {
+    const workflow = readWorkflow('bundle-size.yml');
+    const steps = workflow.jobs?.['bundle-size']?.steps ?? [];
+
+    expectPostSafeBundleSequence('bundle-size.yml', steps);
+  });
+
+  it('keeps the setup action available through code-review bundle checkout changes', () => {
+    const workflow = readWorkflow('code-review.yml');
+    const steps = workflow.jobs?.['bundle-size']?.steps ?? [];
+
+    expectPostSafeBundleSequence('code-review.yml', steps);
+  });
+});


### PR DESCRIPTION
Closes #1514

## Summary

- use the synthetic pull-request merge checkout in the standalone Bundle Size Monitor so repository-owned CI tooling remains available even for stale PR heads,
- preserve `.github/actions/setup-node-pnpm` in `RUNNER_TEMP` before `preactjs/compressed-size-action` changes the workspace checkout,
- restore the repository-owned action after the PR-head checkout so nested composite-action post steps can complete,
- apply the same post-safe sequence to the Code Review bundle-size job,
- add focused regression coverage for checkout order, action preservation, and post-step restoration,
- execute the focused regression in the required CI Quality Gates job.

## Root cause

Two related checkout states caused the release signal to fail:

1. `bundle-size.yml` explicitly checked out the PR head. PRs created before the shared setup action existed therefore could not resolve `./.github/actions/setup-node-pnpm`.
2. `compressed-size-action` changes the checkout while comparing the PR with `main`. Restoring a stale PR head removed the repository-owned action before the composite action's nested post steps ran.

## Changed files

- `.github/workflows/bundle-size.yml`
- `.github/workflows/code-review.yml`
- `.github/workflows/ci.yml`
- `scripts/bundle-workflow-checkout-regression.test.ts`

## Automated regression

The CI Quality Gates job now executes:

```bash
pnpm exec vitest run -c vitest.scripts.config.ts scripts/bundle-workflow-checkout-regression.test.ts --coverage.enabled=false
node scripts/validate-github-workflows.mjs
```

The focused test verifies:

- standalone pull-request bundle checks use the synthetic merge checkout,
- the repository-owned setup action is preserved before `compressed-size-action`,
- the PR checkout is restored after bundle comparison,
- the setup action is restored before nested post steps run,
- the same ordered contract applies to both bundle workflows.

## Required GitHub evidence

- Bundle Size Monitor completes from initialization through post steps,
- Code Review `bundle-size` completes from initialization through post steps,
- CI Quality Gates passes the new focused regression,
- CI, Docker Build, CodeQL, E2E and security audit remain green,
- no required check is skipped or weakened.

## Security and behavior

- no workflow permissions were expanded,
- no `continue-on-error` was added,
- the canonical Node 22 and pnpm 9.12.1 setup action remains authoritative,
- dependency audit remediation from #1545 is unchanged,
- application runtime behavior is unaffected.

## Rollback

Revert this PR to restore the previous checkout sequence. No application or production data migration is involved.