### PR TITLE
[Auth][P0] Stop remote workspace polling after session expiry

### DIFF
--- a/src/components/MeetingsSyncManager.test.tsx
+++ b/src/components/MeetingsSyncManager.test.tsx
@@ -1,12 +1,19 @@
 import { describe, test, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import MeetingsSyncManager from './MeetingsSyncManager';
+import useWorkspaceData from '../hooks/useWorkspaceData';
 
 vi.mock('../hooks/useWorkspaceData', () => ({
   default: vi.fn(),
 }));
 
 describe('MeetingsSyncManager', () => {
+  test('Regression: #1549 — does not create a second workspace synchronization owner', () => {
+    render(<MeetingsSyncManager />);
+
+    expect(useWorkspaceData).not.toHaveBeenCalled();
+  });
+
   test('renders children when provided', () => {
     render(
       <MeetingsSyncManager>

--- a/src/components/MeetingsSyncManager.tsx
+++ b/src/components/MeetingsSyncManager.tsx
@@ -1,7 +1,5 @@
 import { ReactNode } from 'react';
-import useWorkspaceData from '../hooks/useWorkspaceData';
 
 export default function MeetingsSyncManager({ children }: { children?: ReactNode }) {
-  useWorkspaceData();
   return <>{children}</>;
 }

--- a/src/hooks/useWorkspaceData.test.tsx
+++ b/src/hooks/useWorkspaceData.test.tsx
@@ -478,6 +478,30 @@ describe('useWorkspaceData', () => {
     unmount();
   });
 
+  test('Regression: #1549 — stops remote bootstrap polling after a controlled 401', async () => {
+    vi.useFakeTimers();
+    stateServiceMock.mode = 'remote';
+    workspaceState.session = { token: 'expired-token', userId: 'u1', workspaceId: 'ws1' };
+    const unauthorized = Object.assign(new Error('Sesja wygasła.'), { status: 401 });
+    stateServiceMock.bootstrap.mockRejectedValue(unauthorized);
+
+    const { unmount } = renderHook(() => useWorkspaceData());
+
+    await act(async () => {
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+    expect(stateServiceMock.bootstrap).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(stateServiceMock.bootstrap).toHaveBeenCalledTimes(1);
+    expect(meetingsState.setWorkspaceMessage).not.toHaveBeenCalledWith('Sesja wygasła.');
+    unmount();
+  });
+
   test('blocks first remote bootstrap on hosted preview when health probe fails', async () => {
     vi.useFakeTimers();
     stateServiceMock.mode = 'remote';

--- a/src/hooks/useWorkspaceData.ts
+++ b/src/hooks/useWorkspaceData.ts
@@ -32,6 +32,14 @@ type PendingRemoteSync = {
   state: NormalizedWorkspaceState;
   snapshot: string;
 };
+type StateService = ReturnType<typeof createStateService>;
+type BootstrapPromise = ReturnType<StateService['bootstrap']>;
+type PendingRemoteBootstrap = {
+  key: string;
+  promise: BootstrapPromise;
+};
+
+let pendingRemoteBootstrap: PendingRemoteBootstrap | null = null;
 
 function isBackendUnavailableMessage(message = '') {
   return (
@@ -46,6 +54,33 @@ function isBackendUnavailableMessage(message = '') {
       .includes('browser offline') ||
     isTransportErrorMessage(message)
   );
+}
+
+function isUnauthorizedError(error: unknown) {
+  const details = error as { status?: unknown; statusCode?: unknown } | null | undefined;
+  return Number(details?.status || details?.statusCode || 0) === 401;
+}
+
+function requestRemoteWorkspaceBootstrap(
+  stateService: StateService,
+  workspaceId: string,
+  sessionToken: string
+): BootstrapPromise {
+  const key = `${workspaceId}:${sessionToken}`;
+  if (pendingRemoteBootstrap?.key === key) {
+    return pendingRemoteBootstrap.promise;
+  }
+
+  const promise = stateService.bootstrap(workspaceId);
+  pendingRemoteBootstrap = { key, promise };
+  void promise
+    .finally(() => {
+      if (pendingRemoteBootstrap?.promise === promise) {
+        pendingRemoteBootstrap = null;
+      }
+    })
+    .catch(() => undefined);
+  return promise;
 }
 
 export default function useWorkspaceData() {
@@ -97,14 +132,42 @@ export default function useWorkspaceData() {
   const pendingRemoteSyncRef = useRef<PendingRemoteSync | null>(null);
   const migrationAppliedRef = useRef<string | null>(null);
   const skipRemotePullCooldownOnceRef = useRef(false);
+  const sessionInvalidatedRef = useRef(false);
+  const activeSessionTokenRef = useRef('');
 
   const [isHydratingRemoteState, setIsHydratingRemoteState] = useState(
     stateService?.mode === 'remote' && Boolean(session?.token)
   );
 
+  const stopRemoteWorkForInvalidSession = useCallback(() => {
+    sessionInvalidatedRef.current = true;
+    remotePullCooldownUntilRef.current = Number.POSITIVE_INFINITY;
+    pendingRemoteSyncRef.current = null;
+
+    if (syncTimerRef.current !== null) {
+      window.clearTimeout(syncTimerRef.current);
+      syncTimerRef.current = null;
+    }
+    if (remotePollTimerRef.current !== null) {
+      window.clearTimeout(remotePollTimerRef.current);
+      remotePollTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    const nextToken = String(session?.token || '');
+    if (nextToken && nextToken !== activeSessionTokenRef.current) {
+      sessionInvalidatedRef.current = false;
+      remotePullCooldownUntilRef.current = 0;
+      hydratedWorkspaceIdRef.current = '';
+      remoteSnapshotRef.current = '';
+    }
+    activeSessionTokenRef.current = nextToken;
+  }, [session?.token]);
+
   const applyRemoteWorkspaceState = useCallback(
     (result: any) => {
-      if (!result) return;
+      if (!result || sessionInvalidatedRef.current) return;
 
       if (Array.isArray(result.users)) {
         setUsers(result.users);
@@ -227,7 +290,7 @@ export default function useWorkspaceData() {
 
   const flushRemoteWorkspaceState = useCallback(
     async (requestedState: NormalizedWorkspaceState, requestedSnapshot: string) => {
-      if (!currentWorkspaceId) {
+      if (!currentWorkspaceId || sessionInvalidatedRef.current) {
         return;
       }
 
@@ -245,6 +308,9 @@ export default function useWorkspaceData() {
 
       try {
         while (stateToSync) {
+          if (sessionInvalidatedRef.current) {
+            break;
+          }
           pendingRemoteSyncRef.current = null;
           const delta = buildWorkspaceStateDelta(remoteStateRef.current, stateToSync);
           if (Object.keys(delta).length > 0) {
@@ -325,9 +391,17 @@ export default function useWorkspaceData() {
       return undefined;
     }
 
-    if (!session?.token || !session?.userId) {
+    if (!session?.token || !session?.userId || sessionInvalidatedRef.current) {
       setPreviewRuntimeStatus('unknown');
       hydratedWorkspaceIdRef.current = '';
+      setIsHydratingRemoteState(false);
+      return undefined;
+    }
+
+    if (
+      hydratedWorkspaceIdRef.current === session.workspaceId &&
+      remoteSnapshotRef.current.length > 0
+    ) {
       setIsHydratingRemoteState(false);
       return undefined;
     }
@@ -336,6 +410,9 @@ export default function useWorkspaceData() {
     setIsHydratingRemoteState(true);
 
     const attemptBootstrap = async (recoveryAttempt = 0) => {
+      if (cancelled || sessionInvalidatedRef.current) {
+        return;
+      }
       const canConnect = await ensureHostedPreviewConnectivity();
       if (cancelled || !canConnect) {
         if (!cancelled) {
@@ -350,13 +427,22 @@ export default function useWorkspaceData() {
 
       isBootstrappingRef.current = true;
       try {
-        const result = await stateService.bootstrap(session.workspaceId);
+        const result = await requestRemoteWorkspaceBootstrap(
+          stateService,
+          session.workspaceId,
+          session.token
+        );
         if (cancelled || !result) {
           return;
         }
         applyRemoteWorkspaceState(result);
       } catch (error: any) {
         if (cancelled) {
+          return;
+        }
+
+        if (isUnauthorizedError(error)) {
+          stopRemoteWorkForInvalidSession();
           return;
         }
         applyRemoteTransportCooldown(error);
@@ -397,6 +483,7 @@ export default function useWorkspaceData() {
     session?.userId,
     session?.workspaceId,
     stateService,
+    stopRemoteWorkForInvalidSession,
   ]);
 
   useEffect(() => {
@@ -404,7 +491,12 @@ export default function useWorkspaceData() {
       return undefined;
     }
 
-    if (!session?.token || !currentWorkspaceId || isHydratingRemoteState) {
+    if (
+      !session?.token ||
+      !currentWorkspaceId ||
+      isHydratingRemoteState ||
+      sessionInvalidatedRef.current
+    ) {
       return undefined;
     }
 
@@ -470,7 +562,12 @@ export default function useWorkspaceData() {
       return undefined;
     }
 
-    if (!session?.token || !currentWorkspaceId || isHydratingRemoteState) {
+    if (
+      !session?.token ||
+      !currentWorkspaceId ||
+      isHydratingRemoteState ||
+      sessionInvalidatedRef.current
+    ) {
       return undefined;
     }
 
@@ -491,7 +588,7 @@ export default function useWorkspaceData() {
     };
 
     const pullRemoteWorkspaceState = () => {
-      if (cancelled) return;
+      if (cancelled || sessionInvalidatedRef.current) return;
 
       // Skip when hidden, offline, or circuit breaker is open
       if (typeof document !== 'undefined' && document.visibilityState === 'hidden') {
@@ -527,7 +624,11 @@ export default function useWorkspaceData() {
             return;
           }
 
-          const result = await stateService.bootstrap(currentWorkspaceId);
+          const result = await requestRemoteWorkspaceBootstrap(
+            stateService,
+            currentWorkspaceId,
+            String(session?.token || '')
+          );
           if (cancelled || !result?.state) {
             consecutivePollFailures = 0;
             return;
@@ -541,6 +642,11 @@ export default function useWorkspaceData() {
 
           consecutivePollFailures = 0;
         } catch (error) {
+          if (isUnauthorizedError(error)) {
+            stopRemoteWorkForInvalidSession();
+            cancelled = true;
+            return;
+          }
           consecutivePollFailures += 1;
           applyRemoteTransportCooldown(error);
           logRemoteErrorOnce('Remote workspace pull failed.', error);
@@ -576,6 +682,7 @@ export default function useWorkspaceData() {
     pushWorkspaceMessage,
     session?.token,
     stateService,
+    stopRemoteWorkForInvalidSession,
   ]);
 
   const userMeetings = useMemo(

--- a/tests/e2e/auth-session.spec.ts
+++ b/tests/e2e/auth-session.spec.ts
@@ -69,4 +69,125 @@ test.describe('Authentication session scenarios', () => {
     resolveLogin?.();
     await expect(page.locator('.auth-shell')).not.toBeVisible();
   });
+
+  // ─────────────────────────────────────────────────────────────────
+  // Issue #1549 — stop workspace polling after session expiry
+  // Date: 2026-07-22
+  // Bug: a controlled bootstrap 401 left repeated protected polling active.
+  // Fix: one sync owner cancels bootstrap and poll timers until a new token exists.
+  // ─────────────────────────────────────────────────────────────────
+  test('Regression: Issue #1549 — one bootstrap 401 clears the session without further protected polls', async ({
+    page,
+  }) => {
+    let sessionExpired = false;
+    let bootstrapRequests = 0;
+    let unauthorizedBootstrapRequests = 0;
+
+    const user = { id: 'e2e-user', email: 'owner@example.test', name: 'QA Owner' };
+    const workspace = {
+      id: 'e2e-workspace',
+      name: 'QA Workspace',
+      memberIds: [user.id],
+      memberRoles: { [user.id]: 'owner' },
+    };
+    const readyCapabilities = {
+      ok: true,
+      status: 'ready',
+      capabilities: {},
+      degradedCapabilities: [],
+      telemetry: { fallbackModeUsed: false, fallbackModeCapabilities: [] },
+    };
+
+    await page.route('**/auth/login', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ token: 'e2e-session-token', user, workspaceId: workspace.id }),
+      })
+    );
+    await page.route('**/state/bootstrap?*', (route) => {
+      bootstrapRequests += 1;
+      if (sessionExpired) {
+        unauthorizedBootstrapRequests += 1;
+        return route.fulfill({
+          status: 401,
+          contentType: 'application/json',
+          body: JSON.stringify({ message: 'Sesja wygasła.' }),
+        });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          workspaceId: workspace.id,
+          users: [user],
+          workspaces: [workspace],
+          state: {
+            meetings: [],
+            manualTasks: [],
+            manualPeople: [],
+            taskState: {},
+            taskBoards: {},
+            calendarMeta: {},
+            vocabulary: [],
+          },
+        }),
+      });
+    });
+    await page.route('**/api/capabilities', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(readyCapabilities),
+      })
+    );
+    await page.route('**/workspaces/*/capabilities', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(readyCapabilities),
+      })
+    );
+    await page.route('**/voice-profiles', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ profiles: [] }),
+      })
+    );
+
+    await page.goto('/');
+    await page.getByRole('button', { name: 'Logowanie' }).click();
+    await page.getByLabel('Adres email').fill(user.email);
+    await page.getByLabel('Hasło').fill('safe-e2e-password');
+    await page.getByRole('button', { name: 'Zaloguj się' }).click();
+    await expect(page.locator('.app-shell-modern')).toBeVisible();
+    await expect.poll(() => bootstrapRequests).toBeGreaterThanOrEqual(1);
+    expect(bootstrapRequests).toBe(1);
+
+    sessionExpired = true;
+    const navItem = page.locator('.modern-nav-item').filter({ hasText: 'Nagrania' }).first();
+    await expect(navItem).toBeVisible();
+    await navItem.click();
+
+    await expect.poll(() => unauthorizedBootstrapRequests, { timeout: 12_000 }).toBe(1);
+    await expect(page.locator('.auth-shell')).toBeVisible();
+    await expect(page.locator('.app-shell-modern')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Logowanie' })).toBeVisible();
+    expect(
+      await page.evaluate(() => {
+        const session = JSON.parse(window.localStorage.getItem('voicelog.session.v3') || 'null');
+        const workspaceStore = JSON.parse(
+          window.localStorage.getItem('voicelog_workspace_store') || 'null'
+        );
+        return Boolean(session?.token || workspaceStore?.state?.session?.token);
+      })
+    ).toBe(false);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(page.getByRole('button', { name: 'Logowanie' })).toBeVisible();
+    expect(
+      await page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth)
+    ).toBe(true);
+  });
 });


### PR DESCRIPTION
## Summary

- remove the duplicate `useWorkspaceData` owner from `MeetingsSyncManager`
- deduplicate concurrent workspace bootstraps by workspace and session token
- fail closed on bootstrap `401`: cancel sync/poll timers, ignore late data, and resume only after a new token
- add unit and Chromium regression coverage for one controlled `401` with no subsequent protected poll

Closes #1549

## RED to GREEN evidence

Before the fix:

- `MeetingsSyncManager` invoked a second sync owner.
- `useWorkspaceData` made four bootstrap calls after a controlled `401` in the focused unit test.
- Chromium observed seven bootstrap requests before expiry and repeated `401` requests after expiry.

After the fix:

- one bootstrap is observed before expiry;
- exactly one controlled `401` is observed after expiry;
- the UI returns to login, clears persisted session state, and does not retain an interactive workspace shell.

## Validation

- `pnpm exec vitest run src/hooks/useWorkspaceData.test.tsx src/components/MeetingsSyncManager.test.tsx --coverage.enabled=false` — 22 passed
- `pnpm exec playwright test tests/e2e/auth-session.spec.ts --project=chromium` — 2 passed
- `pnpm run typecheck:all` — passed
- `pnpm run lint:all` — passed
- `pnpm run audit:mojibake` — passed
- `pnpm run test:release:guard` — passed (1,575 server tests; 84 critical tests; production build)

## Residual risk

The local environment uses Node 24 with the repository's pnpm 9.12.1, while CI is pinned to Node 22. The behavior is covered by deterministic mocked remote API E2E; a separate remote/staging session-expiry run remains appropriate after CI is green.

## Rollback

Revert commit `3fccb76` to restore the previous workspace sync scheduling behavior.