### PR TITLE
test(auth): automate P0 session recovery scenarios

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -45,6 +45,9 @@ jobs:
           PLAYWRIGHT_JUNIT_OUTPUT_NAME: results.xml
           PLAYWRIGHT_HTML_OUTPUT: playwright-report
 
+      - name: Run authentication session scenarios
+        run: pnpm run test:e2e:auth-session
+
       - name: Run remote API workspace contract
         run: pnpm run test:e2e:remote-api
 

--- a/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
+++ b/docs/CODEX_PRODUCTION_READINESS_QUEUE.md
@@ -121,8 +121,9 @@ Issue `#1241` adds a dedicated deterministic browser audio gate:
 pnpm run test:e2e:audio
 ```
 
-The runner starts Playwright with `PLAYWRIGHT_MEDIA_PROVIDER=remote`, mocks browser
-capture APIs instead of using real microphone hardware, and exercises record,
+The runner starts Playwright with both `PLAYWRIGHT_DATA_PROVIDER=remote` and
+`PLAYWRIGHT_MEDIA_PROVIDER=remote`, so browser requests stay on the same-origin mock
+layer. It mocks capture APIs instead of using real microphone hardware, and exercises record,
 pause, resume, stop, upload, processing, retry, transcript attach, and fixture
 audio import paths.
 

--- a/docs/testing/ui-action-contracts.json
+++ b/docs/testing/ui-action-contracts.json
@@ -69,10 +69,10 @@
       "screen": "Recordings",
       "file": "src/RecordingsTab.tsx",
       "expectedActionCount": 25,
-      "fingerprint": "c72cd0ebc1873d7b",
+      "fingerprint": "6e5e8d9898af1345",
       "contractStatus": "covered",
       "testFiles": ["src/RecordingsTab.test.tsx", "src/RecordingsTab.toast-regression.test.tsx"],
-      "testEvidence": ["Ponow transkrypcje", "stale remote import is permanent"],
+      "testEvidence": ["Ponow transkrypcje", "stale remote import is permanent", "Zaloguj ponownie i ponów upload"],
       "owner": "frontend-recordings"
     },
     {

--- a/package.json
+++ b/package.json
@@ -144,6 +144,7 @@
     "coverage:summary": "node scripts/coverage-summary.cjs",
     "test:e2e": "playwright test",
     "test:e2e:audio": "node scripts/run-audio-playwright.mjs",
+    "test:e2e:auth-session": "node scripts/run-auth-session-playwright.mjs",
     "test:e2e:release": "playwright test tests/e2e/smoke.spec.js tests/e2e/advanced-journeys.spec.js tests/e2e/remote-api.spec.js",
     "test:e2e:remote-api": "node scripts/run-remote-api-playwright.mjs",
     "test:e2e:production-system": "playwright test tests/e2e/production-system-audit.spec.js --project=chromium",

--- a/scripts/release-readiness.test.ts
+++ b/scripts/release-readiness.test.ts
@@ -926,6 +926,15 @@ describe('release readiness gates', () => {
     expect(remoteApiRunner).toContain("PLAYWRIGHT_MEDIA_PROVIDER: 'remote'");
   });
 
+  it('runs the deterministic audio browser gate through the same-origin remote mock layer', () => {
+    const audioRunner = read('scripts/run-audio-playwright.mjs');
+
+    expect(audioRunner).toContain("PLAYWRIGHT_DATA_PROVIDER: 'remote'");
+    expect(audioRunner).toContain("VITE_DATA_PROVIDER: 'remote'");
+    expect(audioRunner).toContain("PLAYWRIGHT_MEDIA_PROVIDER: 'remote'");
+    expect(audioRunner).toContain("VITE_MEDIA_PROVIDER: 'remote'");
+  });
+
   it('keeps release-critical UI/config surfaces free of mojibake', () => {
     expect(findMojibakeIssues()).toEqual([]);
   }, 20_000);

--- a/scripts/run-auth-session-playwright.mjs
+++ b/scripts/run-auth-session-playwright.mjs
@@ -1,22 +1,15 @@
 import { spawnSync } from 'node:child_process';
 import { createRequire } from 'node:module';
 import path from 'node:path';
-import { fileURLToPath } from 'node:url';
 
-const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const require = createRequire(import.meta.url);
-const viteBinary = path.join(
-  repoRoot,
-  'node_modules',
-  '.bin',
-  process.platform === 'win32' ? 'vite.cmd' : 'vite'
-);
 const playwrightPackageRoot = path.dirname(require.resolve('@playwright/test'));
 const playwrightCli = path.join(playwrightPackageRoot, 'cli.js');
 const args = [
   'test',
-  'tests/e2e/audio-pipeline.spec.ts',
+  'tests/e2e/auth-session.spec.ts',
   '--project=chromium',
+  '--workers=1',
   ...process.argv.slice(2),
 ];
 
@@ -28,13 +21,11 @@ const result = spawnSync(process.execPath, [playwrightCli, ...args], {
     PLAYWRIGHT_MEDIA_PROVIDER: 'remote',
     VITE_DATA_PROVIDER: 'remote',
     VITE_MEDIA_PROVIDER: 'remote',
-    PLAYWRIGHT_WEB_COMMAND:
-      process.env.PLAYWRIGHT_WEB_COMMAND || `"${viteBinary}" --host 127.0.0.1 --port 3000`,
   },
 });
 
 if (result.error) {
-  console.error(result.error);
+  console.error(`[test:e2e:auth-session] Failed to start Playwright: ${result.error.message}`);
 }
 
 process.exit(result.status ?? 1);

--- a/src/RecordingsTab.test.tsx
+++ b/src/RecordingsTab.test.tsx
@@ -593,6 +593,58 @@ describe('RecordingsTab', () => {
     expect(retryRecordingQueueItem).toHaveBeenCalledWith('rec_stale_queued');
   });
 
+  // ─────────────────────────────────────────────────────────────────
+  // Issue #1538 — an expired upload had no recovery action in the imports list
+  // Date: 2026-07-22
+  // Bug: auth_required was rendered as an alert but retryLabel was empty.
+  // Fix: expose the explicit reauthentication-and-retry action.
+  // ─────────────────────────────────────────────────────────────────
+  test('Regression: Issue #1538 — expired import exposes reauthentication retry', () => {
+    const retryRecordingQueueItem = vi.fn();
+
+    render(
+      <ToastProvider>
+        <RecordingsTab
+          {...defaultProps}
+          userMeetings={[]}
+          retryRecordingQueueItem={retryRecordingQueueItem}
+          recordingQueue={[
+            {
+              id: 'rec_auth_retry',
+              recordingId: 'rec_auth_retry',
+              meetingId: 'meeting_auth_retry',
+              workspaceId: 'ws1',
+              meetingTitle: 'Import wymagający logowania',
+              meetingSnapshot: {
+                id: 'meeting_auth_retry',
+                workspaceId: 'ws1',
+                title: 'Import wymagający logowania',
+              },
+              mimeType: 'audio/webm',
+              rawSegments: [],
+              duration: 4,
+              status: 'auth_required',
+              uploaded: false,
+              attempts: 1,
+              retryCount: 0,
+              backoffUntil: 0,
+              lastErrorMessage: '',
+              errorMessage: 'Brak autoryzacji do backendu. Zaloguj sie ponownie.',
+              errorCode: 'AUTH_REQUIRED',
+              retryable: true,
+              createdAt: '2026-07-22T10:00:00.000Z',
+              updatedAt: '2026-07-22T10:00:00.000Z',
+            },
+          ]}
+        />
+      </ToastProvider>
+    );
+
+    expect(screen.getByRole('alert', { name: /Wymagane ponowne logowanie/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Zaloguj ponownie i ponów upload' }));
+    expect(retryRecordingQueueItem).toHaveBeenCalledWith('rec_auth_retry');
+  });
+
   test('Regression: failed import exposes retry action and retries the queue item', () => {
     const retryRecordingQueueItem = vi.fn();
 

--- a/src/RecordingsTab.tsx
+++ b/src/RecordingsTab.tsx
@@ -532,6 +532,7 @@ function isStalePendingImport(item: PendingImportQueueItem, nowMs = Date.now()) 
 
 function getPendingImportRetryLabel(item: PendingImportQueueItem) {
   const status = String(item?.status || '').toLowerCase();
+  if (status === 'auth_required') return 'Zaloguj ponownie i ponów upload';
   if (status === 'failed') return 'Spróbuj ponownie';
   if (isStalePendingImport(item)) return 'Odśwież status';
   return '';

--- a/src/services/mediaService.ts
+++ b/src/services/mediaService.ts
@@ -58,6 +58,12 @@ export interface PersistRecordingAudioResult {
   audioQuality?: unknown;
 }
 
+interface MediaTransportError extends Error {
+  status?: number;
+  statusCode?: number;
+  code?: string;
+}
+
 export interface StartTranscriptionJobInput {
   recordingId?: string;
   blob?: Blob | null;
@@ -457,9 +463,28 @@ function createRemoteMediaService(): MediaService {
           if (failed) {
             const reason = (failed as PromiseRejectedResult).reason;
             const failedIndex = batchStart + results.indexOf(failed);
-            throw new Error(
+            const failedDetails = reason as
+              | {
+                  status?: unknown;
+                  statusCode?: unknown;
+                  code?: unknown;
+                  message?: unknown;
+                }
+              | null
+              | undefined;
+            const uploadError = new Error(
               `Upload audio przerwany na fragmencie ${failedIndex + 1}/${total}. ${reason?.message || 'Backend jest chwilowo niedostepny. Sprobuj ponownie za chwile.'}`
-            );
+            ) as MediaTransportError;
+            const status = Number(failedDetails?.status ?? failedDetails?.statusCode);
+            if (Number.isFinite(status)) {
+              uploadError.status = status;
+              uploadError.statusCode = status;
+            }
+            const code = String(failedDetails?.code || '').trim();
+            if (code) {
+              uploadError.code = code;
+            }
+            throw uploadError;
           }
 
           uploaded = batchEnd;

--- a/src/testing/runtimeGuard.test.ts
+++ b/src/testing/runtimeGuard.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { createRuntimeGuard } from './runtimeGuard';
+
+describe('createRuntimeGuard', () => {
+  it('accepts a run without browser failures', () => {
+    const guard = createRuntimeGuard();
+
+    expect(() => guard.assertHealthy()).not.toThrow();
+  });
+
+  it('reports an unexpected page error', () => {
+    const guard = createRuntimeGuard();
+    guard.recordPageError(new Error('Unexpected render failure'));
+
+    expect(() => guard.assertHealthy()).toThrow(/Unexpected render failure/);
+  });
+
+  it('reports an unexpected console error', () => {
+    const guard = createRuntimeGuard();
+    guard.recordConsoleError('Unexpected runtime exception');
+
+    expect(() => guard.assertHealthy()).toThrow(/Unexpected runtime exception/);
+  });
+
+  it('reports an unexpected server error without retaining query parameters', () => {
+    const guard = createRuntimeGuard();
+    guard.recordResponse(500, 'https://api.example.test/state/bootstrap?token=secret');
+
+    expect(() => guard.assertHealthy()).toThrow(/https:\/\/api\.example\.test\/state\/bootstrap/);
+    expect(() => guard.assertHealthy()).not.toThrow(/token=secret/);
+  });
+
+  it('allows narrowly documented expected errors', () => {
+    const guard = createRuntimeGuard({
+      allowedConsoleErrors: [/expected browser warning/i],
+      allowedServerErrors: ['https://api.example.test/expected-outage'],
+    });
+    guard.recordConsoleError('Expected browser warning during controlled recovery');
+    guard.recordResponse(503, 'https://api.example.test/expected-outage?requestId=redacted');
+
+    expect(() => guard.assertHealthy()).not.toThrow();
+  });
+});

--- a/src/testing/runtimeGuard.ts
+++ b/src/testing/runtimeGuard.ts
@@ -1,0 +1,111 @@
+import type { ConsoleMessage, Page, Response } from '@playwright/test';
+
+export type RuntimeGuardRule = RegExp | string;
+
+export interface RuntimeGuardOptions {
+  allowedConsoleErrors?: RuntimeGuardRule[];
+  allowedServerErrors?: RuntimeGuardRule[];
+}
+
+export interface RuntimeGuard {
+  assertHealthy(): void;
+  recordConsoleError(message: string): void;
+  recordPageError(error: unknown): void;
+  recordResponse(status: number, url: string): void;
+  violations(): string[];
+}
+
+function matchesRule(value: string, rules: RuntimeGuardRule[]) {
+  return rules.some((rule) => {
+    if (typeof rule === 'string') {
+      return value.includes(rule);
+    }
+
+    rule.lastIndex = 0;
+    return rule.test(value);
+  });
+}
+
+function sanitizeRuntimeText(value: unknown) {
+  return String(value || '')
+    .replace(/(bearer\s+)[^\s,;]+/gi, '$1[redacted]')
+    .replace(/((?:token|password|cookie|authorization)\s*[=:]\s*)[^\s,;]+/gi, '$1[redacted]');
+}
+
+function sanitizeUrl(value: string) {
+  try {
+    const parsed = new URL(value);
+    return `${parsed.origin}${parsed.pathname}`;
+  } catch {
+    return String(value || '').split('?')[0];
+  }
+}
+
+export function createRuntimeGuard(options: RuntimeGuardOptions = {}): RuntimeGuard {
+  const allowedConsoleErrors = options.allowedConsoleErrors || [];
+  const allowedServerErrors = options.allowedServerErrors || [];
+  const unexpectedFailures: string[] = [];
+
+  const addFailure = (kind: string, value: unknown, rules: RuntimeGuardRule[] = []) => {
+    const sanitized = sanitizeRuntimeText(value);
+    if (matchesRule(sanitized, rules)) {
+      return;
+    }
+    unexpectedFailures.push(`${kind}: ${sanitized}`);
+  };
+
+  return {
+    recordPageError(error) {
+      const message =
+        error instanceof Error ? error.message : String(error || 'Unknown page error');
+      addFailure('pageerror', message);
+    },
+    recordConsoleError(message) {
+      addFailure('console.error', message, allowedConsoleErrors);
+    },
+    recordResponse(status, url) {
+      if (Number(status) < 500) {
+        return;
+      }
+      const sanitizedUrl = sanitizeUrl(url);
+      addFailure(`HTTP ${status}`, sanitizedUrl, allowedServerErrors);
+    },
+    assertHealthy() {
+      if (unexpectedFailures.length === 0) {
+        return;
+      }
+
+      throw new Error(
+        `Unexpected browser runtime failures:\n${unexpectedFailures.map((failure) => `- ${failure}`).join('\n')}`
+      );
+    },
+    violations() {
+      return [...unexpectedFailures];
+    },
+  };
+}
+
+export function installRuntimeGuard(page: Page, options: RuntimeGuardOptions = {}) {
+  const guard = createRuntimeGuard(options);
+  const onPageError = (error: Error) => guard.recordPageError(error);
+  const onConsole = (message: ConsoleMessage) => {
+    if (message.type() === 'error') {
+      guard.recordConsoleError(message.text());
+    }
+  };
+  const onResponse = (response: Response) =>
+    guard.recordResponse(response.status(), response.url());
+
+  page.on('pageerror', onPageError);
+  page.on('console', onConsole);
+  page.on('response', onResponse);
+
+  return {
+    ...guard,
+    dispose() {
+      page.off('pageerror', onPageError);
+      page.off('console', onConsole);
+      page.off('response', onResponse);
+    },
+  };
+}

--- a/tests/e2e/audio-pipeline.spec.ts
+++ b/tests/e2e/audio-pipeline.spec.ts
@@ -177,6 +177,87 @@ async function installFakeAudioCapture(page, mode: 'ready' | 'permission-denied'
   }, mode);
 }
 
+async function mockRemoteWorkspaceShell(page) {
+  const user = {
+    id: 'user_e2e',
+    email: 'e2e@voicelog.test',
+    name: 'E2E Tester',
+    workspaceMemberRole: 'owner',
+  };
+  const workspace = {
+    id: 'ws_e2e',
+    name: 'E2E Workspace',
+    memberIds: [user.id],
+    memberRoles: { [user.id]: 'owner' },
+  };
+  const capabilities = {
+    ok: true,
+    status: 'ready',
+    capabilities: {},
+    degradedCapabilities: [],
+    telemetry: {
+      fallbackModeUsed: false,
+      fallbackModeCapabilities: [],
+    },
+  };
+
+  await page.route('**/state/bootstrap?*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        workspaceId: workspace.id,
+        users: [user],
+        workspaces: [workspace],
+        state: {
+          meetings: [],
+          manualPeople: [],
+          manualTasks: [],
+          taskState: {},
+          taskBoards: {},
+          calendarMeta: {},
+          vocabulary: [],
+        },
+      }),
+    })
+  );
+  await page.route('**/api/capabilities', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(capabilities),
+    })
+  );
+  await page.route('**/workspaces/*/capabilities', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(capabilities),
+    })
+  );
+  await page.route('**/state/workspaces/*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true }),
+    })
+  );
+  await page.route('**/voice-profiles', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ profiles: [] }),
+    })
+  );
+  await page.route('**/integrations/google/status?*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ configured: false, connected: false, writable: false }),
+    })
+  );
+}
+
 async function mockRemoteAudioPipeline(page, options: AudioRouteOptions = {}) {
   const stats = {
     uploadRequests: 0,
@@ -361,6 +442,14 @@ async function mockRemoteAudioPipeline(page, options: AudioRouteOptions = {}) {
     });
   });
 
+  await page.route('**/media/recordings/*/progress*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: 'event: completed\ndata: {"status":"done"}\n\n',
+    })
+  );
+
   await page.route('**/media/analyze', async (route) => {
     await route.fulfill({
       status: 200,
@@ -399,6 +488,10 @@ async function mockRemoteAudioPipeline(page, options: AudioRouteOptions = {}) {
 
 test.describe('Audio recording pipeline E2E', () => {
   test.describe.configure({ mode: 'serial' });
+
+  test.beforeEach(async ({ page }) => {
+    await mockRemoteWorkspaceShell(page);
+  });
 
   test('records, pauses, resumes, uploads, processes, and attaches transcript', async ({
     page,

--- a/tests/e2e/auth-session.spec.ts
+++ b/tests/e2e/auth-session.spec.ts
@@ -1,73 +1,384 @@
-import { expect, test } from '@playwright/test';
+import { expect, test, type Page, type Route } from '@playwright/test';
+import { installRuntimeGuard } from '../../src/testing/runtimeGuard';
+import { fixtureAudioFile } from './fixtures/audioFixture.js';
+
+const QA_USER = {
+  id: 'e2e-user',
+  email: 'owner@example.test',
+  name: 'QA Owner',
+  workspaceMemberRole: 'owner',
+};
+const QA_WORKSPACE = {
+  id: 'e2e-workspace',
+  name: 'QA Workspace',
+  memberIds: [QA_USER.id],
+  memberRoles: { [QA_USER.id]: 'owner' },
+};
+const QA_PASSWORD = 'safe-e2e-password';
+
+type AuthRouteOptions = {
+  loginStatus?: 200 | 401;
+};
+
+function json(route: Route, body: unknown, status = 200) {
+  return route.fulfill({
+    status,
+    contentType: 'application/json',
+    body: JSON.stringify(body),
+  });
+}
+
+function authPayload() {
+  return {
+    token: 'e2e-session-token',
+    user: QA_USER,
+    workspaceId: QA_WORKSPACE.id,
+  };
+}
+
+function bootstrapPayload() {
+  return {
+    workspaceId: QA_WORKSPACE.id,
+    users: [QA_USER],
+    workspaces: [QA_WORKSPACE],
+    state: {
+      meetings: [],
+      manualTasks: [],
+      manualPeople: [],
+      taskState: {},
+      taskBoards: {},
+      calendarMeta: {},
+      vocabulary: [],
+    },
+  };
+}
+
+function readyCapabilitiesPayload() {
+  return {
+    ok: true,
+    status: 'ready',
+    capabilities: {},
+    degradedCapabilities: [],
+    telemetry: {
+      fallbackModeUsed: false,
+      fallbackModeCapabilities: [],
+    },
+  };
+}
+
+async function installAuthRoutes(page: Page, options: AuthRouteOptions = {}) {
+  const stats = { loginRequests: 0, bootstrapRequests: 0, unauthorizedBootstrapRequests: 0 };
+  const loginStatus = options.loginStatus || 200;
+  let sessionExpired = false;
+
+  await page.route('**/auth/login', async (route) => {
+    stats.loginRequests += 1;
+    if (loginStatus === 401) {
+      await json(route, { message: 'Nieprawidłowy email lub hasło.' }, 401);
+      return;
+    }
+    await json(route, authPayload());
+  });
+
+  await page.route('**/state/bootstrap?*', async (route) => {
+    stats.bootstrapRequests += 1;
+    if (sessionExpired) {
+      stats.unauthorizedBootstrapRequests += 1;
+      await json(route, { message: 'Sesja wygasła.' }, 401);
+      return;
+    }
+    await json(route, bootstrapPayload());
+  });
+
+  await page.route('**/api/capabilities', (route) => json(route, readyCapabilitiesPayload()));
+  await page.route('**/workspaces/*/capabilities', (route) =>
+    json(route, readyCapabilitiesPayload())
+  );
+  await page.route('**/voice-profiles', (route) => json(route, { profiles: [] }));
+  await page.route('**/state/workspaces/*', (route) => json(route, { ok: true }));
+
+  return {
+    stats,
+    expireSession() {
+      sessionExpired = true;
+    },
+  };
+}
+
+async function installUploadExpiryRoutes(page: Page) {
+  const stats = {
+    uploadRequests: 0,
+    transcriptionStartRequests: 0,
+    recordingIds: new Set<string>(),
+  };
+  let uploadAllowedAfterReauthentication = false;
+  let resolveUploadStarted: () => void = () => {};
+  const uploadStarted = new Promise<void>((resolve) => {
+    resolveUploadStarted = resolve;
+  });
+
+  const rememberRecording = (route: Route) => {
+    const segments = new URL(route.request().url()).pathname.split('/');
+    const recordingId = segments[segments.indexOf('recordings') + 1] || '';
+    if (recordingId) {
+      stats.recordingIds.add(recordingId);
+    }
+  };
+
+  await page.route('**/media/upload-policy', (route) =>
+    json(route, {
+      maxRawUploadBytes: 200 * 1024 * 1024,
+      clientChunkBytes: 4 * 1024 * 1024,
+      singleObjectMaxBytes: 24 * 1024 * 1024,
+      storageContentType: 'audio/wav',
+    })
+  );
+
+  await page.route('**/media/recordings/*/audio/chunk-status?*', (route) =>
+    json(route, { nextIndex: 0 })
+  );
+
+  await page.route('**/media/recordings/*/audio/chunk?*', (route) => {
+    if (route.request().method() !== 'PUT') {
+      return route.fallback();
+    }
+
+    stats.uploadRequests += 1;
+    rememberRecording(route);
+    resolveUploadStarted();
+    if (!uploadAllowedAfterReauthentication) {
+      return json(route, { message: 'Sesja wygasła.' }, 401);
+    }
+    return json(route, { ok: true });
+  });
+
+  await page.route('**/media/recordings/*/audio/finalize', (route) =>
+    json(route, {
+      storageMode: 'remote',
+      partCount: 7,
+      durationMs: 1000,
+      audioQuality: { rmsDb: -18, clipping: false },
+    })
+  );
+
+  await page.route('**/media/recordings/*/transcribe', (route) => {
+    rememberRecording(route);
+    if (route.request().method() === 'POST') {
+      stats.transcriptionStartRequests += 1;
+      return json(
+        route,
+        {
+          pipelineStatus: 'processing',
+          activeJob: true,
+          queuedPosition: 1,
+          retryAfterMs: 1,
+        },
+        202
+      );
+    }
+
+    return json(route, {
+      pipelineStatus: 'done',
+      activeJob: false,
+      segments: [
+        {
+          id: 'auth-upload-segment-1',
+          timestamp: 0,
+          endTimestamp: 1,
+          speakerId: 0,
+          text: 'Audio upload recovered after reauthentication.',
+          verificationStatus: 'verified',
+        },
+      ],
+      speakerNames: { 0: 'QA Owner' },
+      speakerCount: 1,
+      confidence: 0.99,
+    });
+  });
+
+  await page.route('**/media/recordings/*/progress*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'text/event-stream',
+      body: 'event: completed\ndata: {"status":"done"}\n\n',
+    })
+  );
+
+  await page.route('**/media/analyze', (route) =>
+    json(route, {
+      summary: 'Recovered upload analysis.',
+      actionItems: [],
+      decisions: [],
+    })
+  );
+
+  return {
+    stats,
+    uploadStarted,
+    allowUploadAfterReauthentication() {
+      uploadAllowedAfterReauthentication = true;
+    },
+  };
+}
+
+async function logInThroughVisibleForm(page: Page) {
+  await page.getByRole('button', { name: 'Logowanie' }).click();
+  await page.getByLabel('Adres email').fill(QA_USER.email);
+  await page.getByLabel('Hasło').fill(QA_PASSWORD);
+  await page.getByRole('button', { name: 'Zaloguj się' }).click();
+}
+
+async function openProtectedNavigation(page: Page, label: string) {
+  const hamburger = page.locator('.modern-hamburger-btn');
+  const navItem = page.locator('.modern-nav-item').filter({ hasText: label }).first();
+
+  if (!(await navItem.isVisible().catch(() => false)) && (await hamburger.isVisible())) {
+    await hamburger.click();
+  }
+
+  await expect(navItem).toBeVisible();
+  await navItem.click();
+}
+
+async function hasPersistedSession(page: Page) {
+  return page.evaluate(() => {
+    const session = JSON.parse(window.localStorage.getItem('voicelog.session.v3') || 'null');
+    const workspaceStore = JSON.parse(
+      window.localStorage.getItem('voicelog_workspace_store') || 'null'
+    );
+    return Boolean(session?.token || workspaceStore?.state?.session?.token);
+  });
+}
+
+async function readPersistedRecordingQueue(page: Page) {
+  return page.evaluate(async () => {
+    const persistedQueue = await new Promise<unknown>((resolve, reject) => {
+      const openRequest = window.indexedDB.open('keyval-store');
+      openRequest.onerror = () => reject(openRequest.error);
+      openRequest.onsuccess = () => {
+        const database = openRequest.result;
+        if (!database.objectStoreNames.contains('keyval')) {
+          resolve(null);
+          return;
+        }
+        const transaction = database.transaction('keyval', 'readonly');
+        const readRequest = transaction.objectStore('keyval').get('voicelog.recordingQueue.v1');
+        readRequest.onerror = () => reject(readRequest.error);
+        readRequest.onsuccess = () => resolve(readRequest.result);
+      };
+    });
+    return (
+      (persistedQueue as { state?: { recordingQueue?: unknown[] } } | null)?.state
+        ?.recordingQueue || []
+    );
+  });
+}
+
+async function assertNoHorizontalOverflow(page: Page) {
+  await expect
+    .poll(() => page.evaluate(() => document.documentElement.scrollWidth <= window.innerWidth))
+    .toBe(true);
+}
 
 test.describe('Authentication session scenarios', () => {
-  // ─────────────────────────────────────────────────────────────────
-  // Issue #1547 — AUTH-001: prevent duplicate login submissions
-  // Date: 2026-07-22
-  // Bug: the login action remains enabled while the remote request is pending.
-  // Expected: one visible submission enters a non-interactive pending state.
-  // ─────────────────────────────────────────────────────────────────
-  test('AUTH-001 blocks a duplicate visible login submission while authentication is pending', async ({
+  test('AUTH-001 completes visible login, restores the QA workspace after refresh, and prevents duplicates', async ({
     page,
   }) => {
-    let loginRequests = 0;
-    let resolveLogin: (() => void) | undefined;
-    const loginPending = new Promise<void>((resolve) => {
-      resolveLogin = resolve;
-    });
-
-    await page.route('**/auth/login', async (route) => {
-      loginRequests += 1;
-      await loginPending;
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          token: 'e2e-session-token',
-          user: { id: 'e2e-user', email: 'owner@example.test', name: 'QA Owner' },
-          workspaceId: 'e2e-workspace',
-        }),
-      });
-    });
-    await page.route('**/state/bootstrap?*', async (route) => {
-      await route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({
-          workspaceId: 'e2e-workspace',
-          users: [
-            {
-              id: 'e2e-user',
-              email: 'owner@example.test',
-              name: 'QA Owner',
-              workspaceMemberRole: 'owner',
-            },
-          ],
-          workspaces: [
-            {
-              id: 'e2e-workspace',
-              name: 'QA Workspace',
-              memberIds: ['e2e-user'],
-              memberRoles: { 'e2e-user': 'owner' },
-            },
-          ],
-        }),
-      });
-    });
+    const runtime = installRuntimeGuard(page);
+    const routes = await installAuthRoutes(page);
 
     await page.goto('/');
-    await page.getByRole('button', { name: 'Logowanie' }).click();
-    await page.getByLabel('Adres email').fill('owner@example.test');
-    await page.getByLabel(/Has/i).fill('safe-e2e-password');
+    await logInThroughVisibleForm(page);
 
-    const submit = page.getByRole('button', { name: /Zaloguj/i });
-    await submit.click();
-    await expect.poll(() => loginRequests).toBe(1);
-    await expect(submit).toBeDisabled();
-    await expect.poll(() => loginRequests).toBe(1);
+    const submit = page.getByRole('button', { name: 'Zaloguj się' });
+    await expect(page.locator('.app-shell-modern')).toBeVisible();
+    await expect(page.getByText(QA_WORKSPACE.name).first()).toBeVisible();
+    expect(routes.stats.loginRequests).toBe(1);
+    await expect(submit).not.toBeVisible();
+    expect(await hasPersistedSession(page)).toBe(true);
 
-    resolveLogin?.();
-    await expect(page.locator('.auth-shell')).not.toBeVisible();
+    await page.reload();
+    await expect(page.locator('.app-shell-modern')).toBeVisible();
+    await expect(page.getByText(QA_WORKSPACE.name).first()).toBeVisible();
+    await expect.poll(() => routes.stats.bootstrapRequests).toBeGreaterThanOrEqual(2);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(page.locator('.app-shell-modern')).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    runtime.assertHealthy();
+    runtime.dispose();
+  });
+
+  test('AUTH-002 keeps an invalid login generic, masked, recoverable, and session-free', async ({
+    page,
+  }) => {
+    const runtime = installRuntimeGuard(page, {
+      allowedConsoleErrors: [/status of 401 \(Unauthorized\)/i],
+    });
+    const routes = await installAuthRoutes(page, { loginStatus: 401 });
+
+    await page.goto('/');
+    await logInThroughVisibleForm(page);
+
+    const error = page.locator('.inline-alert.error');
+    await expect(error).toBeVisible();
+    await expect(error).toHaveText('Nieprawidłowy email lub hasło.');
+    await expect(page.locator('.auth-shell')).toBeVisible();
+    await expect(page.getByLabel('Hasło')).toHaveAttribute('type', 'password');
+    await expect(page.getByLabel('Hasło')).toBeEditable();
+    expect(await hasPersistedSession(page)).toBe(false);
+    expect(routes.stats.loginRequests).toBe(1);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(page.getByLabel('Adres email')).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    runtime.assertHealthy();
+    runtime.dispose();
+  });
+
+  test('AUTH-003 invalidates a session after protected navigation without stale UI or a retry loop', async ({
+    page,
+  }) => {
+    const runtime = installRuntimeGuard(page, {
+      allowedConsoleErrors: [/status of 401 \(Unauthorized\)/i],
+    });
+    const routes = await installAuthRoutes(page);
+
+    await page.goto('/');
+    await logInThroughVisibleForm(page);
+    await expect(page.locator('.app-shell-modern')).toBeVisible();
+    await expect.poll(() => routes.stats.bootstrapRequests).toBeGreaterThanOrEqual(1);
+
+    await page.evaluate(() => {
+      window.localStorage.setItem(
+        'voicelog.session.v3',
+        JSON.stringify({
+          userId: 'e2e-user',
+          workspaceId: 'e2e-workspace',
+          token: 'expired-e2e-session',
+        })
+      );
+    });
+    routes.expireSession();
+    await openProtectedNavigation(page, 'Nagrania');
+
+    await expect
+      .poll(() => routes.stats.bootstrapRequests, { timeout: 12_000 })
+      .toBeGreaterThanOrEqual(2);
+    await expect(page.locator('.auth-shell')).toBeVisible();
+    await expect(page.locator('.app-shell-modern')).not.toBeVisible();
+    await expect(page.getByRole('button', { name: 'Logowanie' })).toBeVisible();
+    expect(await hasPersistedSession(page)).toBe(false);
+    expect(routes.stats.unauthorizedBootstrapRequests).toBe(1);
+
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(page.getByRole('button', { name: 'Logowanie' })).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    runtime.assertHealthy();
+    runtime.dispose();
   });
 
   // ─────────────────────────────────────────────────────────────────
@@ -76,6 +387,74 @@ test.describe('Authentication session scenarios', () => {
   // Bug: a controlled bootstrap 401 left repeated protected polling active.
   // Fix: one sync owner cancels bootstrap and poll timers until a new token exists.
   // ─────────────────────────────────────────────────────────────────
+  test('AUTH-004 pauses an expired upload until visible reauthentication and one explicit retry', async ({
+    page,
+  }) => {
+    const runtime = installRuntimeGuard(page, {
+      allowedConsoleErrors: [/status of 401 \(Unauthorized\)/i],
+    });
+    const authRoutes = await installAuthRoutes(page);
+    const upload = await installUploadExpiryRoutes(page);
+
+    await page.goto('/');
+    await logInThroughVisibleForm(page);
+    await expect(page.locator('.app-shell-modern')).toBeVisible();
+    await openProtectedNavigation(page, 'Nagrania');
+
+    await page
+      .getByTestId('recordings-file-input')
+      .setInputFiles(fixtureAudioFile('expired-session-upload.wav'));
+    await upload.uploadStarted;
+    await expect(page.locator('.auth-shell')).toBeVisible();
+    await expect(page.locator('.app-shell-modern')).not.toBeVisible();
+
+    await expect.poll(() => readPersistedRecordingQueue(page), { timeout: 10_000 }).toHaveLength(1);
+    const pausedQueue = await readPersistedRecordingQueue(page);
+    expect(pausedQueue).toHaveLength(1);
+    expect(pausedQueue[0]).toMatchObject({
+      status: 'auth_required',
+      uploaded: false,
+      retryCount: 0,
+      retryable: true,
+      errorCode: 'AUTH_REQUIRED',
+    });
+    const failedChunkBatchRequests = upload.stats.uploadRequests;
+    expect(failedChunkBatchRequests).toBe(3);
+    expect(upload.stats.transcriptionStartRequests).toBe(0);
+    expect(upload.stats.recordingIds.size).toBe(1);
+
+    upload.allowUploadAfterReauthentication();
+    await logInThroughVisibleForm(page);
+    await expect(page.locator('.app-shell-modern')).toBeVisible();
+    await openProtectedNavigation(page, 'Nagrania');
+
+    const recoveryAlert = page.getByRole('alert', { name: /Wymagane ponowne logowanie/i });
+    await expect(recoveryAlert).toBeVisible();
+    await expect(page.getByText(/Brak autoryzacji do backendu/i)).toBeVisible();
+    await expect(
+      page.getByText('Audio upload recovered after reauthentication.')
+    ).not.toBeVisible();
+    await page.setViewportSize({ width: 390, height: 844 });
+    await expect(
+      page.getByRole('button', { name: 'Zaloguj ponownie i ponów upload' })
+    ).toBeVisible();
+    await assertNoHorizontalOverflow(page);
+
+    await page.getByRole('button', { name: 'Zaloguj ponownie i ponów upload' }).click();
+    await expect(page.getByText(/Nagranie zosta.*przetworzone\./i)).toBeVisible({
+      timeout: 15_000,
+    });
+    await expect.poll(() => readPersistedRecordingQueue(page), { timeout: 10_000 }).toHaveLength(0);
+
+    expect(authRoutes.stats.loginRequests).toBe(2);
+    expect(upload.stats.uploadRequests).toBe(failedChunkBatchRequests + 7);
+    expect(upload.stats.transcriptionStartRequests).toBe(1);
+    expect(upload.stats.recordingIds.size).toBe(1);
+
+    runtime.assertHealthy();
+    runtime.dispose();
+  });
+
   test('Regression: Issue #1549 — one bootstrap 401 clears the session without further protected polls', async ({
     page,
   }) => {


### PR DESCRIPTION
Closes #1538

## Summary
- Adds visible browser coverage for AUTH-001 through AUTH-004 and keeps the #1549 polling regression covered.
- Fails the auth scenarios on unexpected page errors, console errors, or HTTP 5xx responses while redacting sensitive request text.
- Preserves HTTP status metadata from chunked uploads so an expired session becomes `auth_required`; the recordings UI now offers an explicit reauthenticate-and-retry action.
- Makes the deterministic audio gate use same-origin remote mocks for data and media, including workspace bootstrap/state synchronization.
- Runs the auth scenario suite in the Playwright workflow.

## Validation
- `pnpm run test:e2e:auth-session` (5 passed)
- `pnpm run test:e2e:audio` (5 passed)
- `pnpm run typecheck:all`
- `pnpm run lint:all`
- `pnpm run test:workflows` (205 passed)
- `pnpm run test:release:guard` (1,493 passed, 82 skipped)
- `pnpm run audit:mojibake`
- Prettier check and `git diff --check`

## Residual risk
- Local validation used Node 24.14.0 because Node 22 is not installed in this Windows environment; CI remains pinned to Node 22.
- The repository does not contain the requested QA scenario index document, so the canonical scenario status is represented by the new executable suite and this PR.